### PR TITLE
fix notifications/initialized message handling

### DIFF
--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/JsonRpcMethods.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/JsonRpcMethods.kt
@@ -2,7 +2,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.constants
 
 object JsonRpcMethods {
     const val INITIALIZE = "initialize"
-    const val INITIALIZED = "initialized"
+    const val NOTIFICATIONS_INITIALIZED = "notifications/initialized"
     const val PING = "ping"
     const val TOOLS_LIST = "tools/list"
     const val TOOLS_CALL = "tools/call"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/KtorMcpServer.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/KtorMcpServer.kt
@@ -200,7 +200,9 @@ class KtorMcpServer(
 
         try {
             val response = jsonRpcHandler.handleRequest(body)
-            call.respondText(response, ContentType.Application.Json)
+            if (response != null){
+                call.respondText(response, ContentType.Application.Json)
+            }
         } catch (e: Exception) {
             LOG.error("Error processing MCP request (Streamable HTTP)", e)
             call.respondText(
@@ -239,9 +241,11 @@ class KtorMcpServer(
         coroutineScope.launch {
             try {
                 val response = jsonRpcHandler.handleRequest(body)
-                val sent = sseSessionManager.sendEvent(sessionId, "message", response)
-                if (!sent) {
-                    LOG.warn("Failed to send response to session $sessionId - session may have closed")
+                if (response != null) {
+                    val sent = sseSessionManager.sendEvent(sessionId, "message", response)
+                    if (!sent) {
+                        LOG.warn("Failed to send response to session $sessionId - session may have closed")
+                    }
                 }
             } catch (e: Exception) {
                 LOG.error("Error processing MCP request (SSE)", e)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
@@ -53,7 +53,7 @@ class ConstantsUnitTest : TestCase() {
 
     fun testJsonRpcMethodsValues() {
         assertEquals("initialize", JsonRpcMethods.INITIALIZE)
-        assertEquals("initialized", JsonRpcMethods.INITIALIZED)
+        assertEquals("notifications/initialized", JsonRpcMethods.NOTIFICATIONS_INITIALIZED)
         assertEquals("ping", JsonRpcMethods.PING)
         assertEquals("tools/list", JsonRpcMethods.TOOLS_LIST)
         assertEquals("tools/call", JsonRpcMethods.TOOLS_CALL)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/McpServerIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/McpServerIntegrationTest.kt
@@ -46,7 +46,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("Initialize should not return error", response.error)
         assertNotNull("Initialize should return result", response.result)
@@ -67,15 +67,13 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
     fun testInitializedEndpoint() = runBlocking {
         val request = JsonRpcRequest(
             id = JsonPrimitive(2),
-            method = "initialized",
+            method = "notifications/initialized",
             params = buildJsonObject { }
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
 
-        assertNull("Initialized should not return error", response.error)
-        assertNotNull("Initialized should return result", response.result)
+        assertNull("notifications/initialized should not have response", responseJson)
     }
 
     fun testPingEndpoint() = runBlocking {
@@ -86,7 +84,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("Ping should not return error", response.error)
         assertNotNull("Ping should return result", response.result)
@@ -102,7 +100,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("tools/list should not return error", response.error)
         assertNotNull("tools/list should return result", response.result)
@@ -122,7 +120,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         val tools = response.result!!.jsonObject["tools"]?.jsonArray
         val toolNames = tools?.map { it.jsonObject["name"]?.jsonPrimitive?.content }
@@ -150,7 +148,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         val tools = response.result!!.jsonObject["tools"]?.jsonArray
         val toolNames = tools?.map { it.jsonObject["name"]?.jsonPrimitive?.content }
@@ -172,7 +170,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         val tools = response.result!!.jsonObject["tools"]?.jsonArray
         val toolNames = tools?.map { it.jsonObject["name"]?.jsonPrimitive?.content }
@@ -199,7 +197,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("${ToolNames.INDEX_STATUS} should not return JSON-RPC error", response.error)
         assertNotNull("${ToolNames.INDEX_STATUS} should return result", response.result)
@@ -216,7 +214,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("Non-existent tool should return error", response.error)
         assertEquals(-32601, response.error?.code)
@@ -232,7 +230,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("Missing tool name should return error", response.error)
         assertEquals(-32602, response.error?.code)
@@ -248,7 +246,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("Invalid method should return error", response.error)
         assertEquals(-32601, response.error?.code)
@@ -256,7 +254,7 @@ class McpServerIntegrationTest : BasePlatformTestCase() {
 
     fun testMalformedJsonReturnsError() = runBlocking {
         val responseJson = handler.handleRequest("{invalid json}")
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("Malformed JSON should return error", response.error)
         assertEquals(-32700, response.error?.code)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandlerTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandlerTest.kt
@@ -43,7 +43,7 @@ class JsonRpcHandlerTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("${ToolNames.INDEX_STATUS} should not return JSON-RPC error", response.error)
         assertNotNull("${ToolNames.INDEX_STATUS} should return result", response.result)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandlerUnitTest.kt
@@ -47,7 +47,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("Initialize should not return error", response.error)
         assertNotNull("Initialize should return result", response.result)
@@ -72,7 +72,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("${JsonRpcMethods.TOOLS_LIST} should not return error", response.error)
         assertNotNull("${JsonRpcMethods.TOOLS_LIST} should return result", response.result)
@@ -88,7 +88,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("${JsonRpcMethods.PING} should not return error", response.error)
         assertNotNull("${JsonRpcMethods.PING} should return result", response.result)
@@ -101,7 +101,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("Unknown method should return error", response.error)
         assertEquals(JsonRpcErrorCodes.METHOD_NOT_FOUND, response.error?.code)
@@ -114,7 +114,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("${JsonRpcMethods.TOOLS_CALL} without params should return error", response.error)
         assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, response.error?.code)
@@ -130,7 +130,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("${JsonRpcMethods.TOOLS_CALL} without tool name should return error", response.error)
         assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, response.error?.code)
@@ -147,7 +147,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("${JsonRpcMethods.TOOLS_CALL} with unknown tool should return error", response.error)
         assertEquals(JsonRpcErrorCodes.METHOD_NOT_FOUND, response.error?.code)
@@ -155,7 +155,7 @@ class JsonRpcHandlerUnitTest : TestCase() {
 
     fun testParseError() = runBlocking {
         val responseJson = handler.handleRequest("not valid json")
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNotNull("Invalid JSON should return error", response.error)
         assertEquals(JsonRpcErrorCodes.PARSE_ERROR, response.error?.code)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/MultiProjectResolutionTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/MultiProjectResolutionTest.kt
@@ -46,7 +46,7 @@ class MultiProjectResolutionTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("Single project should not return JSON-RPC error", response.error)
         assertNotNull("Should return result", response.result)
@@ -70,7 +70,7 @@ class MultiProjectResolutionTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("Explicit project_path should not return JSON-RPC error", response.error)
         assertNotNull("Should return result", response.result)
@@ -92,7 +92,7 @@ class MultiProjectResolutionTest : BasePlatformTestCase() {
         )
 
         val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
-        val response = json.decodeFromString<JsonRpcResponse>(responseJson)
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
 
         assertNull("Should not return JSON-RPC level error", response.error)
         assertNotNull("Should return result", response.result)


### PR DESCRIPTION
This PR brings fix for handling `initialized notification`

1. [Notifications](https://modelcontextprotocol.io/specification/2025-11-25/schema#jsonrpcnotification) are sent from the client to the server or vice versa, as a one-way message. The receiver MUST NOT send a response. [LINK](https://modelcontextprotocol.io/specification/2025-11-25/basic#notifications)

2. After successful initialization, the client MUST send an initialized notification to indicate it is ready to begin normal operations [LINK](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization)
```
{
  "jsonrpc": "2.0",
  "method": "notifications/initialized"
}
```