### PR TITLE
Add SSE support with session management, dual transport handling, and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [1.9.0] - 2025-12-04
+
+### Added
+- **Full SSE transport support** - Responses are now sent via SSE `message` events per MCP spec (2024-11-05)
+- **MCP Inspector compatibility** - Works correctly with `npx @modelcontextprotocol/inspector` in SSE mode
+- **Dual transport support** - Supports both SSE transport and Streamable HTTP transport simultaneously
+
 ## [1.8.0] - 2025-12-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -307,16 +307,28 @@ Configure the plugin at <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP 
 
 ## Architecture
 
-The plugin uses HTTP+SSE (Server-Sent Events) transport on the IDE's built-in web server:
+The plugin supports **dual MCP transports** on the IDE's built-in web server:
+
+### SSE Transport (MCP Inspector, spec-compliant clients)
 
 ```
-AI Assistant ──────► GET /index-mcp/sse     (establish SSE stream)
-                     ◄── event: endpoint    (receive POST URL)
-             ──────► POST /index-mcp        (JSON-RPC requests)
-                     ◄── JSON-RPC response
+AI Assistant ──────► GET /index-mcp/sse              (establish SSE stream)
+                     ◄── event: endpoint             (receive POST URL with sessionId)
+             ──────► POST /index-mcp?sessionId=x     (JSON-RPC requests)
+                     ◄── HTTP 202 Accepted
+                     ◄── event: message              (JSON-RPC response via SSE)
 ```
 
