### PR TITLE
Exclude Rider IDE support and update compatibility documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [1.9.1] - 2025-12-06
+
+### Changed
+- **Rider IDE excluded** - Plugin is now explicitly incompatible with Rider IDE (uses ReSharper backend which is incompatible with IntelliJ PSI APIs)
+- **Documentation updated** - Clarified IDE compatibility: fully tested (IntelliJ IDEA, PyCharm, WebStorm, GoLand, Android Studio) vs untested (PhpStorm, RubyMine, CLion, DataGrip)
+
 ## [1.9.0] - 2025-12-04
 
 ### Added
@@ -81,7 +87,7 @@
 ## [1.5.0] - 2025-11-29
 
 ### Added
-- **Multi-IDE Support** - Works with all JetBrains IDEs: IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, CLion, Rider, DataGrip, Android Studio
+- **Multi-IDE Support** - Works with JetBrains IDEs: IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, CLion, DataGrip, Android Studio
 - **Multi-Language Support** - Navigation tools now work with Java/Kotlin, Python, and JavaScript/TypeScript
 - Agent rule tip panel with copy-to-clipboard in tool window
 - Non-blocking operations for improved responsiveness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 An IntelliJ Platform plugin that exposes an MCP (Model Context Protocol) server, enabling coding agents to leverage the IDE's powerful indexing and refactoring capabilities.
 
-**Works with all JetBrains IDEs**: IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, CLion, Rider, DataGrip, and Android Studio.
+**Works with JetBrains IDEs**: IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, CLion, DataGrip, and Android Studio.
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 A JetBrains IDE plugin that exposes an **MCP (Model Context Protocol) server**, enabling AI coding assistants like Claude, Cursor, and Windsurf to leverage the IDE's powerful indexing and refactoring capabilities.
 
-**Works with all JetBrains IDEs**: IntelliJ IDEA, PyCharm, WebStorm, GoLand, PhpStorm, RubyMine, CLion, Rider, DataGrip, and Android Studio.
+**Fully tested**: IntelliJ IDEA, PyCharm, WebStorm, GoLand, Android Studio
+**May work** (untested): PhpStorm, RubyMine, CLion, DataGrip
 
 <!-- Plugin description -->
 **IDE Index MCP Server** provides AI coding assistants with access to the IDE's powerful code intelligence features through the Model Context Protocol (MCP).
@@ -157,9 +158,9 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 The plugin provides MCP tools organized by availability:
 
-### Universal Tools (All JetBrains IDEs)
+### Universal Tools
 
-These tools work in **every** JetBrains IDE - IntelliJ, PyCharm, WebStorm, GoLand, CLion, Rider, etc.
+These tools work in all supported JetBrains IDEs.
 
 | Tool | Description |
 |------|-------------|
@@ -191,6 +192,8 @@ These tools activate based on available language plugins:
 
 ### Tool Availability by IDE
 
+**Fully Tested:**
+
 | IDE | Universal | Navigation | Refactoring |
 |-----|-----------|------------|-------------|
 | IntelliJ IDEA | ✓ 4 tools | ✓ 5 tools | ✓ 2 tools (rename + safe delete) |
@@ -198,13 +201,17 @@ These tools activate based on available language plugins:
 | PyCharm | ✓ 4 tools | ✓ 5 tools | ✓ 1 tool (rename) |
 | WebStorm | ✓ 4 tools | ✓ 5 tools | ✓ 1 tool (rename) |
 | GoLand | ✓ 4 tools | ✓ 5 tools | ✓ 1 tool (rename) |
+
+**May Work (Untested):**
+
+| IDE | Universal | Navigation | Refactoring |
+|-----|-----------|------------|-------------|
 | PhpStorm | ✓ 4 tools | - | ✓ 1 tool (rename) |
 | RubyMine | ✓ 4 tools | - | ✓ 1 tool (rename) |
 | CLion | ✓ 4 tools | - | ✓ 1 tool (rename) |
-| Rider | ✓ 4 tools | - | ✓ 1 tool (rename) |
 | DataGrip | ✓ 4 tools | - | ✓ 1 tool (rename) |
 
-> **Note**: Navigation tools (type hierarchy, call hierarchy, find implementations, symbol search, find super methods) are available when language plugins are present. PyCharm has Python support, WebStorm has JavaScript/TypeScript support, GoLand has Go support. The rename tool works across all languages in all IDEs.
+> **Note**: Navigation tools (type hierarchy, call hierarchy, find implementations, symbol search, find super methods) are available when language plugins are present. The rename tool works across all languages.
 
 For detailed tool documentation with parameters and examples, see [USAGE.md](USAGE.md).
 
@@ -290,20 +297,20 @@ Configure the plugin at <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP 
 
 ### Supported IDEs
 
-| IDE | Universal | Navigation | Refactoring |
-|-----|-----------|------------|-------------|
-| IntelliJ IDEA Community/Ultimate | Yes | Yes (Java/Kotlin) | Yes (rename + safe delete) |
-| Android Studio | Yes | Yes (Java/Kotlin) | Yes (rename + safe delete) |
-| PyCharm Community/Professional | Yes | Yes (Python) | Yes (rename only) |
-| WebStorm | Yes | Yes (JS/TS) | Yes (rename only) |
-| GoLand | Yes | Yes (Go) | Yes (rename only) |
-| PhpStorm | Yes | No | Yes (rename only) |
-| RubyMine | Yes | No | Yes (rename only) |
-| CLion | Yes | No | Yes (rename only) |
-| Rider | Yes | No | Yes (rename only) |
-| DataGrip | Yes | No | Yes (rename only) |
+**Fully Tested:**
+- IntelliJ IDEA (Community/Ultimate)
+- Android Studio
+- PyCharm (Community/Professional)
+- WebStorm
+- GoLand
 
-> Navigation tools (type hierarchy, call hierarchy, find implementations, symbol search, find super methods) activate based on available language plugins. GoLand has Go support. The rename tool works across all languages; safe delete is Java/Kotlin only.
+**May Work (Untested):**
+- PhpStorm
+- RubyMine
+- CLion
+- DataGrip
+
+> The plugin uses standard IntelliJ Platform APIs and should work on any IntelliJ-based IDE, but has only been tested on the IDEs listed above.
 
 ## Architecture
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.9.0
+pluginVersion = 1.9.1
 
 
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,8 +16,8 @@
     <li><b>Go</b> - GoLand, IntelliJ IDEA Ultimate with Go plugin</li>
 </ul>
 
-<h3>Universal Tools (All IDEs)</h3>
-<p>These tools work in every JetBrains IDE:</p>
+<h3>Universal Tools (All Supported IDEs)</h3>
+<p>These tools work in every supported JetBrains IDE:</p>
 <ul>
     <li><b>Find References</b> - Locate all usages of any symbol across your project</li>
     <li><b>Go to Definition</b> - Jump to symbol declarations instantly</li>
@@ -71,6 +71,9 @@
 <p>See the <a href="https://github.com/hechtcarmel/jetbrains-index-mcp-plugin">GitHub repository</a>
 for detailed documentation and examples.</p>
 ]]>    </description>
+
+    <!-- Rider exclusion - plugin uses IntelliJ PSI APIs not compatible with Rider's ReSharper backend -->
+    <incompatible-with>com.intellij.modules.rider</incompatible-with>
 
     <!-- Platform dependency (required) -->
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
- Remove Rider from supported IDEs and clarify tested vs untested IDEs in documentation.
- Explicitly mark Rider as incompatible in `plugin.xml` due to ReSharper backend limitations.
- Update CHANGELOG and README to reflect compatibility changes.
- Release version 1.9.1.