### PR TITLE
feat: add `astPath` field to `ide_find_references` and `ide_find_definition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Added
+- **`ide_find_references` and `ide_find_definition`: `astPath` field** — Returns the chain of named AST ancestors (classes, methods, etc.) enclosing the target element, providing structural context for each result without requiring additional file reads.
+
 ## [4.7.0] - 2026-03-26
 ### Added
 - Cursor-based pagination for `ide_find_references`, `ide_search_text`, `ide_find_class`, `ide_find_file`, `ide_find_symbol`, and `ide_find_implementations`

--- a/USAGE.md
+++ b/USAGE.md
@@ -152,14 +152,16 @@ Finds all references to a symbol across the entire project using IntelliJ's sema
       "line": 42,
       "column": 15,
       "context": "userService.findUser(id)",
-      "type": "METHOD_CALL"
+      "type": "METHOD_CALL",
+      "astPath": ["UserController", "getUser"]
     },
     {
       "file": "src/test/java/com/example/UserServiceTest.java",
       "line": 28,
       "column": 10,
       "context": "service.findUser(\"test\")",
-      "type": "METHOD_CALL"
+      "type": "METHOD_CALL",
+      "astPath": ["UserServiceTest", "testFindUser"]
     }
   ],
   "totalCount": 2
@@ -217,7 +219,8 @@ Finds the definition/declaration location of a symbol at a given source location
   "line": 15,
   "column": 17,
   "preview": "14:     \n15:     public User findUser(String id) {\n16:         return userRepository.findById(id);\n17:     }",
-  "symbolName": "findUser"
+  "symbolName": "findUser",
+  "astPath": ["UserService"]
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.7.0
+pluginVersion = 4.8.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
@@ -16,7 +16,8 @@ data class UsageLocation(
     val line: Int,
     val column: Int,
     val context: String,
-    val type: String
+    val type: String,
+    val astPath: List<String>,
 )
 
 @Serializable
@@ -39,7 +40,8 @@ data class DefinitionResult(
     val line: Int,
     val column: Int,
     val preview: String,
-    val symbolName: String
+    val symbolName: String,
+    val astPath: List<String>
 )
 
 // ide_read_file output

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
@@ -92,7 +92,8 @@ class FindDefinitionTool : AbstractMcpTool() {
                     line = 1,
                     column = 1,
                     preview = "Package directory: $dirPath",
-                    symbolName = effectiveTarget.name
+                    symbolName = effectiveTarget.name,
+                    astPath = PsiUtils.getAstPath(effectiveTarget)
                 ))
             }
             // PsiPackage is Java-plugin-only; use reflection to avoid NoClassDefFoundError in non-Java IDEs
@@ -112,7 +113,8 @@ class FindDefinitionTool : AbstractMcpTool() {
                             line = 1,
                             column = 1,
                             preview = "Package: $qualifiedName",
-                            symbolName = qualifiedName
+                            symbolName = qualifiedName,
+                            astPath = emptyList()
                         ))
                     }
                 }
@@ -165,7 +167,8 @@ class FindDefinitionTool : AbstractMcpTool() {
                 line = targetLine,
                 column = targetColumn,
                 preview = preview,
-                symbolName = symbolName
+                symbolName = symbolName,
+                astPath = PsiUtils.getAstPath(effectiveTarget)
             ))
         }
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -128,7 +128,8 @@ class FindUsagesTool : AbstractMcpTool() {
                                 line = lineNumber,
                                 column = columnNumber,
                                 context = lineText,
-                                type = classifyUsage(refElement)
+                                type = classifyUsage(refElement),
+                                astPath = PsiUtils.getAstPath(refElement)
                             ))
                         }
                     }
@@ -227,7 +228,8 @@ class FindUsagesTool : AbstractMcpTool() {
                                 line = lineNumber,
                                 column = columnNumber,
                                 context = lineText,
-                                type = classifyUsage(refElement)
+                                type = classifyUsage(refElement),
+                                astPath = PsiUtils.getAstPath(refElement)
                             )
                             newResults.add(PaginationService.SerializedResult(key, json.encodeToJsonElement(usage)))
                         }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
@@ -215,6 +215,26 @@ object PsiUtils {
         return lines.subList(clampedStart, clampedEnd + 1).joinToString("\n")
     }
 
+    /**
+     * Returns the chain of named PSI ancestors enclosing [element], ordered from the
+     * outermost (closest to file root) to the innermost (immediate named parent).
+     * The [element] itself is never included, nor are anonymous (unnamed) nodes.
+     */
+    fun getAstPath(element: PsiElement): List<String> {
+        val ancestors = mutableListOf<String>()
+        var current: PsiElement? = element.parent
+        while (current != null && current !is PsiFile) {
+            if (current is PsiNamedElement) {
+                val name = current.name
+                if (!name.isNullOrEmpty()) {
+                    ancestors.add(name)
+                }
+            }
+            current = current.parent
+        }
+        return ancestors.asReversed()
+    }
+
     fun findNamedElement(element: PsiElement): PsiNamedElement? {
         var current: PsiElement? = element
         while (current != null) {

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -32,8 +32,8 @@ Find all usages of a symbol (semantic, not text search).
 | `maxResults` | integer | no | Default 100, max 500 |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ usages: [{file, line, column, context, usageType}], totalCount, truncated }`
