### PR TITLE
feat: add optional top-level-only available_projects in project resolution errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+- Added `availableProjectsTopLevelOnly` setting to keep `available_projects` errors focused on top-level open projects, with optional workspace sub-project expansion.
 
 ## [4.10.5] - 2026-04-15
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.10.5
+pluginVersion = 4.11.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
@@ -12,6 +12,31 @@ import com.intellij.openapi.roots.ModuleRootManager
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 
+internal data class AvailableProjectEntry(
+    val name: String,
+    val path: String,
+    val workspace: String? = null
+)
+
+/**
+ * Builds the `available_projects` payload and applies top-level filtering when requested.
+ */
+internal fun buildAvailableProjectsJson(
+    entries: List<AvailableProjectEntry>,
+    includeWorkspaceSubProjects: Boolean
+): JsonArray {
+    return buildJsonArray {
+        for (entry in entries) {
+            if (!includeWorkspaceSubProjects && entry.workspace != null) continue
+            add(buildJsonObject {
+                put("name", entry.name)
+                put("path", entry.path)
+                entry.workspace?.let { put("workspace", it) }
+            })
+        }
+    }
+}
+
 object ProjectResolver {
 
     private val LOG = logger<ProjectResolver>()
@@ -139,36 +164,36 @@ object ProjectResolver {
      * so AI agents can discover the correct paths to use.
      */
     private fun buildAvailableProjectsArray(openProjects: List<Project>, includeWorkspaceSubProjects: Boolean): JsonArray {
-        return buildJsonArray {
-            for (proj in openProjects) {
-                add(buildJsonObject {
-                    put("name", proj.name)
-                    put("path", proj.basePath ?: "")
-                })
+        val entries = mutableListOf<AvailableProjectEntry>()
+        for (proj in openProjects) {
+            entries += AvailableProjectEntry(
+                name = proj.name,
+                path = proj.basePath ?: ""
+            )
 
-                if (!includeWorkspaceSubProjects) continue
+            if (!includeWorkspaceSubProjects) continue
 
-                // Include workspace sub-projects (module content roots)
-                try {
-                    val modules = ModuleManager.getInstance(proj).modules
-                    for (module in modules) {
-                        val contentRoots = ModuleRootManager.getInstance(module).contentRoots
-                        for (root in contentRoots) {
-                            val rootPath = root.path
-                            if (rootPath != proj.basePath) {
-                                add(buildJsonObject {
-                                    put("name", module.name)
-                                    put("path", rootPath)
-                                    put("workspace", proj.name)
-                                })
-                            }
+            // Include workspace sub-projects (module content roots)
+            try {
+                val modules = ModuleManager.getInstance(proj).modules
+                for (module in modules) {
+                    val contentRoots = ModuleRootManager.getInstance(module).contentRoots
+                    for (root in contentRoots) {
+                        val rootPath = root.path
+                        if (rootPath != proj.basePath) {
+                            entries += AvailableProjectEntry(
+                                name = module.name,
+                                path = rootPath,
+                                workspace = proj.name
+                            )
                         }
                     }
-                } catch (e: Exception) {
-                    LOG.debug("Failed to list module content roots for project ${proj.name}", e)
                 }
+            } catch (e: Exception) {
+                LOG.debug("Failed to list module content roots for project ${proj.name}", e)
             }
         }
+        return buildAvailableProjectsJson(entries, includeWorkspaceSubProjects)
     }
 
     private fun shouldReturnTopLevelProjectsOnly(): Boolean {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
@@ -1,6 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.intellij.openapi.diagnostic.logger
@@ -29,6 +30,7 @@ object ProjectResolver {
     fun resolve(projectPath: String?): Result {
         val openProjects = ProjectManager.getInstance().openProjects
             .filter { !it.isDefault }
+        val includeWorkspaceSubProjects = !shouldReturnTopLevelProjectsOnly()
 
         // No projects open
         if (openProjects.isEmpty()) {
@@ -78,7 +80,7 @@ object ProjectResolver {
                         text = json.encodeToString(buildJsonObject {
                             put("error", ErrorMessages.ERROR_PROJECT_NOT_FOUND)
                             put("message", ErrorMessages.msgProjectNotFound(projectPath))
-                            put("available_projects", buildAvailableProjectsArray(openProjects))
+                            put("available_projects", buildAvailableProjectsArray(openProjects, includeWorkspaceSubProjects))
                         })
                     )),
                     isError = true
@@ -99,7 +101,7 @@ object ProjectResolver {
                     text = json.encodeToString(buildJsonObject {
                         put("error", ErrorMessages.ERROR_MULTIPLE_PROJECTS)
                         put("message", ErrorMessages.MSG_MULTIPLE_PROJECTS)
-                        put("available_projects", buildAvailableProjectsArray(openProjects))
+                        put("available_projects", buildAvailableProjectsArray(openProjects, includeWorkspaceSubProjects))
                     })
                 )),
                 isError = true
@@ -136,13 +138,15 @@ object ProjectResolver {
      * For workspace projects, lists each module's content root as a separate entry
      * so AI agents can discover the correct paths to use.
      */
-    private fun buildAvailableProjectsArray(openProjects: List<Project>): JsonArray {
+    private fun buildAvailableProjectsArray(openProjects: List<Project>, includeWorkspaceSubProjects: Boolean): JsonArray {
         return buildJsonArray {
             for (proj in openProjects) {
                 add(buildJsonObject {
                     put("name", proj.name)
                     put("path", proj.basePath ?: "")
                 })
+
+                if (!includeWorkspaceSubProjects) continue
 
                 // Include workspace sub-projects (module content roots)
                 try {
@@ -165,5 +169,10 @@ object ProjectResolver {
                 }
             }
         }
+    }
+
+    private fun shouldReturnTopLevelProjectsOnly(): Boolean {
+        return runCatching { McpSettings.getInstance().availableProjectsTopLevelOnly }
+            .getOrDefault(false)
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -21,6 +21,7 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
      */
     data class State(
         var maxHistorySize: Int = 100,
+        var availableProjectsTopLevelOnly: Boolean = false,
         var syncExternalChanges: Boolean = false,
         var disabledTools: MutableSet<String> = mutableSetOf("ide_build_project", "ide_file_structure", "ide_find_symbol", "ide_read_file", "ide_get_active_file", "ide_open_file", "ide_reformat_code", "ide_optimize_imports", "ide_convert_java_to_kotlin"),
         var serverPort: Int = -1, // -1 means use IDE-specific default
@@ -38,6 +39,10 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
     var maxHistorySize: Int
         get() = state.maxHistorySize
         set(value) { state.maxHistorySize = value }
+
+    var availableProjectsTopLevelOnly: Boolean
+        get() = state.availableProjectsTopLevelOnly
+        set(value) { state.availableProjectsTopLevelOnly = value }
 
     var syncExternalChanges: Boolean
         get() = state.syncExternalChanges

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -45,6 +45,7 @@ class McpSettingsConfigurable : Configurable {
     private var serverHostField: JBTextField? = null
     private var maxHistorySizeSpinner: JSpinner? = null
     private var serverPortSpinner: JSpinner? = null
+    private var availableProjectsTopLevelOnlyCheckBox: JBCheckBox? = null
     private var syncExternalChangesCheckBox: JBCheckBox? = null
     private val toolCheckBoxes = mutableMapOf<String, JBCheckBox>()
     private var uiDisposable: Disposable? = null
@@ -92,12 +93,19 @@ class McpSettingsConfigurable : Configurable {
         serverPortSpinner = JSpinner(SpinnerNumberModel(McpConstants.getDefaultServerPort(), 1024, 65535, 1)).apply {
             toolTipText = McpBundle.message("settings.serverPort.tooltip")
         }
+        availableProjectsTopLevelOnlyCheckBox = JBCheckBox(McpBundle.message("settings.availableProjectsTopLevelOnly")).apply {
+            toolTipText = McpBundle.message("settings.availableProjectsTopLevelOnly.tooltip")
+        }
         syncExternalChangesCheckBox = JBCheckBox(McpBundle.message("settings.syncExternalChanges")).apply {
             toolTipText = McpBundle.message("settings.syncExternalChanges.tooltip")
         }
 
         val warningLabel = JBLabel(McpBundle.message("settings.syncExternalChanges.warning")).apply {
             foreground = JBColor.RED
+        }
+
+        val availableProjectsPanel = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
+            add(availableProjectsTopLevelOnlyCheckBox)
         }
 
         val syncPanel = JPanel().apply {
@@ -119,6 +127,7 @@ class McpSettingsConfigurable : Configurable {
             .addComponentToRightColumn(hostWarningLabel!!)
             .addLabeledComponent(JBLabel(McpBundle.message("settings.serverPort") + ":"), serverPortSpinner!!, 1, false)
             .addLabeledComponent(JBLabel(McpBundle.message("settings.maxHistorySize") + ":"), maxHistorySizeSpinner!!, 1, false)
+            .addComponent(availableProjectsPanel, 1)
             .addComponent(syncPanel, 1)
             .addSeparator(10)
             .addComponent(JBLabel(McpBundle.message("settings.tools.title")), 5)
@@ -163,6 +172,7 @@ class McpSettingsConfigurable : Configurable {
         if (serverHostField?.text?.trim() != settings.serverHost ||
             serverPortSpinner?.value != settings.serverPort ||
             maxHistorySizeSpinner?.value != settings.maxHistorySize ||
+            availableProjectsTopLevelOnlyCheckBox?.isSelected != settings.availableProjectsTopLevelOnly ||
             syncExternalChangesCheckBox?.isSelected != settings.syncExternalChanges) {
             return true
         }
@@ -216,6 +226,7 @@ class McpSettingsConfigurable : Configurable {
         settings.serverHost = newHost
         settings.serverPort = newPort
         settings.maxHistorySize = maxHistorySizeSpinner?.value as? Int ?: 100
+        settings.availableProjectsTopLevelOnly = availableProjectsTopLevelOnlyCheckBox?.isSelected ?: false
         settings.syncExternalChanges = syncExternalChangesCheckBox?.isSelected ?: false
 
         val disabledTools = mutableSetOf<String>()
@@ -301,6 +312,7 @@ class McpSettingsConfigurable : Configurable {
         serverHostField?.text = settings.serverHost
         serverPortSpinner?.value = settings.serverPort
         maxHistorySizeSpinner?.value = settings.maxHistorySize
+        availableProjectsTopLevelOnlyCheckBox?.isSelected = settings.availableProjectsTopLevelOnly
         syncExternalChangesCheckBox?.isSelected = settings.syncExternalChanges
         
         hostValidationErrorLabel?.isVisible = false
@@ -396,6 +408,7 @@ class McpSettingsConfigurable : Configurable {
         hostValidIcon = null
         serverPortSpinner = null
         maxHistorySizeSpinner = null
+        availableProjectsTopLevelOnlyCheckBox = null
         syncExternalChangesCheckBox = null
         toolCheckBoxes.clear()
         uiDisposable?.let { Disposer.dispose(it) }

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -73,6 +73,9 @@ Default: 29277<br>\
 Valid range: 1024-65535<br><br>\
 Changes take effect immediately (server auto-restarts).</html>
 settings.maxHistorySize=Max History Size
+settings.availableProjectsTopLevelOnly=Only return top-level open projects in errors
+settings.availableProjectsTopLevelOnly.tooltip=<html>When enabled, `available_projects` in `project_not_found` and `multiple_projects` errors only includes top-level open projects.<br><br>\
+When disabled, workspace module content roots are also included (larger payload).</html>
 settings.syncExternalChanges=Sync external file changes before operations
 settings.syncExternalChanges.warning=WARNING: This option significantly slows down every operation. Only enable if absolutely necessary.
 settings.syncExternalChanges.tooltip=<html><b style="color:red;">WARNING: SIGNIFICANT PERFORMANCE IMPACT</b><br><br>\

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolverUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolverUnitTest.kt
@@ -1,6 +1,8 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 
 import junit.framework.TestCase
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 class ProjectResolverUnitTest : TestCase() {
 
@@ -20,5 +22,32 @@ class ProjectResolverUnitTest : TestCase() {
 
     fun testNormalizePathHandlesMixedSeparators() {
         assertEquals("C:/Users/project/src", ProjectResolver.normalizePath("C:\\Users/project\\src/"))
+    }
+
+    fun testBuildAvailableProjectsJsonIncludesWorkspaceSubProjectsWhenEnabled() {
+        val entries = listOf(
+            AvailableProjectEntry(name = "workspace-root", path = "/repo"),
+            AvailableProjectEntry(name = "module-a", path = "/repo/module-a", workspace = "workspace-root")
+        )
+
+        val result = buildAvailableProjectsJson(entries, includeWorkspaceSubProjects = true)
+
+        assertEquals(2, result.size)
+        assertNull(result[0].jsonObject["workspace"])
+        assertEquals("workspace-root", result[1].jsonObject["workspace"]?.jsonPrimitive?.content)
+    }
+
+    fun testBuildAvailableProjectsJsonExcludesWorkspaceSubProjectsWhenDisabled() {
+        val entries = listOf(
+            AvailableProjectEntry(name = "workspace-root", path = "/repo"),
+            AvailableProjectEntry(name = "module-a", path = "/repo/module-a", workspace = "workspace-root")
+        )
+
+        val result = buildAvailableProjectsJson(entries, includeWorkspaceSubProjects = false)
+
+        assertEquals(1, result.size)
+        val topLevelOnly = result.first().jsonObject
+        assertEquals("workspace-root", topLevelOnly["name"]?.jsonPrimitive?.content)
+        assertNull(topLevelOnly["workspace"])
     }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
@@ -10,6 +10,7 @@ class McpSettingsUnitTest : TestCase() {
         val state = McpSettings.State()
 
         assertEquals("Default maxHistorySize should be 100", 100, state.maxHistorySize)
+        assertFalse("Default availableProjectsTopLevelOnly should be false", state.availableProjectsTopLevelOnly)
         assertFalse("Default syncExternalChanges should be false", state.syncExternalChanges)
         assertEquals("Default serverHost should be 127.0.0.1", "127.0.0.1", state.serverHost)
     }
@@ -37,15 +38,24 @@ class McpSettingsUnitTest : TestCase() {
         assertTrue(state.syncExternalChanges)
     }
 
+    fun testStateAvailableProjectsTopLevelOnlyMutable() {
+        val state = McpSettings.State()
+        state.availableProjectsTopLevelOnly = true
+
+        assertTrue(state.availableProjectsTopLevelOnly)
+    }
+
     // State custom constructor tests
 
     fun testStateCustomConstructor() {
         val state = McpSettings.State(
             maxHistorySize = 500,
+            availableProjectsTopLevelOnly = true,
             syncExternalChanges = true
         )
 
         assertEquals(500, state.maxHistorySize)
+        assertTrue(state.availableProjectsTopLevelOnly)
         assertTrue(state.syncExternalChanges)
     }
 
@@ -57,6 +67,7 @@ class McpSettingsUnitTest : TestCase() {
 
         assertEquals(50, original.maxHistorySize)
         assertEquals(150, copy.maxHistorySize)
+        assertEquals(original.availableProjectsTopLevelOnly, copy.availableProjectsTopLevelOnly)
         assertEquals(original.syncExternalChanges, copy.syncExternalChanges)
     }
 
@@ -97,9 +108,11 @@ class McpSettingsUnitTest : TestCase() {
         val settings = McpSettings()
 
         settings.maxHistorySize = 250
+        settings.availableProjectsTopLevelOnly = true
         settings.syncExternalChanges = true
 
         assertEquals(250, settings.maxHistorySize)
+        assertTrue(settings.availableProjectsTopLevelOnly)
         assertTrue(settings.syncExternalChanges)
     }
 
@@ -107,12 +120,14 @@ class McpSettingsUnitTest : TestCase() {
         val settings = McpSettings()
         val newState = McpSettings.State(
             maxHistorySize = 75,
+            availableProjectsTopLevelOnly = true,
             syncExternalChanges = true
         )
 
         settings.loadState(newState)
 
         assertEquals(75, settings.maxHistorySize)
+        assertTrue(settings.availableProjectsTopLevelOnly)
         assertTrue(settings.syncExternalChanges)
     }
 


### PR DESCRIPTION
  ## Summary

  This PR adds a new setting to reduce oversized `available_projects`
  payloads in multi-module workspaces.

  When enabled, `available_projects` in `project_not_found` and
  `multiple_projects` errors returns only top-level open projects
  (workspace roots), instead of including module content roots.

  ## Changes

  - Added new setting: `availableProjectsTopLevelOnly` (default: `false`)
  - Added settings UI checkbox + tooltip
  - Updated `ProjectResolver` to honor the setting when building
  `available_projects`
  - Refactored payload-building logic into testable helpers
  - Added unit tests for both modes:
    - include workspace sub-projects
    - top-level only
  - Updated `CHANGELOG.md` (`[Unreleased]`)
  - Bumped plugin version to `4.11.0` per PR checklist

  ## Why

  In large multi-module projects, error responses can include very large
  `available_projects` payloads, which may increase context usage and
  trigger truncation in MCP clients. This provides a configurable way to
  keep responses compact.

  ## Verification

  - Ran unit tests:
    - `./gradlew test --tests "*UnitTest*"`
  - Result: passed

  ## Related

  - Addresses: #128