### PR TITLE
add overrideStrategy parameter to control super method dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+## [3.12.0] - 2026-03-01
+
+### Added
+- **`overrideStrategy` parameter for `ide_refactor_rename`** — Controls how renaming a method that overrides a base method is handled, enabling fully headless/agent usage without modal dialogs
+  - `"rename_base"` (default): Automatically renames the base method and all overrides by resolving to the deepest super method via `PsiMethod.findDeepestSuperMethods()`, bypassing the dialog entirely
+  - `"rename_only_current"`: Renames only the current method, leaving the base and other overrides unchanged
+  - `"ask"`: Preserves original IDE behavior, showing the dialog for interactive choice
+
 ## [3.11.0] - 2026-02-27
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 3.11.0
+pluginVersion = 3.12.0
 
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -5,6 +5,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import com.intellij.lang.LanguageNamesValidation
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
@@ -38,6 +39,10 @@ import kotlinx.serialization.json.jsonPrimitive
  * 2. **EDT Phase**: Execute rename via RenameProcessor (handles all references)
  */
 class RenameSymbolTool : AbstractMcpTool() {
+
+    companion object {
+        private val LOG = logger<RenameSymbolTool>()
+    }
 
     override val name = "ide_refactor_rename"
 
@@ -412,8 +417,8 @@ class RenameSymbolTool : AbstractMcpTool() {
             val result = recordUtilClass.getMethod("getRecordComponentForAccessor", Class.forName("com.intellij.psi.PsiMethod"))
                 .invoke(null, element)
             if (result is PsiNamedElement) return result
-        } catch (_: Exception) {
-            // Not a Java method or no Java plugin — ignore
+        } catch (e: Exception) {
+            LOG.warn("Failed to resolve record component for accessor: ${e.message}", e)
         }
         return element
     }
@@ -440,8 +445,8 @@ class RenameSymbolTool : AbstractMcpTool() {
                 }
                 return null
             }
-        } catch (_: Exception) {
-            // PsiMethod not available
+        } catch (e: Exception) {
+            LOG.warn("Failed to resolve deepest super method via PsiMethod API: ${e.message}", e)
         }
 
         // Try Kotlin KtNamedFunction path — unwrap to light method and use PsiMethod API
@@ -465,8 +470,8 @@ class RenameSymbolTool : AbstractMcpTool() {
             if (deepestSuperMethods.isNotEmpty()) {
                 return deepestSuperMethods[0] as? PsiNamedElement
             }
-        } catch (_: Exception) {
-            // Kotlin plugin not available or different API version
+        } catch (e: Exception) {
+            LOG.warn("Failed to resolve deepest super method via Kotlin KtNamedFunction API: ${e.message}", e)
         }
 
         return null


### PR DESCRIPTION
When renaming a method that overrides a base method, IntelliJ's RenameJavaMethodProcessor calls SuperMethodWarningUtil.checkSuperMethod() which shows a modal dialog asking whether to rename the base method. This blocks headless/agent usage.

Add an `overrideStrategy` enum parameter with three options:
- "rename_base" (default): resolve to the deepest super method via PsiMethod.findDeepestSuperMethods(), bypassing the dialog entirely
- "rename_only_current": rename only the current method, skipping substituteElementToRename() to avoid the dialog
- "ask": preserve original behavior, showing the IDE dialog

The deepest super method resolution handles both Java PsiMethod (including Kotlin KtLightMethod) and pure Kotlin KtNamedFunction (via toLightMethods() reflection).