-**usageType values**: `method_call`, `field_access`, `import`, `parameter`, `variable`, `reference`
+**Returns**: `{ usages: [{ file, line, column, context, type, astPath }], totalCount, truncated }`
+**type values**: `METHOD_CALL`, `FIELD_ACCESS`, `IMPORT`, `PARAMETER`, `VARIABLE`, `REFERENCE`
 
 ### ide_find_definition
 Go to where a symbol is defined.
@@ -47,7 +47,7 @@ Go to where a symbol is defined.
 | `maxPreviewLines` | integer | no | Max lines for full preview (default 50, max 500) |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ file, line, column, preview, symbolName }`
+**Returns**: `{ file, line, column, preview, symbolName, astPath }`
 Handles: packages, compiled classes, library sources (jar: URLs).
 
 ### ide_find_class

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
@@ -128,6 +128,7 @@ class ToolExecutionIntegrationTest : BasePlatformTestCase() {
         }
 
         assertTrue("Full preview should include method name", definition.preview.contains("doWork"))
+        assertEquals("astPath should contain enclosing class", listOf("Service"), definition.astPath)
     }
 
     fun testReadFileToolValidation() = runBlocking {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/models/ToolModelsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/models/ToolModelsUnitTest.kt
@@ -37,7 +37,8 @@ class ToolModelsUnitTest : TestCase() {
             line = 25,
             column = 12,
             context = "val service = UserService()",
-            type = "METHOD_CALL"
+            type = "METHOD_CALL",
+            astPath = listOf("MyClass", "myMethod")
         )
 
         val serialized = json.encodeToString(location)
@@ -48,6 +49,7 @@ class ToolModelsUnitTest : TestCase() {
         assertEquals(12, deserialized.column)
         assertEquals("val service = UserService()", deserialized.context)
         assertEquals("METHOD_CALL", deserialized.type)
+        assertEquals(listOf("MyClass", "myMethod"), deserialized.astPath)
     }
 
     // FindUsagesResult tests
@@ -55,8 +57,8 @@ class ToolModelsUnitTest : TestCase() {
     fun testFindUsagesResultSerialization() {
         val result = FindUsagesResult(
             usages = listOf(
-                UsageLocation("file1.kt", 10, 5, "context1", "REFERENCE"),
-                UsageLocation("file2.kt", 20, 8, "context2", "METHOD_CALL")
+                UsageLocation("file1.kt", 10, 5, "context1", "REFERENCE", listOf("ClassA", "methodX")),
+                UsageLocation("file2.kt", 20, 8, "context2", "METHOD_CALL", listOf("ClassB", "methodY"))
             ),
             totalCount = 2
         )
@@ -86,7 +88,8 @@ class ToolModelsUnitTest : TestCase() {
             line = 5,
             column = 1,
             preview = "data class User(val name: String)",
-            symbolName = "User"
+            symbolName = "User",
+            astPath = listOf("UserService")
         )
 
         val serialized = json.encodeToString(result)
@@ -97,6 +100,7 @@ class ToolModelsUnitTest : TestCase() {
         assertEquals(1, deserialized.column)
         assertEquals("data class User(val name: String)", deserialized.preview)
         assertEquals("User", deserialized.symbolName)
+        assertEquals(listOf("UserService"), deserialized.astPath)
     }
 
     // TypeHierarchyResult tests


### PR DESCRIPTION
## Summary

Adds an `astPath` field to `ide_find_references` and `ide_find_definition` tool responses. This field returns the chain of named AST ancestors (classes, methods, etc.) enclosing the target element, ordered from outermost to innermost. This provides structural context for each result – e.g. knowing that a reference lives inside `UserController.getUser` – without requiring additional file reads.

- New `PsiUtils.getAstPath(element)` utility walks PSI ancestors to build the path
- `UsageLocation` and `DefinitionResult` models extended with `astPath: List<String>`
- Updated documentation (USAGE.md, tools-reference.md, CHANGELOG.md)
- Version bumped to 4.8.0

## Test plan

- [x] Unit tests updated: `ToolModelsUnitTest` verifies `astPath` serialization/deserialization for both `UsageLocation` and `DefinitionResult`
- [x] Integration test updated: `ToolExecutionIntegrationTest` asserts `astPath` contains the enclosing class name for a definition result
- [x] Manual: run `ide_find_definition` and verify `astPath` reflects the definition's enclosing structure: see _ide_find_definition.png_
- [x] Manual: run `ide_find_references` on a method and verify `astPath` appears in each usage with correct enclosing scope chain: see _ide_find_references.png_

## Screenshots

Manual run via [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector):

<details><summary><b>ide_find_definition.png</b></summary>

<img width="716" height="auto" alt="ide_find_definition" src="https://github.com/user-attachments/assets/ff94b521-c6f5-4406-a923-5b60c1361275" />

</details>

<details><summary><b>ide_find_references.png</b></summary>

<img width="716" height="auto" alt="ide_find_references" src="https://github.com/user-attachments/assets/ff4b58cf-232c-464b-8d6a-e2e8fa0d007c" />

</details> 

<br/>

Generated with [Claude Code](https://claude.com/claude-code)