### PR TITLE
fix(perf): use suspendingReadAction in all tools to prevent write lock starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-01-26
+
+### Fixed
+- **Performance: Prevent IDE freezes during rapid tool calls** - Switched from blocking `readAction` to yielding `suspendingReadAction` in all tools. This prevents write lock starvation that caused IDE freezes when Claude Code's Explore agent fired many tool calls in succession.
+
 ## [3.2.0] - 2026-01-23
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 3.2.0
+pluginVersion = 3.2.1
 
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsTool.kt
@@ -161,12 +161,12 @@ class GetDiagnosticsTool : AbstractMcpTool() {
         column: Int,
         startLine: Int?,
         endLine: Int?
-    ): ToolCallResult = readAction {
+    ): ToolCallResult = suspendingReadAction {
         val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-            ?: return@readAction createErrorResult("Could not parse file: $filePath")
+            ?: return@suspendingReadAction createErrorResult("Could not parse file: $filePath")
 
         val document = PsiDocumentManager.getInstance(project).getDocument(psiFile)
-            ?: return@readAction createErrorResult("Could not get document for file")
+            ?: return@suspendingReadAction createErrorResult("Could not get document for file")
 
         val editor = fileEditorManager.getEditors(virtualFile)
             .filterIsInstance<TextEditor>()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
@@ -104,16 +104,16 @@ class CallHierarchyTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        return readAction {
+        return suspendingReadAction {
             ProgressManager.checkCanceled() // Allow cancellation
 
             val element = findPsiElement(project, file, line, column)
-                ?: return@readAction createErrorResult("No element found at position $file:$line:$column")
+                ?: return@suspendingReadAction createErrorResult("No element found at position $file:$line:$column")
 
             // Find appropriate handler for this element's language
             val handler = LanguageHandlerRegistry.getCallHierarchyHandler(element)
             if (handler == null) {
-                return@readAction createErrorResult(
+                return@suspendingReadAction createErrorResult(
                     "No call hierarchy handler available for language: ${element.language.id}. " +
                     "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForCallHierarchy()}"
                 )
@@ -123,7 +123,7 @@ class CallHierarchyTool : AbstractMcpTool() {
 
             val hierarchyData = handler.getCallHierarchy(element, project, direction, depth)
             if (hierarchyData == null) {
-                return@readAction createErrorResult("No method/function found at position")
+                return@suspendingReadAction createErrorResult("No method/function found at position")
             }
 
             // Convert handler result to tool result

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
@@ -60,13 +60,13 @@ class FileStructureTool : AbstractMcpTool() {
         val file = arguments["file"]?.jsonPrimitive?.content
             ?: return createErrorResult("Missing required parameter: file")
 
-        return readAction {
+        return suspendingReadAction {
             val psiFile = getPsiFile(project, file)
-                ?: return@readAction createErrorResult("File not found: $file")
+                ?: return@suspendingReadAction createErrorResult("File not found: $file")
 
             // Get structure handler for this file's language
             val handler = LanguageHandlerRegistry.getStructureHandler(psiFile)
-                ?: return@readAction createErrorResult(
+                ?: return@suspendingReadAction createErrorResult(
                     "Language not supported for file structure. " +
                     "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForStructure().joinToString(", ")}"
                 )
@@ -75,7 +75,7 @@ class FileStructureTool : AbstractMcpTool() {
             val nodes = handler.getFileStructure(psiFile, project)
 
             if (nodes.isEmpty()) {
-                return@readAction createSuccessResult(
+                return@suspendingReadAction createSuccessResult(
                     "File is empty or has no parseable structure.\n\n" +
                     "File: ${psiFile.name}\n" +
                     "Language: ${psiFile.language.id}"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
@@ -79,9 +79,9 @@ class FindDefinitionTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        return readAction {
+        return suspendingReadAction {
             val element = findPsiElement(project, file, line, column)
-                ?: return@readAction createErrorResult(ErrorMessages.noElementAtPosition(file, line, column))
+                ?: return@suspendingReadAction createErrorResult(ErrorMessages.noElementAtPosition(file, line, column))
 
             // Try to find a reference at this position
             val reference = element.reference ?: findReferenceInParent(element)
@@ -94,15 +94,15 @@ class FindDefinitionTool : AbstractMcpTool() {
             }
 
             if (targetElement == null) {
-                return@readAction createErrorResult(ErrorMessages.SYMBOL_NOT_RESOLVED)
+                return@suspendingReadAction createErrorResult(ErrorMessages.SYMBOL_NOT_RESOLVED)
             }
 
             val targetFile = targetElement.containingFile?.virtualFile
-                ?: return@readAction createErrorResult(ErrorMessages.DEFINITION_FILE_NOT_FOUND)
+                ?: return@suspendingReadAction createErrorResult(ErrorMessages.DEFINITION_FILE_NOT_FOUND)
 
             val document = PsiDocumentManager.getInstance(project)
                 .getDocument(targetElement.containingFile)
-                ?: return@readAction createErrorResult(ErrorMessages.DEFINITION_DOCUMENT_NOT_FOUND)
+                ?: return@suspendingReadAction createErrorResult(ErrorMessages.DEFINITION_DOCUMENT_NOT_FOUND)
 
             val targetLine = document.getLineNumber(targetElement.textOffset) + 1
             val targetColumn = targetElement.textOffset -

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
@@ -75,14 +75,14 @@ class FindImplementationsTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        return readAction {
+        return suspendingReadAction {
             val element = findPsiElement(project, file, line, column)
-                ?: return@readAction createErrorResult("No element found at position $file:$line:$column")
+                ?: return@suspendingReadAction createErrorResult("No element found at position $file:$line:$column")
 
             // Find appropriate handler for this element's language
             val handler = LanguageHandlerRegistry.getImplementationsHandler(element)
             if (handler == null) {
-                return@readAction createErrorResult(
+                return@suspendingReadAction createErrorResult(
                     "No implementations handler available for language: ${element.language.id}. " +
                     "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForImplementations()}"
                 )
@@ -90,7 +90,7 @@ class FindImplementationsTool : AbstractMcpTool() {
 
             val implementations = handler.findImplementations(element, project)
             if (implementations == null) {
-                return@readAction createErrorResult("No method or class found at position")
+                return@suspendingReadAction createErrorResult("No method or class found at position")
             }
 
             // Convert handler results to tool results

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
@@ -81,14 +81,14 @@ class FindSuperMethodsTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        return readAction {
+        return suspendingReadAction {
             val element = findPsiElement(project, file, line, column)
-                ?: return@readAction createErrorResult("No element found at $file:$line:$column")
+                ?: return@suspendingReadAction createErrorResult("No element found at $file:$line:$column")
 
             // Find appropriate handler for this element's language
             val handler = LanguageHandlerRegistry.getSuperMethodsHandler(element)
             if (handler == null) {
-                return@readAction createErrorResult(
+                return@suspendingReadAction createErrorResult(
                     "No super methods handler available for language: ${element.language.id}. " +
                     "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForSuperMethods()}"
                 )
@@ -96,7 +96,7 @@ class FindSuperMethodsTool : AbstractMcpTool() {
 
             val superMethodsData = handler.findSuperMethods(element, project)
             if (superMethodsData == null) {
-                return@readAction createErrorResult(
+                return@suspendingReadAction createErrorResult(
                     "No method found at position. Ensure the position is within a method declaration or body."
                 )
             }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
@@ -87,11 +87,11 @@ class FindSymbolTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        return readAction {
+        return suspendingReadAction {
             // Aggregate results from ALL available language handlers
             val handlers = LanguageHandlerRegistry.getAllSymbolSearchHandlers()
             if (handlers.isEmpty()) {
-                return@readAction createErrorResult(
+                return@suspendingReadAction createErrorResult(
                     "No symbol search handlers available. " +
                     "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForSymbolSearch()}"
                 )

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -88,13 +88,13 @@ class FindUsagesTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        return readAction {
+        return suspendingReadAction {
             val element = findPsiElement(project, file, line, column)
-                ?: return@readAction createErrorResult(ErrorMessages.noElementAtPosition(file, line, column))
+                ?: return@suspendingReadAction createErrorResult(ErrorMessages.noElementAtPosition(file, line, column))
 
             // Find the named element (go up the tree if needed)
             val targetElement = PsiUtils.findNamedElement(element)
-                ?: return@readAction createErrorResult(ErrorMessages.NO_NAMED_ELEMENT)
+                ?: return@suspendingReadAction createErrorResult(ErrorMessages.NO_NAMED_ELEMENT)
 
             val usages = mutableListOf<UsageLocation>()
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
@@ -77,7 +77,7 @@ class TypeHierarchyTool : AbstractMcpTool() {
         val className = arguments["className"]?.jsonPrimitive?.content
         val file = arguments["file"]?.jsonPrimitive?.content
 
-        return readAction {
+        return suspendingReadAction {
             ProgressManager.checkCanceled() // Allow cancellation
 
             val element = resolveTargetElement(project, arguments)
@@ -87,13 +87,13 @@ class TypeHierarchyTool : AbstractMcpTool() {
                     file != null -> "No class found at the specified file/line/column position."
                     else -> "Provide either 'className' (e.g., 'com.example.MyClass') or 'file' + 'line' + 'column'."
                 }
-                return@readAction createErrorResult(errorMsg)
+                return@suspendingReadAction createErrorResult(errorMsg)
             }
 
             // Find appropriate handler for this element's language
             val handler = LanguageHandlerRegistry.getTypeHierarchyHandler(element)
             if (handler == null) {
-                return@readAction createErrorResult(
+                return@suspendingReadAction createErrorResult(
                     "No type hierarchy handler available for language: ${element.language.id}. " +
                     "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForTypeHierarchy()}"
                 )
@@ -103,7 +103,7 @@ class TypeHierarchyTool : AbstractMcpTool() {
 
             val hierarchyData = handler.getTypeHierarchy(element, project)
             if (hierarchyData == null) {
-                return@readAction createErrorResult("No class/type found at the specified position.")
+                return@suspendingReadAction createErrorResult("No class/type found at the specified position.")
             }
 
             // Convert handler result to tool result

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -115,9 +115,9 @@ class RenameSymbolTool : AbstractMcpTool() {
         requireSmartMode(project)
 
         // ═══════════════════════════════════════════════════════════════════════
-        // PHASE 1: BACKGROUND - Find element and validate (read action)
+        // PHASE 1: BACKGROUND - Find element and validate (suspending read action)
         // ═══════════════════════════════════════════════════════════════════════
-        val validation = readAction {
+        val validation = suspendingReadAction {
             validateAndPrepare(project, file, line, column, newName)
         }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -101,9 +101,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         requireSmartMode(project)
 
         // ═══════════════════════════════════════════════════════════════════════
-        // PHASE 1: BACKGROUND - Find element and check usages (read action)
+        // PHASE 1: BACKGROUND - Find element and check usages (suspending read action)
         // ═══════════════════════════════════════════════════════════════════════
-        val preparation = readAction {
+        val preparation = suspendingReadAction {
             prepareDelete(project, file, line, column)
         } ?: return createErrorResult("No deletable element found at the specified position")
 


### PR DESCRIPTION
## Summary

Migrate all MCP tools from blocking `readAction` to yielding `suspendingReadAction` to prevent IDE freezes during rapid tool invocations.

## Problem

When Claude Code's Explore agent fires many tool calls in rapid succession, the IDE becomes unresponsive. Thread dumps showed:

- **EDT blocked** waiting to acquire a write lock (`DumbServiceImpl.decrementDumbCounter` trying to exit dumb mode)
- **Multiple background threads** holding read locks via `ReadAction.compute()`
- Classic **write lock starvation** pattern

## Root Cause

All tools used the blocking `readAction` method which holds read locks for the entire operation duration. This prevents write actions from executing, causing the IDE to freeze.

The `suspendingReadAction` infrastructure (backed by `platformReadAction`) was added in commits 57c5aaa and db932c1 specifically to solve this—it yields to pending write actions periodically. However, the tools were never migrated to use it.

## Solution

Switch all tools from `readAction { }` to `suspendingReadAction { }`