### PR TITLE
 fix(tools): prefer source files for library classes in FindClassTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+## [3.3.3] - 2026-02-03
+
+### Fixed
+- **Symbol navigation resolution** - `ide_find_class` and optimized symbol search now resolve file/line/name via navigation elements for accurate locations.
+
 ## [3.3.2] - 2026-02-02
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 3.3.2
+pluginVersion = 3.3.3
 
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/OptimizedSymbolSearch.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/OptimizedSymbolSearch.kt
@@ -200,23 +200,24 @@ object OptimizedSymbolSearch {
             }
         } ?: return null
 
-        val language = getLanguageName(element)
+        val targetElement = element.navigationElement ?: element
+        val language = getLanguageName(targetElement)
 
         // Apply language filter if specified
         if (languageFilter != null && language !in languageFilter) {
             return null
         }
 
-        val file = element.containingFile?.virtualFile ?: return null
+        val file = targetElement.containingFile?.virtualFile ?: return null
         val basePath = project.basePath ?: ""
         val relativePath = file.path.removePrefix(basePath).removePrefix("/")
 
-        val name = when (element) {
-            is PsiNamedElement -> element.name
+        val name = when (targetElement) {
+            is PsiNamedElement -> targetElement.name
             else -> {
                 try {
-                    val method = element.javaClass.getMethod("getName")
-                    method.invoke(element) as? String
+                    val method = targetElement.javaClass.getMethod("getName")
+                    method.invoke(targetElement) as? String
                 } catch (e: Exception) {
                     null
                 }
@@ -224,15 +225,15 @@ object OptimizedSymbolSearch {
         } ?: return null
 
         val qualifiedName = try {
-            val method = element.javaClass.getMethod("getQualifiedName")
-            method.invoke(element) as? String
+            val method = targetElement.javaClass.getMethod("getQualifiedName")
+            method.invoke(targetElement) as? String
         } catch (e: Exception) {
             null
         }
 
-        val line = getLineNumber(project, element) ?: 1
-        val kind = determineKind(element)
-        val containerName = getContainerName(element)
+        val line = getLineNumber(project, targetElement) ?: 1
+        val kind = determineKind(targetElement)
+        val containerName = getContainerName(targetElement)
 
         return SymbolData(
             name = name,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
@@ -233,17 +233,18 @@ class FindClassTool : AbstractMcpTool() {
                 }
             }
         } ?: return null
+        val targetElement = element.navigationElement ?: element
 
-        val file = element.containingFile?.virtualFile ?: return null
+        val file = targetElement.containingFile?.virtualFile ?: return null
         val basePath = project.basePath ?: ""
         val relativePath = file.path.removePrefix(basePath).removePrefix("/")
 
-        val name = when (element) {
-            is PsiNamedElement -> element.name
+        val name = when (targetElement) {
+            is PsiNamedElement -> targetElement.name
             else -> {
                 try {
-                    val method = element.javaClass.getMethod("getName")
-                    method.invoke(element) as? String
+                    val method = targetElement.javaClass.getMethod("getName")
+                    method.invoke(targetElement) as? String
                 } catch (_: Exception) {
                     null
                 }
@@ -251,15 +252,15 @@ class FindClassTool : AbstractMcpTool() {
         } ?: return null
 
         val qualifiedName = try {
-            val method = element.javaClass.getMethod("getQualifiedName")
-            method.invoke(element) as? String
+            val method = targetElement.javaClass.getMethod("getQualifiedName")
+            method.invoke(targetElement) as? String
         } catch (e: Exception) {
             null
         }
 
-        val line = getLineNumber(project, element) ?: 1
-        val kind = determineKind(element)
-        val language = getLanguageName(element)
+        val line = getLineNumber(project, targetElement) ?: 1
+        val kind = determineKind(targetElement)
+        val language = getLanguageName(targetElement)
 
         return SymbolMatch(
             name = name,


### PR DESCRIPTION
    Updated convertToSymbolMatch to resolve to source navigation element
    before building SymbolMatch, mirroring IDEA's behavior when sources
    are attached (e.g., SomeClient.java in source.jar).

    Changes:
    - Use SourceNavigationHelper.getInstance(project).getSourceElement(element) to resolve to source element, falling back to original element when no sources are available
    - File path, name, qualifiedName, line, kind, and language now come from the source element when present

    This means:
    - If dependency has source.jar, results point to .java/.kt files
    - If not, results still point to compiled classes in classes.jar