-This approach:
+### Streamable HTTP Transport (Claude Code, simple clients)
+
+```
+AI Assistant ──────► POST /index-mcp                 (JSON-RPC requests)
+                     ◄── JSON-RPC response           (immediate HTTP response)
+```
+
+This dual approach:
+- **MCP Inspector compatible** - Full SSE transport per MCP spec (2024-11-05)
+- **Claude Code compatible** - Streamable HTTP for simple request/response
 - Requires no additional ports or processes
 - Works with any MCP-compatible client
 - Automatically adapts to the IDE's server port

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.8.0
+pluginVersion = 1.9.0
 
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/McpConstants.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/McpConstants.kt
@@ -9,6 +9,7 @@ object McpConstants {
     // MCP Endpoint paths (HTTP+SSE transport)
     const val MCP_ENDPOINT_PATH = "/index-mcp"
     const val SSE_ENDPOINT_PATH = "$MCP_ENDPOINT_PATH/sse"
+    const val SESSION_ID_PARAM = "sessionId"
 
     // JSON-RPC version
     const val JSON_RPC_VERSION = "2.0"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
@@ -27,6 +27,7 @@ class McpServerService : Disposable {
 
     private val toolRegistry: ToolRegistry = ToolRegistry()
     private val jsonRpcHandler: JsonRpcHandler
+    private val sseSessionManager: SseSessionManager = SseSessionManager()
 
     /**
      * Coroutine scope for non-blocking tool execution.
@@ -54,6 +55,8 @@ class McpServerService : Disposable {
     fun getToolRegistry(): ToolRegistry = toolRegistry
 
     fun getJsonRpcHandler(): JsonRpcHandler = jsonRpcHandler
+
+    fun getSseSessionManager(): SseSessionManager = sseSessionManager
 
     /**
      * Returns the SSE endpoint URL for MCP connections.
@@ -88,6 +91,7 @@ class McpServerService : Disposable {
 
     override fun dispose() {
         LOG.info("Disposing MCP Server Service")
+        sseSessionManager.closeAllSessions()
         coroutineScope.cancel("McpServerService disposed")
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/SseSessionManager.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/SseSessionManager.kt
@@ -1,0 +1,168 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.intellij.openapi.diagnostic.logger
+import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http.DefaultHttpContent
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Manages active SSE sessions for the MCP server.
+ *
+ * Each SSE connection is assigned a unique session ID. When a client POSTs
+ * a JSON-RPC request, the session ID is used to route the response back
+ * through the correct SSE stream.
+ *
+ * Thread-safe using ConcurrentHashMap.
+ */
+class SseSessionManager {
+
+    private val sessions = ConcurrentHashMap<String, SseSession>()
+
+    companion object {
+        private val LOG = logger<SseSessionManager>()
+    }
+
+    /**
+     * Creates a new SSE session and registers the channel.
+     *
+     * @param context The Netty channel context for the SSE connection
+     * @return The generated session ID
+     */
+    fun createSession(context: ChannelHandlerContext): String {
+        val sessionId = UUID.randomUUID().toString()
+        val session = SseSession(sessionId, context)
+        sessions[sessionId] = session
+
+        // Register close listener to clean up session when connection closes
+        context.channel().closeFuture().addListener {
+            removeSession(sessionId)
+        }
+
+        LOG.info("Created SSE session: $sessionId (active sessions: ${sessions.size})")
+        return sessionId
+    }
+
+    /**
+     * Gets an active session by ID.
+     *
+     * @param sessionId The session ID
+     * @return The session, or null if not found or closed
+     */
+    fun getSession(sessionId: String): SseSession? {
+        val session = sessions[sessionId]
+        if (session != null && !session.isActive()) {
+            // Clean up stale session
+            removeSession(sessionId)
+            return null
+        }
+        return session
+    }
+
+    /**
+     * Removes a session by ID.
+     *
+     * @param sessionId The session ID to remove
+     */
+    fun removeSession(sessionId: String) {
+        val removed = sessions.remove(sessionId)
+        if (removed != null) {
+            LOG.info("Removed SSE session: $sessionId (active sessions: ${sessions.size})")
+        }
+    }
+
+    /**
+     * Sends an SSE event to a specific session.
+     *
+     * @param sessionId The session ID
+     * @param eventType The SSE event type (e.g., "message", "endpoint")
+     * @param data The event data
+     * @return true if sent successfully, false if session not found or inactive
+     */
+    fun sendEvent(sessionId: String, eventType: String, data: String): Boolean {
+        val session = getSession(sessionId)
+        if (session == null) {
+            LOG.warn("Cannot send event to session $sessionId: session not found")
+            return false
+        }
+        return session.sendEvent(eventType, data)
+    }
+
+    /**
+     * Gets the number of active sessions.
+     */
+    fun getActiveSessionCount(): Int = sessions.size
+
+    /**
+     * Closes all active sessions.
+     */
+    fun closeAllSessions() {
+        sessions.keys.toList().forEach { sessionId ->
+            getSession(sessionId)?.close()
+            removeSession(sessionId)
+        }
+    }
+}
+
+/**
+ * Represents an active SSE session.
+ *
+ * @param sessionId The unique session identifier
+ * @param context The Netty channel context for sending events
+ */
+class SseSession(
+    val sessionId: String,
+    private val context: ChannelHandlerContext
+) {
+    companion object {
+        private val LOG = logger<SseSession>()
+    }
+
+    /**
+     * Checks if the session's channel is still active.
+     */
+    fun isActive(): Boolean = context.channel().isActive
+
+    /**
+     * Sends an SSE event over this session's channel.
+     *
+     * @param eventType The SSE event type
+     * @param data The event data (will be sent as-is in the data field)
+     * @return true if sent successfully
+     */
+    fun sendEvent(eventType: String, data: String): Boolean {
+        if (!isActive()) {
+            LOG.warn("Cannot send event to session $sessionId: channel inactive")
+            return false
+        }
+
+        return try {
+            // SSE spec: each line of data must be prefixed with "data: "
+            // This handles multiline data correctly
+            val dataLines = data.lines().joinToString("\n") { "data: $it" }
+            val sseEvent = "event: $eventType\n$dataLines\n\n"
+            val buffer = Unpooled.copiedBuffer(sseEvent, StandardCharsets.UTF_8)
+
+            // Send on the event loop thread to ensure thread safety
+            // Netty handles inactive channels gracefully (fails write, releases buffer)
+            context.channel().eventLoop().execute {
+                context.writeAndFlush(DefaultHttpContent(buffer))
+            }
+            true
+        } catch (e: Exception) {
+            LOG.error("Failed to send SSE event to session $sessionId", e)
+            false
+        }
+    }
+
+    /**
+     * Closes the SSE connection.
+     */
+    fun close() {
+        if (isActive()) {
+            context.close()
+        }
+    }
+}


### PR DESCRIPTION
… updated JSON-RPC routing

- Introduce `SseSessionManager` for managing SSE sessions with thread safety.
- Implement SSE transport in `McpRequestHandler` with session ID-based routing.
- Extend `McpServerService` to support `SseSessionManager` and session cleanup on service disposal.
- Support dual JSON-RPC transport modes: SSE-based and streamable HTTP.
- Update constants, documentation, and CHANGELOG to reflect new transport support.
- Release version 1.9.0.