### PR TITLE
Fix: Remove unused settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+## [1.10.1] - 2025-12-07
+
+### Removed
+- **Auto-scroll setting** - Removed the "Auto-scroll to new commands" setting from plugin preferences
+
 ## [1.10.0] - 2025-12-07
 
 ### Added
@@ -238,7 +243,6 @@
 
 #### Settings
 - Maximum history size (default: 100)
-- Auto-scroll toggle (default: enabled)
 - Sync external file changes toggle (default: disabled)
 
 ### Technical Details

--- a/README.md
+++ b/README.md
@@ -286,7 +286,6 @@ Configure the plugin at <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | Max History Size | 100 | Maximum number of commands to keep in history |
-| Auto-scroll | true | Auto-scroll to new commands in history |
 | Sync External Changes | false | Sync external file changes before operations |
 
 ## Requirements

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.10.0
+pluginVersion = 1.10.1
 
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -15,7 +15,6 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
 
     data class State(
         var maxHistorySize: Int = 100,
-        var autoScroll: Boolean = true,
         var syncExternalChanges: Boolean = false
     )
 
@@ -30,10 +29,6 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
     var maxHistorySize: Int
         get() = state.maxHistorySize
         set(value) { state.maxHistorySize = value }
-
-    var autoScroll: Boolean
-        get() = state.autoScroll
-        set(value) { state.autoScroll = value }
 
     var syncExternalChanges: Boolean
         get() = state.syncExternalChanges

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -18,14 +18,12 @@ class McpSettingsConfigurable : Configurable {
 
     private var panel: JPanel? = null
     private var maxHistorySizeSpinner: JSpinner? = null
-    private var autoScrollCheckBox: JBCheckBox? = null
     private var syncExternalChangesCheckBox: JBCheckBox? = null
 
     override fun getDisplayName(): String = McpBundle.message("settings.title")
 
     override fun createComponent(): JComponent {
         maxHistorySizeSpinner = JSpinner(SpinnerNumberModel(100, 10, 10000, 10))
-        autoScrollCheckBox = JBCheckBox(McpBundle.message("settings.autoScroll"))
         syncExternalChangesCheckBox = JBCheckBox(McpBundle.message("settings.syncExternalChanges")).apply {
             toolTipText = McpBundle.message("settings.syncExternalChanges.tooltip")
         }
@@ -50,7 +48,6 @@ class McpSettingsConfigurable : Configurable {
 
         panel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel(McpBundle.message("settings.maxHistorySize") + ":"), maxHistorySizeSpinner!!, 1, false)
-            .addComponent(autoScrollCheckBox!!, 1)
             .addComponent(syncPanel, 1)
             .addComponentFillVertically(JPanel(), 0)
             .panel
@@ -61,28 +58,24 @@ class McpSettingsConfigurable : Configurable {
     override fun isModified(): Boolean {
         val settings = McpSettings.getInstance()
         return maxHistorySizeSpinner?.value != settings.maxHistorySize ||
-            autoScrollCheckBox?.isSelected != settings.autoScroll ||
             syncExternalChangesCheckBox?.isSelected != settings.syncExternalChanges
     }
 
     override fun apply() {
         val settings = McpSettings.getInstance()
         settings.maxHistorySize = maxHistorySizeSpinner?.value as? Int ?: 100
-        settings.autoScroll = autoScrollCheckBox?.isSelected ?: true
         settings.syncExternalChanges = syncExternalChangesCheckBox?.isSelected ?: false
     }
 
     override fun reset() {
         val settings = McpSettings.getInstance()
         maxHistorySizeSpinner?.value = settings.maxHistorySize
-        autoScrollCheckBox?.isSelected = settings.autoScroll
         syncExternalChangesCheckBox?.isSelected = settings.syncExternalChanges
     }
 
     override fun disposeUIResources() {
         panel = null
         maxHistorySizeSpinner = null
-        autoScrollCheckBox = null
         syncExternalChangesCheckBox = null
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/ui/McpToolWindowPanel.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/ui/McpToolWindowPanel.kt
@@ -8,7 +8,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandHistoryList
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandHistoryService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandStatus
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.intellij.icons.AllIcons
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -161,9 +160,7 @@ class McpToolWindowPanel(
 
     override fun onCommandAdded(entry: CommandEntry) {
         historyListModel.add(0, entry)
-        if (McpSettings.getInstance().autoScroll) {
-            historyList.selectedIndex = 0
-        }
+        historyList.selectedIndex = 0
     }
 
     override fun onCommandUpdated(entry: CommandEntry) {

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -46,7 +46,6 @@ config.selectClient=Select MCP Client
 # Settings
 settings.title=MCP Server Settings
 settings.maxHistorySize=Max History Size
-settings.autoScroll=Auto-scroll to new commands
 settings.syncExternalChanges=Sync external file changes before operations
 settings.syncExternalChanges.warning=WARNING: This option significantly slows down every operation. Only enable if absolutely necessary.
 settings.syncExternalChanges.tooltip=<html><b style="color:red;">WARNING: SIGNIFICANT PERFORMANCE IMPACT</b><br><br>\

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
@@ -10,7 +10,6 @@ class McpSettingsUnitTest : TestCase() {
         val state = McpSettings.State()
 
         assertEquals("Default maxHistorySize should be 100", 100, state.maxHistorySize)
-        assertTrue("Default autoScroll should be true", state.autoScroll)
         assertFalse("Default syncExternalChanges should be false", state.syncExternalChanges)
     }
 
@@ -21,13 +20,6 @@ class McpSettingsUnitTest : TestCase() {
         state.maxHistorySize = 200
 
         assertEquals(200, state.maxHistorySize)
-    }
-
-    fun testStateAutoScrollMutable() {
-        val state = McpSettings.State()
-        state.autoScroll = false
-
-        assertFalse(state.autoScroll)
     }
 
     fun testStateSyncExternalChangesMutable() {
@@ -42,12 +34,10 @@ class McpSettingsUnitTest : TestCase() {
     fun testStateCustomConstructor() {
         val state = McpSettings.State(
             maxHistorySize = 500,
-            autoScroll = false,
             syncExternalChanges = true
         )
 
         assertEquals(500, state.maxHistorySize)
-        assertFalse(state.autoScroll)
         assertTrue(state.syncExternalChanges)
     }
 
@@ -59,7 +49,7 @@ class McpSettingsUnitTest : TestCase() {
 
         assertEquals(50, original.maxHistorySize)
         assertEquals(150, copy.maxHistorySize)
-        assertEquals(original.autoScroll, copy.autoScroll)
+        assertEquals(original.syncExternalChanges, copy.syncExternalChanges)
     }
 
     // State equals and hashCode tests
@@ -93,18 +83,15 @@ class McpSettingsUnitTest : TestCase() {
         // Should have default state
         assertNotNull(settings.state)
         assertEquals(100, settings.maxHistorySize)
-        assertTrue(settings.autoScroll)
     }
 
     fun testMcpSettingsPropertyDelegation() {
         val settings = McpSettings()
 
         settings.maxHistorySize = 250
-        settings.autoScroll = false
         settings.syncExternalChanges = true
 
         assertEquals(250, settings.maxHistorySize)
-        assertFalse(settings.autoScroll)
         assertTrue(settings.syncExternalChanges)
     }
 
@@ -112,14 +99,12 @@ class McpSettingsUnitTest : TestCase() {
         val settings = McpSettings()
         val newState = McpSettings.State(
             maxHistorySize = 75,
-            autoScroll = false,
             syncExternalChanges = true
         )
 
         settings.loadState(newState)
 
         assertEquals(75, settings.maxHistorySize)
-        assertFalse(settings.autoScroll)
         assertTrue(settings.syncExternalChanges)
     }
 


### PR DESCRIPTION
- Eliminate `autoScroll` property and associated UI elements from settings.
- Adjust tests, resources, and usage to reflect removal.
- Update plugin version to 1.10.1 and document changes in CHANGELOG.