### PR TITLE
feat(tools): add ide_read_file tool with library source support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 build
 tmp
 .claude
+local.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## [Unreleased]
 
+## [3.3.4] - 2026-02-05
+
+### Added
+- **New tool: `ide_read_file`** - Read source file contents from project or library dependencies
+  - Supports multiple file path formats: relative, absolute, jar paths (`path/to/lib.jar!/com/example/Class.java`), and jar URLs
+  - Can read files by qualified class name (e.g., `java.util.ArrayList`)
+  - Supports optional line range extraction with `startLine` and `endLine` parameters (1-based, inclusive)
+  - Automatically detects library files and resolves jar file paths
+  - Returns file metadata: language ID, line count, and whether it's a library file
+
+### Changed
+- **Enhanced library source navigation** - `ide_find_definition` and symbol resolution now prefer source files (`.java`) over compiled files (`.class`) when library sources are attached
+  - Added `PsiUtils.getNavigationElement()` utility for consistent navigation element resolution
+  - Improves readability when navigating to library code with attached sources
+
 ## [3.3.3] - 2026-02-03
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 3.3.3
+pluginVersion = 3.3.4
 
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
@@ -35,6 +35,7 @@ object ParamNames {
     const val INCLUDE_TESTS = "includeTests"
     const val PATH = "path"
     const val FQN = "fqn"
+    const val QUALIFIED_NAME = "qualifiedName"
 
     // Symbol search parameters
     const val QUERY = "query"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
@@ -13,6 +13,7 @@ object ToolNames {
     const val FIND_CLASS = "ide_find_class"
     const val FIND_FILE = "ide_find_file"
     const val SEARCH_TEXT = "ide_search_text"
+    const val READ_FILE = "ide_read_file"
 
     // Intelligence tools
     const val DIAGNOSTICS = "ide_diagnostics"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -22,7 +22,7 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
     data class State(
         var maxHistorySize: Int = 100,
         var syncExternalChanges: Boolean = false,
-        var disabledTools: MutableSet<String> = mutableSetOf("ide_file_structure", "ide_find_symbol"),
+        var disabledTools: MutableSet<String> = mutableSetOf("ide_file_structure", "ide_find_symbol", "ide_read_file"),
         var serverPort: Int = -1, // -1 means use IDE-specific default
         var migratedToVersion: Int = 0 // Track migration status (2 = v2.0.0 migration done)
     )

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -9,6 +9,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindClass
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindDefinitionTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.ReadFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool
@@ -217,6 +218,7 @@ class ToolRegistry {
         register(FindClassTool())
         register(FindFileTool())
         register(SearchTextTool())
+        register(ReadFileTool())
 
         LOG.info("Registered universal tools (available in all JetBrains IDEs)")
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
@@ -35,6 +35,18 @@ data class DefinitionResult(
     val symbolName: String
 )
 
+// ide_read_file output
+@Serializable
+data class ReadFileResult(
+    val file: String,
+    val content: String,
+    val language: String?,
+    val lineCount: Int,
+    val startLine: Int?,
+    val endLine: Int?,
+    val isLibraryFile: Boolean
+)
+
 
 // type_hierarchy output
 @Serializable

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
@@ -84,8 +84,11 @@ class FindDefinitionTool : AbstractMcpTool() {
             // Use semantic reference resolution to find what this position refers to.
             // This correctly handles method calls (resolves to the called method)
             // vs declarations (returns the declaration itself).
-            val targetElement = PsiUtils.resolveTargetElement(element)
+            val resolvedElement = PsiUtils.resolveTargetElement(element)
                 ?: return@suspendingReadAction createErrorResult(ErrorMessages.SYMBOL_NOT_RESOLVED)
+
+            // Prefer source files (.java) over compiled files (.class) for library classes
+            val targetElement = PsiUtils.getNavigationElement(resolvedElement)
 
             val targetFile = targetElement.containingFile?.virtualFile
                 ?: return@suspendingReadAction createErrorResult(ErrorMessages.DEFINITION_FILE_NOT_FOUND)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/ReadFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/ReadFileTool.kt
@@ -1,0 +1,141 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ReadFileResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiManager
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+@Suppress("unused")
+class ReadFileTool : AbstractMcpTool() {
+
+    override val name = ToolNames.READ_FILE
+
+    override val description = """
+    File lookup: by file path (relative, absolute, jar path with !/or jar://) or qualifiedName (e.g., java.util.ArrayList).
+    Best for library/dependency Java sources (jars/external libs). For project files, prefer native tools; enable only when needed.
+
+    Returns: file content (full or line range) with metadata (language, lineCount, start/end, isLibraryFile).
+
+    Parameters: file or qualifiedName (one required), startLine (optional), endLine (optional).
+
+    Examples: {"file": "src/main/java/MyClass.java"} or {"qualifiedName": "java.util.ArrayList"} or {"file": "MyClass.java", "startLine": 10, "endLine": 20}
+""".trimIndent()
+
+    override val inputSchema: JsonObject = buildJsonObject {
+        put(SchemaConstants.TYPE, SchemaConstants.TYPE_OBJECT)
+        putJsonObject(SchemaConstants.PROPERTIES) {
+            putJsonObject(ParamNames.PROJECT_PATH) {
+                put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                put(SchemaConstants.DESCRIPTION, SchemaConstants.DESC_PROJECT_PATH)
+            }
+            putJsonObject(ParamNames.FILE) {
+                put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                put(SchemaConstants.DESCRIPTION, "File path (relative, absolute, jar path with jar!/, or jar:// URL).")
+            }
+            putJsonObject(ParamNames.QUALIFIED_NAME) {
+                put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                put(SchemaConstants.DESCRIPTION, "Fully qualified class name (e.g., java.util.ArrayList).")
+            }
+            putJsonObject(ParamNames.START_LINE) {
+                put(SchemaConstants.TYPE, SchemaConstants.TYPE_INTEGER)
+                put(SchemaConstants.DESCRIPTION, "Starting line number (1-based, inclusive).")
+            }
+            putJsonObject(ParamNames.END_LINE) {
+                put(SchemaConstants.TYPE, SchemaConstants.TYPE_INTEGER)
+                put(SchemaConstants.DESCRIPTION, "Ending line number (1-based, inclusive).")
+            }
+        }
+        putJsonArray(SchemaConstants.REQUIRED) {
+            // Either file or qualifiedName is required (validated in code)
+        }
+    }
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val filePath = arguments[ParamNames.FILE]?.jsonPrimitive?.content
+        val qualifiedName = arguments[ParamNames.QUALIFIED_NAME]?.jsonPrimitive?.content
+        val startLineInput = arguments[ParamNames.START_LINE]?.jsonPrimitive?.int
+        val endLineInput = arguments[ParamNames.END_LINE]?.jsonPrimitive?.int
+
+        if (filePath.isNullOrBlank() && qualifiedName.isNullOrBlank()) {
+            return createErrorResult("Either '${ParamNames.FILE}' or '${ParamNames.QUALIFIED_NAME}' is required")
+        }
+
+        var startLine = startLineInput
+        var endLine = endLineInput
+
+        if (startLine == null && endLine != null) {
+            return createErrorResult("startLine is required when endLine is provided")
+        }
+
+        if (startLine != null && endLine == null) {
+            endLine = startLine
+        }
+
+        if (startLine != null && endLine != null) {
+            if (startLine < 1 || endLine < 1) {
+                return createErrorResult("startLine and endLine must be >= 1")
+            }
+            if (endLine < startLine) {
+                return createErrorResult("endLine must be >= startLine")
+            }
+        }
+
+        return suspendingReadAction {
+            val virtualFile = when {
+                !qualifiedName.isNullOrBlank() -> {
+                    requireSmartMode(project)
+                    val element = findClassByName(project, qualifiedName)
+                        ?: return@suspendingReadAction createErrorResult("Class not found: $qualifiedName")
+                    element.containingFile?.virtualFile
+                }
+                !filePath.isNullOrBlank() -> PsiUtils.resolveVirtualFileAnywhere(project, filePath)
+                else -> null
+            } ?: return@suspendingReadAction createErrorResult("File not found: ${filePath ?: qualifiedName}")
+
+            val content = if (startLine != null && endLine != null) {
+                PsiUtils.getFileContentByLines(project, virtualFile, startLine, endLine)
+            } else {
+                PsiUtils.getFileContent(project, virtualFile)
+            } ?: return@suspendingReadAction createErrorResult("Unable to read file contents")
+
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+            val document = psiFile?.let { PsiDocumentManager.getInstance(project).getDocument(it) }
+            val fullText = if (document == null) PsiUtils.getFileContent(project, virtualFile) else null
+            val lineCount = document?.lineCount ?: fullText?.split("\n")?.size ?: content.split("\n").size
+            val language = psiFile?.language?.id
+
+            val resolvedPath = when {
+                ProjectUtils.isProjectFile(project, virtualFile) -> ProjectUtils.getRelativePath(project, virtualFile)
+                virtualFile.fileSystem.protocol == "jar" -> virtualFile.url
+                else -> virtualFile.path
+            }
+
+            val isLibraryFile = !ProjectUtils.isProjectFile(project, virtualFile) ||
+                virtualFile.fileSystem.protocol == "jar"
+
+            createJsonResult(ReadFileResult(
+                file = resolvedPath,
+                content = content,
+                language = language,
+                lineCount = lineCount,
+                startLine = startLine,
+                endLine = endLine,
+                isLibraryFile = isLibraryFile
+            ))
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
@@ -2,7 +2,9 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.util
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -113,6 +115,82 @@ object PsiUtils {
         return LocalFileSystem.getInstance().refreshAndFindFileByPath(fullPath)
     }
 
+    fun resolveVirtualFileAnywhere(project: Project, path: String): VirtualFile? {
+        val virtualFileManager = VirtualFileManager.getInstance()
+        
+        // Handle already-formatted jar:// URLs
+        if (path.startsWith("jar://")) {
+            return virtualFileManager.findFileByUrl(path)
+        }
+
+        // Handle jar path format: /path/to/file.jar!/internal/path
+        if (path.contains(".jar!/")) {
+            val parts = path.split("!/", limit = 2)
+            if (parts.size == 2) {
+                val jarPath = parts[0]
+                val internalPath = parts[1]
+                
+                // Normalize the jar file path to absolute path
+                val absoluteJarPath = when {
+                    jarPath.startsWith("/") -> jarPath
+                    jarPath.startsWith("~") -> {
+                        val homeDir = System.getProperty("user.home")
+                        jarPath.replaceFirst("~", homeDir)
+                    }
+                    else -> {
+                        // Try as relative to project first
+                        val basePath = project.basePath
+                        if (basePath != null) {
+                            "$basePath/$jarPath"
+                        } else {
+                            // Try as absolute path without leading /
+                            "/$jarPath"
+                        }
+                    }
+                }
+                
+                // Construct the jar URL: jar://absolute/path/to/file.jar!/internal/path
+                val jarUrl = "jar://$absoluteJarPath!/$internalPath"
+                val findFileByUrl = virtualFileManager.findFileByUrl(jarUrl)
+                return findFileByUrl
+            }
+        }
+
+        return getVirtualFile(project, path)
+    }
+
+    fun getFileContent(project: Project, virtualFile: VirtualFile): String? {
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+        val document = psiFile?.let { PsiDocumentManager.getInstance(project).getDocument(it) }
+        return document?.text ?: runCatching { VfsUtil.loadText(virtualFile) }.getOrNull()
+    }
+
+    fun getFileContentByLines(
+        project: Project,
+        virtualFile: VirtualFile,
+        startLine: Int,
+        endLine: Int
+    ): String? {
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+        val document = psiFile?.let { PsiDocumentManager.getInstance(project).getDocument(it) }
+
+        if (document != null) {
+            val clampedStart = (startLine - 1).coerceAtLeast(0)
+            val clampedEnd = (endLine - 1).coerceAtMost(document.lineCount - 1)
+            if (clampedStart > clampedEnd) return ""
+            val startOffset = document.getLineStartOffset(clampedStart)
+            val endOffset = document.getLineEndOffset(clampedEnd)
+            return document.getText(com.intellij.openapi.util.TextRange(startOffset, endOffset))
+        }
+
+        val text = runCatching { VfsUtil.loadText(virtualFile) }.getOrNull() ?: return null
+        val lines = text.lines()
+        val clampedStart = (startLine - 1).coerceAtLeast(0)
+        val clampedEnd = (endLine - 1).coerceAtMost(lines.size - 1)
+        if (clampedStart > clampedEnd) return ""
+        return lines.subList(clampedStart, clampedEnd + 1).joinToString("\n")
+    }
+
     fun getContainingClass(element: PsiElement): PsiClass? {
         return PsiTreeUtil.getParentOfType(element, PsiClass::class.java)
     }
@@ -151,5 +229,24 @@ object PsiUtils {
                     line.removePrefix("*").trim()
                 }
         }
+    }
+
+    /**
+     * Gets the navigation element for a PSI element, preferring source files over compiled files.
+     *
+     * This is crucial for library classes where we want to navigate to `.java` source files
+     * instead of `.class` bytecode files when sources are available.
+     *
+     * **Why this matters:**
+     * When you have a library with attached sources (e.g., via Maven or Gradle), IntelliJ
+     * stores both the compiled `.class` files and the source `.java` files. By default,
+     * PSI elements may point to the `.class` file, but `navigationElement` provides the
+     * source file if available, which is much more useful for reading code.
+     *
+     * @param element The PSI element to get the navigation target for
+     * @return The navigation element (preferably source), or the original element if no navigation target exists
+     */
+    fun getNavigationElement(element: PsiElement): PsiElement {
+        return element.navigationElement ?: element
     }
 }


### PR DESCRIPTION
- Add new ide_read_file tool for reading source files and library dependencies
  - Support multiple file path formats (relative, absolute, jar paths, jar URLs)
  - Support qualified class name lookup (e.g., java.util.ArrayList)
  - Optional line range extraction with startLine/endLine parameters
  - Returns file metadata (language, line count, library file flag)

- Enhance library source navigation across tools
  - Prefer source files (.java) over compiled files (.class) for libraries
  - Add PsiUtils.getNavigationElement() for consistent navigation resolution
  - Update ide_find_definition and findClassByName to use navigation elements