### PR TITLE
fix(tools): normalize blank MCP arguments

### DIFF
--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
@@ -48,6 +48,7 @@ object ParamNames {
     const val LIMIT = "limit"
     const val CONTEXT = "context"
     const val CASE_SENSITIVE = "caseSensitive"
+    const val CURSOR = "cursor"
 
     // Preview parameters
     const val FULL_ELEMENT_PREVIEW = "fullElementPreview"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -4,6 +4,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.toArgumentFailure
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.exceptions.IndexNotReadyException
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
@@ -42,10 +43,16 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 /**
  * Abstract base class for MCP tools providing common functionality.
@@ -434,6 +441,77 @@ abstract class AbstractMcpTool : McpTool {
         return psiFile.findElementAt(offset)
     }
 
+    protected enum class LookupModeState {
+        MISSING,
+        POSITION,
+        SYMBOL,
+        CONFLICT
+    }
+
+    /**
+     * Returns a normalized optional string argument.
+     * Missing/null/blank/whitespace-only values are treated as absent (null).
+     */
+    protected fun optionalStringArg(arguments: JsonObject, name: String): String? {
+        val raw = arguments[name] ?: return null
+        if (raw == JsonNull) return null
+        return raw.jsonPrimitive.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Returns a required non-blank string argument.
+     * Missing/null/blank values fail with a missing-required-parameter error.
+     */
+    @JvmName("requiredStringArg")
+    protected fun requiredStringArg(arguments: JsonObject, name: String): Result<String> {
+        val value = optionalStringArg(arguments, name)
+            ?: return ErrorMessages.missingRequiredParam(name).toArgumentFailure()
+        return Result.success(value)
+    }
+
+    /**
+     * Resolves whether arguments represent position lookup, symbol lookup, conflict, or missing mode.
+     * Blank string fields do not count as present.
+     */
+    protected fun resolveLookupMode(arguments: JsonObject): LookupModeState {
+        val hasSymbol = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
+            optionalStringArg(arguments, ParamNames.SYMBOL) != null
+        val hasPosition = optionalStringArg(arguments, ParamNames.FILE) != null ||
+            arguments[ParamNames.LINE]?.jsonPrimitive?.int != null ||
+            arguments[ParamNames.COLUMN]?.jsonPrimitive?.int != null
+
+        return when {
+            hasSymbol && hasPosition -> LookupModeState.CONFLICT
+            hasSymbol -> LookupModeState.SYMBOL
+            hasPosition -> LookupModeState.POSITION
+            else -> LookupModeState.MISSING
+        }
+    }
+
+    /**
+     * Extracts the raw scope value from arguments for error reporting.
+     * Returns empty string if scope is missing/null, the string content if primitive, or toString() for complex types.
+     */
+    protected fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
+        null -> ""
+        is JsonPrimitive -> scopeElement.content
+        else -> scopeElement.toString()
+    }
+
+    /**
+     * Creates a structured invalid-scope error response.
+     * Includes the provided value and list of supported scope values.
+     */
+    protected fun createInvalidScopeError(provided: String): ToolCallResult =
+        createStructuredErrorResult(buildJsonObject {
+            put("error", JsonPrimitive("invalid_scope"))
+            put("parameter", JsonPrimitive(ParamNames.SCOPE))
+            put("provided", JsonPrimitive(provided))
+            put("supportedValues", buildJsonArray {
+                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
+            })
+        })
+
     /**
      * Resolves a PSI element from arguments using either `language`+`symbol` or `file`+`line`+`column`.
      *
@@ -452,47 +530,44 @@ abstract class AbstractMcpTool : McpTool {
         arguments: JsonObject,
         allowLibraryFilesForPosition: Boolean = false
     ): Result<PsiElement> {
-        val language = arguments[ParamNames.LANGUAGE]?.jsonPrimitive?.content
-        val symbol = arguments[ParamNames.SYMBOL]?.jsonPrimitive?.content
-        val file = arguments[ParamNames.FILE]?.jsonPrimitive?.content
+        val language = optionalStringArg(arguments, ParamNames.LANGUAGE)
+        val symbol = optionalStringArg(arguments, ParamNames.SYMBOL)
+        val file = optionalStringArg(arguments, ParamNames.FILE)
         val line = arguments[ParamNames.LINE]?.jsonPrimitive?.int
         val column = arguments[ParamNames.COLUMN]?.jsonPrimitive?.int
 
-        val hasSymbol = language != null || symbol != null
-        val hasPosition = file != null || line != null || column != null
+        return when (resolveLookupMode(arguments)) {
+            LookupModeState.CONFLICT -> ErrorMessages.SYMBOL_AND_POSITION_EXCLUSIVE.toArgumentFailure()
 
-        if (hasSymbol && hasPosition) {
-            return ErrorMessages.SYMBOL_AND_POSITION_EXCLUSIVE.toArgumentFailure()
-        }
+            LookupModeState.SYMBOL -> {
+                if (language == null) return ErrorMessages.missingParamForSymbol(ParamNames.LANGUAGE).toArgumentFailure()
+                if (symbol == null) return ErrorMessages.missingParamForSymbol(ParamNames.SYMBOL).toArgumentFailure()
 
-        if (hasSymbol) {
-            if (language == null) return ErrorMessages.missingParamForSymbol(ParamNames.LANGUAGE).toArgumentFailure()
-            if (symbol == null) return ErrorMessages.missingParamForSymbol(ParamNames.SYMBOL).toArgumentFailure()
+                val handler = LanguageHandlerRegistry.getSymbolReferenceHandlerByLanguageName(language)
+                    ?: return ErrorMessages.noSymbolReferenceHandler(
+                        language, LanguageHandlerRegistry.getSupportedLanguageNamesForSymbolReference()
+                    ).toArgumentFailure()
 
-            val handler = LanguageHandlerRegistry.getSymbolReferenceHandlerByLanguageName(language)
-                ?: return ErrorMessages.noSymbolReferenceHandler(
-                    language, LanguageHandlerRegistry.getSupportedLanguageNamesForSymbolReference()
-                ).toArgumentFailure()
-
-            return handler.resolveSymbol(project, symbol)
-        }
-
-        if (hasPosition) {
-            if (file == null) return ErrorMessages.missingParamForPosition(ParamNames.FILE, "line or column").toArgumentFailure()
-            if (line == null) return ErrorMessages.missingParamForPosition(ParamNames.LINE, "file or column").toArgumentFailure()
-            if (column == null) return ErrorMessages.missingParamForPosition(ParamNames.COLUMN, "file or line").toArgumentFailure()
-
-            val element = if (allowLibraryFilesForPosition) {
-                findNavigablePsiElement(project, file, line, column)
-            } else {
-                findPsiElement(project, file, line, column)
+                handler.resolveSymbol(project, symbol)
             }
-                ?: return ErrorMessages.noElementAtPosition(file, line, column).toArgumentFailure()
 
-            return Result.success(element)
+            LookupModeState.POSITION -> {
+                if (file == null) return ErrorMessages.missingParamForPosition(ParamNames.FILE, "line or column").toArgumentFailure()
+                if (line == null) return ErrorMessages.missingParamForPosition(ParamNames.LINE, "file or column").toArgumentFailure()
+                if (column == null) return ErrorMessages.missingParamForPosition(ParamNames.COLUMN, "file or line").toArgumentFailure()
+
+                val element = if (allowLibraryFilesForPosition) {
+                    findNavigablePsiElement(project, file, line, column)
+                } else {
+                    findPsiElement(project, file, line, column)
+                }
+                    ?: return ErrorMessages.noElementAtPosition(file, line, column).toArgumentFailure()
+
+                Result.success(element)
+            }
+
+            LookupModeState.MISSING -> ErrorMessages.SYMBOL_OR_POSITION_REQUIRED.toArgumentFailure()
         }
-
-        return ErrorMessages.SYMBOL_OR_POSITION_REQUIRED.toArgumentFailure()
     }
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/OpenFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/OpenFileTool.kt
@@ -34,8 +34,9 @@ class OpenFileTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val filePath = arguments["file"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
+        val filePath = requiredStringArg(arguments, "file").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
 
         val line = arguments["line"]?.jsonPrimitive?.int
         val column = arguments["column"]?.jsonPrimitive?.int

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
@@ -105,7 +105,7 @@ class CallHierarchyTool : AbstractMcpTool() {
 
             val hierarchyData = handler.getCallHierarchy(element, project, direction, depth, scope)
             if (hierarchyData == null) {
-                val isSymbolMode = arguments[ParamNames.LANGUAGE] != null
+                val isSymbolMode = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
                 return@suspendingReadAction createErrorResult(
                     if (isSymbolMode) "No method/function found for the specified symbol"
                     else "No method/function found at position"
@@ -119,22 +119,6 @@ class CallHierarchyTool : AbstractMcpTool() {
             ))
         }
     }
-
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
-
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 
     /**
      * Converts handler CallElementData to tool CallElement.

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
@@ -42,8 +42,9 @@ class FileStructureTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val file = arguments["file"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
+        val file = requiredStringArg(arguments, "file").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
 
         return suspendingReadAction {
             val psiFile = getPsiFile(project, file)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
@@ -86,7 +86,7 @@ class FindClassTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val cursor = arguments["cursor"]?.jsonPrimitive?.content
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
         if (cursor != null) {
             val pageSize = resolveExplicitPageSize(arguments, aliases = arrayOf("limit"))
             return buildPaginatedResult<SymbolMatch, FindClassResult>(getPageFromCache(cursor, pageSize, project)) { items, page ->
@@ -322,21 +322,7 @@ class FindClassTool : AbstractMcpTool() {
         return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
     }
 
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
 
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 
     private fun convertToSymbolMatch(item: NavigationItem, project: Project, scope: GlobalSearchScope): SymbolMatch? {
         val element = extractPsiElement(item) ?: return null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
@@ -76,7 +76,7 @@ class FindFileTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val cursor = arguments["cursor"]?.jsonPrimitive?.content
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
         if (cursor != null) {
             val pageSize = resolveExplicitPageSize(arguments, aliases = arrayOf("limit"))
             return buildPaginatedResult<FileMatch, FindFileResult>(getPageFromCache(cursor, pageSize, project)) { items, page ->
@@ -299,21 +299,7 @@ class FindFileTool : AbstractMcpTool() {
         return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
     }
 
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
 
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 
     private fun convertToFileMatch(item: NavigationItem, project: Project, scope: GlobalSearchScope): FileMatch? {
         val virtualFile = extractVirtualFile(item) ?: return null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
@@ -71,7 +71,7 @@ class FindImplementationsTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val cursor = arguments["cursor"]?.jsonPrimitive?.content
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
         if (cursor != null) {
             val pageSize = resolveExplicitPageSize(arguments)
             return buildPaginatedResult<ImplementationLocation, ImplementationResult>(getPageFromCache(cursor, pageSize, project)) { items, page ->
@@ -114,7 +114,7 @@ class FindImplementationsTool : AbstractMcpTool() {
 
             val implementations = handler.findImplementations(element, project, scope)
             if (implementations == null) {
-                val isSymbolMode = arguments[ParamNames.LANGUAGE] != null
+                val isSymbolMode = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
                 return@suspendingReadAction null to createErrorResult(
                     if (isSymbolMode) "No method or class found for the specified symbol"
                     else "No method or class found at position"
@@ -169,19 +169,5 @@ class FindImplementationsTool : AbstractMcpTool() {
         }
     }
 
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
 
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
@@ -67,7 +67,7 @@ class FindSuperMethodsTool : AbstractMcpTool() {
 
             val superMethodsData = handler.findSuperMethods(element, project)
             if (superMethodsData == null) {
-                val isSymbolMode = arguments[ParamNames.LANGUAGE] != null
+                val isSymbolMode = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
                 return@suspendingReadAction createErrorResult(
                     if (isSymbolMode) "No method found for the specified symbol. Ensure the symbol refers to a method declaration."
                     else "No method found at position. Ensure the position is within a method declaration or body."

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
@@ -66,7 +66,7 @@ class FindSymbolTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val cursor = arguments["cursor"]?.jsonPrimitive?.content
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
         if (cursor != null) {
             val pageSize = resolveExplicitPageSize(arguments, aliases = arrayOf("limit"))
             return buildPaginatedResult<SymbolMatch, FindSymbolResult>(getPageFromCache(cursor, pageSize, project)) { items, page ->
@@ -206,19 +206,5 @@ class FindSymbolTool : AbstractMcpTool() {
 
     private fun SymbolMatch.paginationKey(): String = "$file:$line:$column:$name"
 
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
 
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -83,7 +83,7 @@ class FindUsagesTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val cursor = arguments["cursor"]?.jsonPrimitive?.content
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
         if (cursor != null) {
             val pageSize = resolveExplicitPageSize(arguments, aliases = arrayOf("maxResults"))
             return buildPaginatedResult<UsageLocation, FindUsagesResult>(getPageFromCache(cursor, pageSize, project)) { items, page ->
@@ -300,19 +300,5 @@ class FindUsagesTool : AbstractMcpTool() {
             }
     }
 
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
 
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
@@ -72,7 +72,7 @@ class SearchTextTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val cursor = arguments["cursor"]?.jsonPrimitive?.content
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
         if (cursor != null) {
             val pageSize = resolveExplicitPageSize(arguments, aliases = arrayOf("limit"))
             return buildPaginatedResult<TextMatch, SearchTextResult>(getPageFromCache(cursor, pageSize, project)) { items, page ->

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
@@ -107,21 +107,7 @@ class TypeHierarchyTool : AbstractMcpTool() {
         }
     }
 
-    private fun rawScopeValue(scopeElement: JsonElement?): String = when (scopeElement) {
-        null -> ""
-        is JsonPrimitive -> scopeElement.content
-        else -> scopeElement.toString()
-    }
 
-    private fun createInvalidScopeError(provided: String): ToolCallResult =
-        createStructuredErrorResult(buildJsonObject {
-            put("error", JsonPrimitive("invalid_scope"))
-            put("parameter", JsonPrimitive(ParamNames.SCOPE))
-            put("provided", JsonPrimitive(provided))
-            put("supportedValues", buildJsonArray {
-                BuiltInSearchScope.supportedWireValues().forEach { add(JsonPrimitive(it)) }
-            })
-        })
 
     private fun resolveTargetElement(project: Project, arguments: JsonObject): PsiElement? {
         // Try className first (Java/Kotlin specific)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -100,10 +100,12 @@ open class MoveFileTool : AbstractRefactoringTool() {
     )
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val file = arguments["file"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
-        val destination = arguments["destination"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: destination")
+        val file = requiredStringArg(arguments, "file").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
+        val destination = requiredStringArg(arguments, "destination").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: destination")
+        }
 
         requireSmartMode(project)
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -47,8 +47,9 @@ class OptimizeImportsTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val file = arguments[ParamNames.FILE]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
+        val file = requiredStringArg(arguments, ParamNames.FILE).getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
 
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Resolve file (suspending read action)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -76,8 +76,9 @@ class ReformatCodeTool : AbstractMcpTool() {
     )
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val file = arguments[ParamNames.FILE]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
+        val file = requiredStringArg(arguments, ParamNames.FILE).getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
         val startLine = arguments[ParamNames.START_LINE]?.jsonPrimitive?.int
         val endLine = arguments[ParamNames.END_LINE]?.jsonPrimitive?.int
         val optimizeImports = arguments[ParamNames.OPTIMIZE_IMPORTS]?.jsonPrimitive?.boolean ?: true

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -108,8 +108,9 @@ class RenameSymbolTool : AbstractMcpTool() {
     )
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val file = arguments["file"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
+        val file = requiredStringArg(arguments, "file").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
         val line = arguments["line"]?.jsonPrimitive?.int
         val column = arguments["column"]?.jsonPrimitive?.int
         val newName = arguments["newName"]?.jsonPrimitive?.content

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -125,8 +125,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     }
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
-        val file = arguments["file"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
+        val file = requiredStringArg(arguments, "file").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: file")
+        }
         val targetType = arguments["target_type"]?.jsonPrimitive?.content ?: "symbol"
         val force = arguments["force"]?.jsonPrimitive?.content?.toBoolean() ?: false
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/PaginationServiceUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/PaginationServiceUnitTest.kt
@@ -40,6 +40,23 @@ class PaginationServiceUnitTest : TestCase() {
         assertNull(service.decodeCursor("YWJj"))  // base64 of "abc" - no colon separator
     }
 
+    /**
+     * Contract: PaginationService maintains strict decode behavior for non-empty malformed cursors.
+     * Blank-cursor bypass (treating "" and whitespace as fresh-search signals) is a tool-layer
+     * concern, handled by paginated tools (FindUsagesTool, FindClassTool, etc.) via argument
+     * normalization helpers in AbstractMcpTool. This separation ensures:
+     * - PaginationService remains a pure cursor codec with no knowledge of tool semantics
+     * - Tools control when blank cursors trigger fresh searches vs. cursor-path validation
+     * - Malformed non-empty cursors always fail decode, preventing accidental fallthrough
+     */
+    fun testMalformedNonEmptyCursorFailsDecodeStrictly() {
+        val service = createTestService()
+        // Non-empty malformed cursors must fail decode — tools cannot accidentally bypass validation
+        assertNull(service.decodeCursor("invalid-token-format"))
+        assertNull(service.decodeCursor("not-base64!!"))
+        assertNull(service.decodeCursor("YWJj"))  // base64 of "abc" - no colon separator
+    }
+
     fun testDecodeCursorWithZeroOffset() {
         val service = createTestService()
         val token = service.encodeCursor("id", 0)
@@ -136,6 +153,20 @@ class PaginationServiceUnitTest : TestCase() {
     fun testGetPageMalformedToken() = runBlocking {
         val service = createTestService()
         val result = service.getPage("garbage", 10, "/project", 42L)
+        assertTrue(result is PaginationService.GetPageResult.Error)
+        assertEquals(PaginationService.CursorError.MALFORMED, (result as PaginationService.GetPageResult.Error).reason)
+    }
+
+    /**
+     * Contract: PaginationService.getPage() rejects malformed non-empty cursors with MALFORMED error.
+     * Blank cursors ("", whitespace) are NOT normalized here — that is a tool-layer responsibility.
+     * Tools must normalize blank cursors to null before calling getPage(), triggering fresh-search logic.
+     * This ensures PaginationService remains a pure cursor codec without tool-specific semantics.
+     */
+    fun testGetPageRejectsNonEmptyMalformedCursorStrictly() = runBlocking {
+        val service = createTestService()
+        // Non-empty malformed cursors fail decode — tools cannot accidentally bypass validation
+        val result = service.getPage("not-a-valid-cursor-token", 10, "/project", 42L)
         assertTrue(result is PaginationService.GetPageResult.Error)
         assertEquals(PaginationService.CursorError.MALFORMED, (result as PaginationService.GetPageResult.Error).reason)
     }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/NavigationFiltersIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/NavigationFiltersIntegrationTest.kt
@@ -881,10 +881,7 @@ class NavigationFiltersIntegrationTest : BasePlatformTestCase() {
         val exitCode = if (compiler != null) {
             compiler.run(null, null, null, *args.toTypedArray())
         } else {
-            val javaHome = System.getenv("JAVA_HOME")
-            assertNotNull("Tests require a JDK with javac available", javaHome)
-
-            val javac = Path.of(javaHome!!, "bin", "javac").toString()
+            val javac = resolveJavacCommand()
             val process = ProcessBuilder(listOf(javac) + args)
                 .redirectErrorStream(true)
                 .start()
@@ -897,6 +894,25 @@ class NavigationFiltersIntegrationTest : BasePlatformTestCase() {
         }
 
         assertEquals("Library sources should compile successfully", 0, exitCode)
+    }
+
+    private fun resolveJavacCommand(): String {
+        val javaHome = System.getenv("JAVA_HOME")
+        val runtimeHome = System.getProperty("java.home")
+
+        val candidates = buildList {
+            if (!javaHome.isNullOrBlank()) add(Path.of(javaHome, "bin", "javac"))
+            if (!runtimeHome.isNullOrBlank()) {
+                val runtimePath = Path.of(runtimeHome)
+                add(runtimePath.resolve("bin").resolve("javac"))
+                runtimePath.parent?.let { add(it.resolve("bin").resolve("javac")) }
+            }
+        }
+
+        return candidates
+            .firstOrNull { Files.isRegularFile(it) }
+            ?.toString()
+            ?: "javac"
     }
 
     private fun findPosition(text: String, needle: String): Pair<Int, Int> {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
@@ -561,10 +561,7 @@ class ToolExecutionIntegrationTest : BasePlatformTestCase() {
                 sourceFile.toString()
             )
         } else {
-            val javaHome = System.getenv("JAVA_HOME")
-            assertNotNull("Tests require a JDK with javac available", javaHome)
-
-            val javac = Path.of(javaHome!!, "bin", "javac").toString()
+            val javac = resolveJavacCommand()
             val process = ProcessBuilder(
                 javac,
                 "-d",
@@ -579,6 +576,25 @@ class ToolExecutionIntegrationTest : BasePlatformTestCase() {
             0
         }
         assertEquals("Library source should compile successfully", 0, exitCode)
+    }
+
+    private fun resolveJavacCommand(): String {
+        val javaHome = System.getenv("JAVA_HOME")
+        val runtimeHome = System.getProperty("java.home")
+
+        val candidates = buildList {
+            if (!javaHome.isNullOrBlank()) add(Path.of(javaHome, "bin", "javac"))
+            if (!runtimeHome.isNullOrBlank()) {
+                val runtimePath = Path.of(runtimeHome)
+                add(runtimePath.resolve("bin").resolve("javac"))
+                runtimePath.parent?.let { add(it.resolve("bin").resolve("javac")) }
+            }
+        }
+
+        return candidates
+            .firstOrNull { Files.isRegularFile(it) }
+            ?.toString()
+            ?: "javac"
     }
 
     private fun findPosition(text: String, needle: String): Pair<Int, Int> {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpToolArgumentNormalizationUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpToolArgumentNormalizationUnitTest.kt
@@ -1,0 +1,127 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.intellij.openapi.project.Project
+import junit.framework.TestCase
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class AbstractMcpToolArgumentNormalizationUnitTest : TestCase() {
+
+    private val tool = ProbeTool()
+    private val project = Proxy.newProxyInstance(
+        Project::class.java.classLoader,
+        arrayOf(Project::class.java)
+    ) { _, _, _ -> null } as Project
+
+    fun testOptionalBlankToNullNormalization() {
+        val arguments = buildJsonObject { put("cursor", JsonPrimitive("   ")) }
+
+        val normalized = invokeOptionalStringArg(arguments, "cursor")
+
+        assertNull("Blank optional value should normalize to null", normalized)
+    }
+
+    fun testOptionalNonEmptyValueIsPreservedTrimmed() {
+        val arguments = buildJsonObject { put("cursor", JsonPrimitive("  page-2  ")) }
+
+        val normalized = invokeOptionalStringArg(arguments, "cursor")
+
+        assertEquals("page-2", normalized)
+    }
+
+    fun testOptionalNullNormalization() {
+        val arguments = buildJsonObject { put("cursor", JsonNull) }
+
+        val normalized = invokeOptionalStringArg(arguments, "cursor")
+
+        assertNull("Null optional value should normalize to null", normalized)
+    }
+
+    fun testRequiredBlankRejected() {
+        val arguments = buildJsonObject { put("file", JsonPrimitive("   ")) }
+
+        val requiredResult = invokeRequiredStringArg(arguments, "file")
+
+        assertTrue("Required blank value should be rejected", requiredResult.isFailure)
+        val message = requiredResult.exceptionOrNull()?.message
+        assertEquals(ErrorMessages.missingRequiredParam("file"), message)
+    }
+
+    fun testLookupInferenceIgnoresBlankFileLanguageAndSymbol() {
+        val arguments = buildJsonObject {
+            put("file", JsonPrimitive("   "))
+            put("language", JsonPrimitive("  "))
+            put("symbol", JsonPrimitive("\t"))
+        }
+
+        val result = tool.resolveElementForTest(project, arguments)
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            ErrorMessages.SYMBOL_OR_POSITION_REQUIRED,
+            result.exceptionOrNull()?.message
+        )
+    }
+
+    fun testMixedNonEmptyLookupModesRemainMutuallyExclusive() {
+        val arguments = buildJsonObject {
+            put("file", JsonPrimitive("src/Main.kt"))
+            put("line", JsonPrimitive(12))
+            put("column", JsonPrimitive(5))
+            put("language", JsonPrimitive("kotlin"))
+            put("symbol", JsonPrimitive("com.example.Main#run()"))
+        }
+
+        val result = tool.resolveElementForTest(project, arguments)
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            ErrorMessages.SYMBOL_AND_POSITION_EXCLUSIVE,
+            result.exceptionOrNull()?.message
+        )
+    }
+
+    private fun invokeOptionalStringArg(arguments: JsonObject, name: String): String? {
+        val method = findMethod("optionalStringArg")
+        return method.invoke(tool, arguments, name) as String?
+    }
+
+    private fun invokeRequiredStringArg(arguments: JsonObject, name: String): Result<*> {
+        return tool.requiredStringForTest(arguments, name)
+    }
+
+    private fun findMethod(name: String): Method {
+        return try {
+            AbstractMcpTool::class.java.getDeclaredMethod(name, JsonObject::class.java, String::class.java).apply {
+                isAccessible = true
+            }
+        } catch (noSuchMethod: NoSuchMethodException) {
+            fail("Expected AbstractMcpTool.$name(JsonObject, String) to exist for argument normalization contract")
+            throw noSuchMethod
+        }
+    }
+
+    private class ProbeTool : AbstractMcpTool() {
+        override val name: String = "probe"
+        override val description: String = "probe"
+        override val inputSchema: JsonObject = buildJsonObject {}
+
+        override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+            error("Not used in unit tests")
+        }
+
+        fun resolveElementForTest(project: Project, arguments: JsonObject): Result<com.intellij.psi.PsiElement> {
+            return resolveElementFromArguments(project, arguments)
+        }
+
+        fun requiredStringForTest(arguments: JsonObject, name: String): Result<String> {
+            return requiredStringArg(arguments, name)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesToolUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesToolUnitTest.kt
@@ -1,6 +1,11 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
 
 import junit.framework.TestCase
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 class FindUsagesToolUnitTest : TestCase() {
 
@@ -12,5 +17,41 @@ class FindUsagesToolUnitTest : TestCase() {
         assertTrue("Should mention search infrastructure failure", message.contains("Reference search failed due to IDE/plugin API incompatibility"))
         assertTrue("Should include original error type", message.contains("NoSuchMethodError"))
         assertTrue("Should suggest ide_search_text fallback", message.contains("ide_search_text"))
+    }
+
+    fun testBlankCursorShouldUseFreshSearchPath() {
+        val arguments = buildJsonObject { put("cursor", JsonPrimitive("")) }
+
+        val isCursorPath = usesCursorPaginationPath(arguments)
+
+        assertFalse("Blank cursor should be treated as fresh search", isCursorPath)
+    }
+
+    fun testWhitespaceCursorShouldUseFreshSearchPath() {
+        val arguments = buildJsonObject { put("cursor", JsonPrimitive("   \t  ")) }
+
+        val isCursorPath = usesCursorPaginationPath(arguments)
+
+        assertFalse("Whitespace cursor should be treated as fresh search", isCursorPath)
+    }
+
+    fun testMalformedNonEmptyCursorShouldUseCursorPathAndFailValidationLater() {
+        val arguments = buildJsonObject { put("cursor", JsonPrimitive("not-a-valid-cursor")) }
+
+        val isCursorPath = usesCursorPaginationPath(arguments)
+
+        assertTrue("Non-empty malformed cursor must stay on cursor path for invalid-cursor handling", isCursorPath)
+    }
+
+    /**
+     * Mirrors FindUsagesTool cursor-routing gate after normalization:
+     * `val cursor = optionalStringArg(arguments, ParamNames.CURSOR); if (cursor != null) ...`
+     *
+     * Blank/whitespace cursors are normalized to null and use fresh-search path.
+     * Non-empty malformed cursors stay non-null and use cursor path for validation.
+     */
+    private fun usesCursorPaginationPath(arguments: JsonObject): Boolean {
+        val cursor = arguments["cursor"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+        return cursor != null
     }
 }


### PR DESCRIPTION
## Changelog

### 🐛 Bug Fixes

- **Normalize blank MCP arguments**: Fixed issue where blank, null, or whitespace-only string arguments were not properly normalized. Tools now correctly treat missing or blank values as absent, preventing unexpected behavior when clients send empty strings (`"cursor": ""`). This improves robustness across navigation and refactoring tools.

### 🧪 Testing

- **Improve test reliability**: Enhanced integration tests to properly resolve `javac` from the runtime home directory, ensuring tests run correctly across different Java installations and CI environments.