### PR TITLE
Add PHP symbol reference handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 ### Added
 - **PHP symbol reference handler** — PHP now supports `language`+`symbol` parameter mode for `ide_find_references`, `ide_find_definition`, `ide_call_hierarchy`, `ide_find_implementations`, and `ide_find_super_methods`. Accepts symbol formats with PHP namespaces (e.g., `\\App\\Service\\UserService`, `\\App\\Service\\UserService::find()`, `\\App\\Service\\UserService::\$property`). Fixes [#179](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/179).
+- **PHP symbol reference member lookup** — Inherited and case-insensitive PHP methods resolve through PhpStorm's `findMethodByName(CharSequence)` API, field/constant lookup uses the matching `findFieldByName(CharSequence, boolean)` signature, and plain `Class::name` symbols do not fall back to properties without the documented `$property` syntax.
 
 ## [4.17.2] - 2026-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ## [Unreleased]
 ### Added
-- **PHP symbol reference handler** — PHP now supports `language`+`symbol` parameter mode for `ide_find_references`, `ide_find_definition`, `ide_call_hierarchy`, `ide_find_implementations`, and `ide_find_super_methods`. Accepts symbol formats with PHP namespaces (e.g., `\\App\\Service\\UserService`, `\\App\\Service\\UserService::find()`, `\\App\\Service\\UserService::\$property`). Fixes [#179](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/179).
+- **PHP symbol reference handler** — PHP now supports `language`+`symbol` parameter mode for `ide_find_references`, `ide_find_definition`, `ide_call_hierarchy`, `ide_find_implementations`, and `ide_find_super_methods`. Accepts symbol formats with PHP namespaces (e.g., `\\App\\Service\\UserService`, `\\App\\Service\\UserService::find()`, `\\App\\Service\\UserService::$property`). Fixes [#179](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/179).
 - **PHP symbol reference member lookup** — Inherited and case-insensitive PHP methods resolve through PhpStorm's `findMethodByName(CharSequence)` API, field/constant lookup uses the matching `findFieldByName(CharSequence, boolean)` signature, and plain `Class::name` symbols do not fall back to properties without the documented `$property` syntax.
+- **PHP enum case resolution** — `EnumType::CASE` now resolves to enum case PSI elements via PhpStorm's `getEnumCases()` API. Enum case lookup runs before class constant lookup so `::CASE` correctly targets enum cases on enum types. `::CASE()` still resolves as a method call.
 
 ## [4.17.2] - 2026-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+- **PHP symbol reference handler** — PHP now supports `language`+`symbol` parameter mode for `ide_find_references`, `ide_find_definition`, `ide_call_hierarchy`, `ide_find_implementations`, and `ide_find_super_methods`. Accepts symbol formats with PHP namespaces (e.g., `\\App\\Service\\UserService`, `\\App\\Service\\UserService::find()`, `\\App\\Service\\UserService::\$property`). Fixes [#179](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/179).
 
 ## [4.17.2] - 2026-05-18
 ### Fixed

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/LanguageHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/LanguageHandler.kt
@@ -259,7 +259,7 @@ interface SymbolReferenceHandler : LanguageHandler<PsiNamedElement> {
     /**
      * The language name this handler supports.
      *
-     * Currently implemented for "Java". Future handlers may use "Kotlin", "Python", "JavaScript", etc.
+     * Currently implemented for languages such as "Java" and "PHP". Future handlers may use "Kotlin", "Python", "JavaScript", etc.
      *
      * This is the user-facing language name used in the `language` tool parameter.
      * Should match the [com.intellij.lang.Language.displayName] (case-insensitive matching is used).
@@ -270,7 +270,7 @@ interface SymbolReferenceHandler : LanguageHandler<PsiNamedElement> {
      * Resolves a symbol reference string to a PSI element.
      *
      * @param project The project context
-     * @param symbol The symbol reference string (e.g., `com.example.MyClass#method(String)`)
+     * @param symbol The symbol reference string (e.g., `com.example.MyClass#method(String)` or `\\App\\Service\\UserService::find()`)
      * @return A [Result] containing the resolved element or a failure
      */
     fun resolveSymbol(project: Project, symbol: String): Result<PsiNamedElement>

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
@@ -259,6 +259,17 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
     }
 
     /**
+     * Checks if a PhpClass element is an enum using reflection.
+     */
+    protected fun isEnum(phpClass: PsiElement): Boolean {
+        return try {
+            phpClass.javaClass.getMethod("isEnum").invoke(phpClass) as? Boolean ?: false
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
      * Finds containing PhpClass using reflection.
      */
     protected fun findContainingPhpClass(element: PsiElement): PsiElement? {
@@ -429,14 +440,79 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
         }
     }
 
+    protected data class DeclaredPhpMethod(
+        val method: PsiElement,
+        val declaringClass: PsiElement
+    )
+
     /**
      * Finds a method by name in a PhpClass using reflection.
      * Uses PhpStorm's `findMethodByName(CharSequence)` API so inherited methods
      * and PHP's case-insensitive method names are handled by the PHP plugin.
+     *
+     * This is appropriate for direct symbol resolution (`Child::inheritedMethod()`),
+     * but implementation/super-method traversal should use declared-only helpers.
      */
     protected fun findMethodInClass(phpClass: PsiElement, methodName: String): PsiElement? {
         return findMethodByName(phpClass, methodName)
-            ?: findMethodInClassCollections(phpClass, methodName)
+            ?: findMethodInClassCollections(phpClass, methodName, includeInherited = true)
+    }
+
+    /**
+     * Finds a method declared directly on the given PhpClass/interface.
+     * Does not use PhpClass.findMethodByName() and does not inspect getMethods(),
+     * because both can return inherited methods.
+     */
+    protected fun findOwnMethodInClass(phpClass: PsiElement, methodName: String): PsiElement? {
+        return findMethodInClassCollections(phpClass, methodName, includeInherited = false)
+    }
+
+    /**
+     * Finds the nearest ancestor class that actually declares the requested method.
+     */
+    protected fun findOwnMethodInClassHierarchy(
+        phpClass: PsiElement,
+        methodName: String
+    ): DeclaredPhpMethod? {
+        val visited = mutableSetOf<String>()
+        var currentClass: PsiElement? = phpClass
+
+        while (currentClass != null) {
+            val classKey = getFQN(currentClass) ?: getName(currentClass) ?: currentClass.textOffset.toString()
+            if (!visited.add(classKey)) return null
+
+            val ownMethod = findOwnMethodInClass(currentClass, methodName)
+            if (ownMethod != null) {
+                return DeclaredPhpMethod(ownMethod, currentClass)
+            }
+
+            currentClass = getSuperClass(currentClass)
+        }
+
+        return null
+    }
+
+    /**
+     * Finds the nearest interface in an extends chain that actually declares the method.
+     */
+    protected fun findOwnMethodInInterfaceHierarchy(
+        iface: PsiElement,
+        methodName: String,
+        visited: MutableSet<String> = mutableSetOf()
+    ): DeclaredPhpMethod? {
+        val ifaceKey = getFQN(iface) ?: getName(iface) ?: iface.textOffset.toString()
+        if (!visited.add(ifaceKey)) return null
+
+        val ownMethod = findOwnMethodInClass(iface, methodName)
+        if (ownMethod != null) {
+            return DeclaredPhpMethod(ownMethod, iface)
+        }
+
+        return getImplementedInterfaces(iface)
+            ?.filterIsInstance<PsiElement>()
+            ?.firstNotNullOfOrNull { parentInterface ->
+                findOwnMethodInInterfaceHierarchy(parentInterface, methodName, visited)
+            }
     }
 
     private fun findMethodByName(phpClass: PsiElement, methodName: String): PsiElement? {
@@ -461,8 +537,18 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
         return null
     }
 
-    private fun findMethodInClassCollections(phpClass: PsiElement, methodName: String): PsiElement? {
-        for (collectionMethodName in listOf("getOwnMethods", "getMethods")) {
+    private fun findMethodInClassCollections(
+        phpClass: PsiElement,
+        methodName: String,
+        includeInherited: Boolean
+    ): PsiElement? {
+        val collectionMethodNames = if (includeInherited) {
+            listOf("getOwnMethods", "getMethods")
+        } else {
+            listOf("getOwnMethods")
+        }
+
+        for (collectionMethodName in collectionMethodNames) {
             val method = try {
                 val getMethodsMethod = phpClass.javaClass.getMethod(collectionMethodName)
                 toPsiElements(getMethodsMethod.invoke(phpClass)).find {
@@ -528,6 +614,34 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
     protected fun findConstantInClass(phpClass: PsiElement, constantName: String): PsiElement? {
         return findFieldByName(phpClass, constantName, findConstant = true)
             ?: findFieldInClassCollections(phpClass, constantName, expectedConstant = true)
+    }
+
+    /**
+     * Finds an enum case by name in a PhpClass enum using reflection.
+     * Uses PhpStorm's `getEnumCases()` API to retrieve enum cases.
+     */
+    protected fun findEnumCaseInClass(phpClass: PsiElement, caseName: String): PsiElement? {
+        val collectionMethodNames = listOf("getEnumCases")
+
+        for (methodName in collectionMethodNames) {
+            val result = try {
+                val method = phpClass.javaClass.getMethod(methodName)
+                toPsiElements(method.invoke(phpClass)).firstOrNull {
+                    getName(it) == caseName
+                }
+            } catch (_: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                LOG.debug("Error resolving PHP enum case $caseName using $methodName: ${e.message}")
+                null
+            }
+
+            if (result != null) {
+                return result
+            }
+        }
+
+        return null
     }
 
     private fun findFieldByName(
@@ -1293,8 +1407,9 @@ class PhpImplementationsHandler : BasePhpHandler<List<ImplementationData>>(), Im
                 .filter { shouldIncludeNavigationElement(searchScope, it) }
                 .take(100)
                 .forEach { subclass ->
-                // Find method with same name in this subclass
-                val overridingMethod = findMethodInClass(subclass, methodName)
+                // Find only methods declared directly in this subclass. Inherited methods
+                // are not implementations/overrides of the queried method.
+                val overridingMethod = findOwnMethodInClass(subclass, methodName)
                 if (overridingMethod != null) {
                     val file = overridingMethod.containingFile?.virtualFile
                     if (file != null) {
@@ -1424,31 +1539,35 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
         val containingClass = getContainingClass(method) ?: return
         val methodName = getName(method) ?: return
 
-        // Check superclass
+        // Check superclass. Search the class chain for the nearest class that
+        // actually declares the method instead of collecting an inherited PSI
+        // element under an intermediate class key.
         val superClass = getSuperClass(containingClass)
         if (superClass != null) {
-            val superClassName = getFQN(superClass) ?: getName(superClass)
-            val key = "$superClassName::$methodName"
-            if (key !in visited) {
-                visited.add(key)
-                val superMethod = findMethodInClass(superClass, methodName)
-                if (superMethod != null) {
-                    result.add(superMethod)
-                    findSuperMethodsRecursive(project, superMethod, result, visited)
+            val declaredSuperMethod = findOwnMethodInClassHierarchy(superClass, methodName)
+            if (declaredSuperMethod != null) {
+                val declaringClassName = getFQN(declaredSuperMethod.declaringClass)
+                    ?: getName(declaredSuperMethod.declaringClass)
+                val key = "$declaringClassName::$methodName"
+                if (key !in visited) {
+                    visited.add(key)
+                    result.add(declaredSuperMethod.method)
+                    findSuperMethodsRecursive(project, declaredSuperMethod.method, result, visited)
                 }
             }
         }
 
-        // Check interfaces
+        // Check interfaces. Use the declaring interface as the visited key.
         val interfaces = getImplementedInterfaces(containingClass)
         interfaces?.filterIsInstance<PsiElement>()?.forEach { iface ->
-            val ifaceName = getFQN(iface) ?: getName(iface)
-            val key = "$ifaceName::$methodName"
-            if (key !in visited) {
-                visited.add(key)
-                val ifaceMethod = findMethodInClass(iface, methodName)
-                if (ifaceMethod != null) {
-                    result.add(ifaceMethod)
+            val declaredIfaceMethod = findOwnMethodInInterfaceHierarchy(iface, methodName)
+            if (declaredIfaceMethod != null) {
+                val ifaceName = getFQN(declaredIfaceMethod.declaringClass)
+                    ?: getName(declaredIfaceMethod.declaringClass)
+                val key = "$ifaceName::$methodName"
+                if (key !in visited) {
+                    visited.add(key)
+                    result.add(declaredIfaceMethod.method)
                 }
             }
         }
@@ -1678,27 +1797,30 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
             val containingClass = getContainingClass(method) ?: return emptyList()
             val methodName = getName(method) ?: return emptyList()
 
-            // Check superclass
+            // Check superclass. Skip intermediate classes that only inherit the method,
+            // and report the actual class that declares the super method.
             val superClass = getSuperClass(containingClass)
             if (superClass != null) {
-                val superClassName = getFQN(superClass) ?: getName(superClass)
-                val key = "$superClassName::$methodName"
-                if (key !in visited) {
-                    visited.add(key)
+                val declaredSuperMethod = findOwnMethodInClassHierarchy(superClass, methodName)
+                if (declaredSuperMethod != null) {
+                    val superMethod = declaredSuperMethod.method
+                    val declaringClass = declaredSuperMethod.declaringClass
+                    val declaringClassName = getFQN(declaringClass) ?: getName(declaringClass)
+                    val key = "$declaringClassName::$methodName"
+                    if (key !in visited) {
+                        visited.add(key)
 
-                    val superMethod = findMethodInClass(superClass, methodName)
-                    if (superMethod != null) {
                         val file = superMethod.containingFile?.virtualFile
 
                         hierarchy.add(SuperMethodData(
                             name = methodName,
                             signature = buildMethodSignature(superMethod),
-                            containingClass = superClassName ?: "unknown",
-                            containingClassKind = determineClassKind(superClass),
+                            containingClass = declaringClassName ?: "unknown",
+                            containingClassKind = determineClassKind(declaringClass),
                             file = file?.let { getRelativePath(project, it) },
                             line = getLineNumber(project, superMethod),
                             column = getColumnNumber(project, superMethod),
-                            isInterface = isInterface(superClass),
+                            isInterface = isInterface(declaringClass),
                             depth = depth,
                             language = "PHP"
                         ))
@@ -1708,16 +1830,19 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
                 }
             }
 
-            // Check interfaces
+            // Check interfaces. As with classes, report the interface that actually
+            // declares the method, not an intermediate interface that only inherits it.
             val interfaces = getImplementedInterfaces(containingClass)
             interfaces?.filterIsInstance<PsiElement>()?.forEach { iface ->
-                val ifaceName = getFQN(iface) ?: getName(iface)
-                val key = "$ifaceName::$methodName"
-                if (key !in visited) {
-                    visited.add(key)
+                val declaredIfaceMethod = findOwnMethodInInterfaceHierarchy(iface, methodName)
+                if (declaredIfaceMethod != null) {
+                    val ifaceMethod = declaredIfaceMethod.method
+                    val declaringInterface = declaredIfaceMethod.declaringClass
+                    val ifaceName = getFQN(declaringInterface) ?: getName(declaringInterface)
+                    val key = "$ifaceName::$methodName"
+                    if (key !in visited) {
+                        visited.add(key)
 
-                    val ifaceMethod = findMethodInClass(iface, methodName)
-                    if (ifaceMethod != null) {
                         val file = ifaceMethod.containingFile?.virtualFile
 
                         hierarchy.add(SuperMethodData(
@@ -1792,6 +1917,7 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
  * - `\\App\\Service\\UserService::find()` - Method with parameters (ignored; PHP has no overloading by type)
  * - `\\App\\Service\\UserService::\$name` - Field/property
  * - `\\App\\Service\\UserService::ROLE_ADMIN` - Class constant
+ * - `\\App\\Service\\StatusEnum::ACTIVE` - Enum case
  */
 class PhpSymbolReferenceHandler : BasePhpHandler<PsiNamedElement>(), SymbolReferenceHandler {
 
@@ -1823,7 +1949,8 @@ class PhpSymbolReferenceHandler : BasePhpHandler<PsiNamedElement>(), SymbolRefer
             "'\\App\\Service\\UserService::find'",
             "'\\App\\Service\\UserService::find()'",
             "'\\App\\Service\\UserService::\$property'",
-            "'\\App\\Service\\UserService::ROLE_ADMIN'"
+            "'\\App\\Service\\UserService::ROLE_ADMIN'",
+            "'\\App\\Service\\StatusEnum::ACTIVE'"
         )
     }
 
@@ -1898,9 +2025,19 @@ class PhpSymbolReferenceHandler : BasePhpHandler<PsiNamedElement>(), SymbolRefer
             return method.toPsiNamedElementResult()
         }
 
-        // No parentheses and no $ prefix: could be a constant or a method name.
-        // Properties require the documented `$property` syntax so a missing constant
+        // No parentheses and no $ prefix: could be an enum case, constant, or method.
+        // Properties require the documented `$property` syntax so a plain name
         // does not silently navigate to a same-named property.
+
+        // Try enum case first (only if the type is an enum)
+        if (isEnum(phpClass)) {
+            val enumCase = findEnumCaseInClass(phpClass, memberName)
+            if (enumCase != null) {
+                return enumCase.toPsiNamedElementResult()
+            }
+        }
+
+        // Try constant
         val constant = findConstantInClass(phpClass, memberName)
         if (constant != null) {
             return constant.toPsiNamedElementResult()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
@@ -431,22 +431,56 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
 
     /**
      * Finds a method by name in a PhpClass using reflection.
-     * Uses `findMethodByName()` API, falling back to searching `getOwnMethods()`.
+     * Uses PhpStorm's `findMethodByName(CharSequence)` API so inherited methods
+     * and PHP's case-insensitive method names are handled by the PHP plugin.
      */
     protected fun findMethodInClass(phpClass: PsiElement, methodName: String): PsiElement? {
-        return try {
-            val findMethodByNameMethod = phpClass.javaClass.getMethod("findMethodByName", String::class.java)
-            findMethodByNameMethod.invoke(phpClass, methodName) as? PsiElement
-        } catch (e: Exception) {
-            // Fallback to getOwnMethods and search manually
-            try {
-                val getMethodsMethod = phpClass.javaClass.getMethod("getOwnMethods")
-                val methods = getMethodsMethod.invoke(phpClass) as? Array<*> ?: return null
-                methods.filterIsInstance<PsiElement>().find { getName(it) == methodName }
-            } catch (e2: Exception) {
+        return findMethodByName(phpClass, methodName)
+            ?: findMethodInClassCollections(phpClass, methodName)
+    }
+
+    private fun findMethodByName(phpClass: PsiElement, methodName: String): PsiElement? {
+        val parameterTypes = listOf(CharSequence::class.java, String::class.java)
+
+        for (parameterType in parameterTypes) {
+            val method = try {
+                val findMethodByNameMethod = phpClass.javaClass.getMethod("findMethodByName", parameterType)
+                findMethodByNameMethod.invoke(phpClass, methodName) as? PsiElement
+            } catch (_: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                LOG.debug("Error resolving PHP method $methodName using findMethodByName: ${e.message}")
                 null
             }
+
+            if (method != null) {
+                return method
+            }
         }
+
+        return null
+    }
+
+    private fun findMethodInClassCollections(phpClass: PsiElement, methodName: String): PsiElement? {
+        for (collectionMethodName in listOf("getOwnMethods", "getMethods")) {
+            val method = try {
+                val getMethodsMethod = phpClass.javaClass.getMethod(collectionMethodName)
+                toPsiElements(getMethodsMethod.invoke(phpClass)).find {
+                    getName(it)?.equals(methodName, ignoreCase = true) == true
+                }
+            } catch (_: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                LOG.debug("Error resolving PHP method $methodName using $collectionMethodName: ${e.message}")
+                null
+            }
+
+            if (method != null) {
+                return method
+            }
+        }
+
+        return null
     }
 
     /**
@@ -501,11 +535,17 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
         fieldName: String,
         findConstant: Boolean
     ): PsiElement? {
-        val booleanParameterTypes = listOfNotNull(Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType)
+        val booleanPrimitiveType = Boolean::class.javaPrimitiveType ?: Boolean::class.javaObjectType
+        val signatureCandidates = listOf(
+            arrayOf(CharSequence::class.java, booleanPrimitiveType),
+            arrayOf(CharSequence::class.java, Boolean::class.javaObjectType),
+            arrayOf<Class<*>>(String::class.java, booleanPrimitiveType),
+            arrayOf<Class<*>>(String::class.java, Boolean::class.javaObjectType)
+        )
 
-        for (booleanParameterType in booleanParameterTypes) {
+        for (signature in signatureCandidates) {
             val field = try {
-                val method = phpClass.javaClass.getMethod("findFieldByName", String::class.java, booleanParameterType)
+                val method = phpClass.javaClass.getMethod("findFieldByName", *signature)
                 method.invoke(phpClass, fieldName, findConstant) as? PsiElement
             } catch (_: NoSuchMethodException) {
                 null
@@ -1858,9 +1898,9 @@ class PhpSymbolReferenceHandler : BasePhpHandler<PsiNamedElement>(), SymbolRefer
             return method.toPsiNamedElementResult()
         }
 
-        // No parentheses and no $ prefix: could be constant, method, or field
-        // Resolve order: constant -> method -> field as graceful fallback
-        // Try constant first
+        // No parentheses and no $ prefix: could be a constant or a method name.
+        // Properties require the documented `$property` syntax so a missing constant
+        // does not silently navigate to a same-named property.
         val constant = findConstantInClass(phpClass, memberName)
         if (constant != null) {
             return constant.toPsiNamedElementResult()
@@ -1870,12 +1910,6 @@ class PhpSymbolReferenceHandler : BasePhpHandler<PsiNamedElement>(), SymbolRefer
         val method = findMethodInClass(phpClass, memberName)
         if (method != null) {
             return method.toPsiNamedElementResult()
-        }
-
-        // Try field (some PHP property names don't use $ syntax in getName)
-        val field = findFieldInClass(phpClass, memberName)
-        if (field != null) {
-            return field.toPsiNamedElementResult()
         }
 
         return ErrorMessages.memberNotFoundInType(memberPart, classFqn).toArgumentFailure()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
@@ -1,5 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.php
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.toArgumentFailure
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.*
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureKind
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureNode
@@ -11,6 +13,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
@@ -66,6 +69,7 @@ object PhpHandlers {
             registry.registerCallHierarchyHandler(PhpCallHierarchyHandler())
             registry.registerSuperMethodsHandler(PhpSuperMethodsHandler())
             registry.registerStructureHandler(PhpStructureHandler())
+            registry.registerSymbolReferenceHandler(PhpSymbolReferenceHandler())
 
             LOG.info("Registered PHP handlers")
         } catch (e: ClassNotFoundException) {
@@ -442,6 +446,122 @@ abstract class BasePhpHandler<T> : LanguageHandler<T> {
             } catch (e2: Exception) {
                 null
             }
+        }
+    }
+
+    /**
+     * Finds a PHP class, interface, or trait by its fully qualified name using PhpIndex.
+     */
+    protected fun getClassByFQN(project: Project, fqn: String): PsiElement? {
+        val phpIndex = getPhpIndex(project) ?: return null
+        val lookupMethods = listOf(
+            "getClassesByFQN",
+            "getInterfacesByFQN",
+            "getTraitsByFQN"
+        )
+
+        for (methodName in lookupMethods) {
+            val element = try {
+                val method = phpIndex.javaClass.getMethod(methodName, String::class.java)
+                toPsiElements(method.invoke(phpIndex, fqn)).firstOrNull()
+            } catch (e: NoSuchMethodException) {
+                LOG.debug("PhpIndex.$methodName(String) is not available")
+                null
+            } catch (e: Exception) {
+                LOG.debug("Error resolving PHP type by FQN $fqn using $methodName: ${e.message}")
+                null
+            }
+
+            if (element != null) {
+                return element
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Finds a non-constant field/property by name in a PhpClass using reflection.
+     */
+    protected fun findFieldInClass(phpClass: PsiElement, fieldName: String): PsiElement? {
+        return findFieldByName(phpClass, fieldName, findConstant = false)
+            ?: findFieldInClassCollections(phpClass, fieldName, expectedConstant = false)
+    }
+
+    /**
+     * Finds a class constant by name in a PhpClass using reflection.
+     */
+    protected fun findConstantInClass(phpClass: PsiElement, constantName: String): PsiElement? {
+        return findFieldByName(phpClass, constantName, findConstant = true)
+            ?: findFieldInClassCollections(phpClass, constantName, expectedConstant = true)
+    }
+
+    private fun findFieldByName(
+        phpClass: PsiElement,
+        fieldName: String,
+        findConstant: Boolean
+    ): PsiElement? {
+        val booleanParameterTypes = listOfNotNull(Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType)
+
+        for (booleanParameterType in booleanParameterTypes) {
+            val field = try {
+                val method = phpClass.javaClass.getMethod("findFieldByName", String::class.java, booleanParameterType)
+                method.invoke(phpClass, fieldName, findConstant) as? PsiElement
+            } catch (_: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                LOG.debug("Error resolving PHP field $fieldName using findFieldByName: ${e.message}")
+                null
+            }
+
+            if (field != null && isField(field) && isConstantField(field) == findConstant) {
+                return field
+            }
+        }
+
+        return null
+    }
+
+    private fun findFieldInClassCollections(
+        phpClass: PsiElement,
+        fieldName: String,
+        expectedConstant: Boolean
+    ): PsiElement? {
+        for (methodName in listOf("getOwnFields", "getFields")) {
+            val field = try {
+                val method = phpClass.javaClass.getMethod(methodName)
+                toPsiElements(method.invoke(phpClass)).find {
+                    isField(it) && getName(it) == fieldName && isConstantField(it) == expectedConstant
+                }
+            } catch (_: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                LOG.debug("Error resolving PHP field $fieldName using $methodName: ${e.message}")
+                null
+            }
+
+            if (field != null) {
+                return field
+            }
+        }
+
+        return null
+    }
+
+    private fun isConstantField(field: PsiElement): Boolean {
+        return try {
+            val method = field.javaClass.getMethod("isConstant")
+            method.invoke(field) as? Boolean ?: false
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun toPsiElements(value: Any?): Sequence<PsiElement> {
+        return when (value) {
+            is Array<*> -> value.asSequence().filterIsInstance<PsiElement>()
+            is Iterable<*> -> value.asSequence().filterIsInstance<PsiElement>()
+            else -> emptySequence()
         }
     }
 }
@@ -1616,6 +1736,156 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
             "$methodName($params)"
         } catch (e: Exception) {
             getName(method) ?: "unknown"
+        }
+    }
+}
+
+/**
+ * PHP implementation of [SymbolReferenceHandler].
+ *
+ * Resolves PHP symbol reference strings (e.g., `\\App\\Service\\UserService::find()`) to PSI elements.
+ *
+ * Supported symbol formats:
+ * - `\\App\\Service\\UserService` - Class/interface/trait by fully qualified name
+ * - `App\\Service\\UserService` - Same, without leading backslash (auto-normalized)
+ * - `\\App\\Service\\UserService::find` - Method by name
+ * - `\\App\\Service\\UserService::find()` - Method with parameters (ignored; PHP has no overloading by type)
+ * - `\\App\\Service\\UserService::\$name` - Field/property
+ * - `\\App\\Service\\UserService::ROLE_ADMIN` - Class constant
+ */
+class PhpSymbolReferenceHandler : BasePhpHandler<PsiNamedElement>(), SymbolReferenceHandler {
+
+    companion object {
+        // A valid PHP identifier (simplified: covers the vast majority of code)
+        private const val IDENTIFIER = """[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"""
+
+        // A PHP namespace segment (same as identifier)
+        private const val NAMESPACE_SEGMENT = IDENTIFIER
+
+        // Fully qualified name with optional leading backslash and backslash-separated segments
+        // In the triple-quoted string, \\ = regex \\ (matches one literal \\)
+        private const val FQN = """\\?(?:$NAMESPACE_SEGMENT\\)*$NAMESPACE_SEGMENT"""
+
+        // Property prefixed with $, regex: \$ matches literal $
+        private const val PROPERTY = "\\$" + IDENTIFIER
+
+        // Method call with optional parameters, e.g. methodName(...)
+        private const val METHOD_CALL = """$IDENTIFIER\([^)]*\)"""
+
+        // Member: method call, property, or plain identifier (constant/method name)
+        private const val MEMBER = """(?:$METHOD_CALL|$PROPERTY|$IDENTIFIER)"""
+
+        // Full pattern: FQN with optional ::member
+        internal val PHP_SYMBOL_PATTERN = """^$FQN(::$MEMBER)?$""".toRegex()
+
+        private val SYMBOL_EXAMPLES = listOf(
+            "'\\App\\Service\\UserService'",
+            "'\\App\\Service\\UserService::find'",
+            "'\\App\\Service\\UserService::find()'",
+            "'\\App\\Service\\UserService::\$property'",
+            "'\\App\\Service\\UserService::ROLE_ADMIN'"
+        )
+    }
+
+    override val languageId = "PHP"
+    override val languageName = "PHP"
+
+    override fun canHandle(element: PsiElement): Boolean =
+        isAvailable() && isPhpLanguage(element)
+
+    override fun isAvailable(): Boolean =
+        PluginDetectors.php.isAvailable && phpClassClass != null && phpNamedElementClass != null
+
+    override fun resolveSymbol(project: Project, symbol: String): Result<PsiNamedElement> {
+        val trimmed = symbol.trim()
+
+        if (!PHP_SYMBOL_PATTERN.matches(trimmed)) {
+            return ErrorMessages.invalidSymbolFormat(trimmed, SYMBOL_EXAMPLES).toArgumentFailure()
+        }
+
+        val fullyQualifiedName: String
+        val memberPart: String?
+
+        val memberSeparatorIndex = trimmed.indexOf("::")
+        if (memberSeparatorIndex >= 0) {
+            fullyQualifiedName = trimmed.substring(0, memberSeparatorIndex)
+            memberPart = trimmed.substring(memberSeparatorIndex + 2)
+        } else {
+            fullyQualifiedName = trimmed
+            memberPart = null
+        }
+
+        // Normalize to leading backslash (PhpIndex resolves both forms but leading \ is canonical)
+        val classFqn = if (fullyQualifiedName.startsWith("\\")) fullyQualifiedName else "\\$fullyQualifiedName"
+
+        val phpClass = getClassByFQN(project, classFqn)
+            ?: return ErrorMessages.typeNotFound(classFqn, project.name).toArgumentFailure()
+
+        if (memberPart == null) {
+            return phpClass.toPsiNamedElementResult()
+        }
+
+        return resolvePhpMember(phpClass, classFqn, memberPart)
+    }
+
+    private fun resolvePhpMember(
+        phpClass: PsiElement,
+        classFqn: String,
+        memberPart: String
+    ): Result<PsiNamedElement> {
+        // Strip parameter parentheses for method lookup (PHP has no overloading by type)
+        val hasParens = memberPart.endsWith(")") && memberPart.contains("(")
+        val memberName = if (hasParens) {
+            memberPart.substring(0, memberPart.indexOf('('))
+        } else {
+            memberPart
+        }
+
+        val isProperty = memberName.startsWith("$")
+
+        if (isProperty) {
+            // Field/property: strip the leading $ for the getName comparison
+            val fieldName = memberName.substring(1)
+            val field = findFieldInClass(phpClass, fieldName)
+                ?: return ErrorMessages.memberNotFoundInType(memberPart, classFqn).toArgumentFailure()
+            return field.toPsiNamedElementResult()
+        }
+
+        if (hasParens) {
+            // Explicit method call syntax with (): look up method by name (ignore params)
+            val method = findMethodInClass(phpClass, memberName)
+                ?: return ErrorMessages.memberNotFoundInType(memberPart, classFqn).toArgumentFailure()
+            return method.toPsiNamedElementResult()
+        }
+
+        // No parentheses and no $ prefix: could be constant, method, or field
+        // Resolve order: constant -> method -> field as graceful fallback
+        // Try constant first
+        val constant = findConstantInClass(phpClass, memberName)
+        if (constant != null) {
+            return constant.toPsiNamedElementResult()
+        }
+
+        // Try method
+        val method = findMethodInClass(phpClass, memberName)
+        if (method != null) {
+            return method.toPsiNamedElementResult()
+        }
+
+        // Try field (some PHP property names don't use $ syntax in getName)
+        val field = findFieldInClass(phpClass, memberName)
+        if (field != null) {
+            return field.toPsiNamedElementResult()
+        }
+
+        return ErrorMessages.memberNotFoundInType(memberPart, classFqn).toArgumentFailure()
+    }
+
+    private fun PsiElement.toPsiNamedElementResult(): Result<PsiNamedElement> {
+        return if (this is PsiNamedElement) {
+            Result.success(this)
+        } else {
+            ErrorMessages.SYMBOL_NOT_RESOLVED.toArgumentFailure()
         }
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -132,6 +132,16 @@ abstract class AbstractMcpTool : McpTool {
     protected open val requiresPsiSync: Boolean = true
 
     /**
+     * Human-readable list of languages that currently support language+symbol lookup.
+     */
+    protected fun supportedSymbolReferenceLanguagesDescription(): String {
+        return LanguageHandlerRegistry.getSupportedLanguageNamesForSymbolReference()
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(", ")
+            ?: "none"
+    }
+
+    /**
      * Executes an action on the EDT, reusing the current thread if already on EDT.
      *
      * This avoids deadlocks when called from `runBlocking` on EDT in tests

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
@@ -44,12 +44,13 @@ class CallHierarchyTool : AbstractMcpTool() {
 
         Target (mutually exclusive):
         - file + line + column: position-based lookup
-        - language + symbol: fully qualified symbol reference (currently supported for Java only)
+        - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
         Parameters: direction (required): "callers" or "callees". depth (optional, default: 3, max: 5). scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files).
 
         Example: {"file": "src/Service.java", "line": 42, "column": 10, "direction": "callers"}
         Example: {"language": "Java", "symbol": "com.example.Service#processRequest(String)", "direction": "callers", "scope": "project_and_libraries"}
+        Example: {"language": "PHP", "symbol": "\\App\\Service\\UserService::find()", "direction": "callers"}
     """.trimIndent()
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
@@ -34,10 +34,11 @@ class FindDefinitionTool : AbstractMcpTool() {
 
         Target (mutually exclusive):
         - file + line + column: position-based lookup
-        - language + symbol: fully qualified symbol reference (currently supported for Java only)
+        - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
         Example: {"file": "src/Main.java", "line": 15, "column": 10}
         Example: {"language": "Java", "symbol": "com.example.MyClass#processData(String)"}
+        Example: {"language": "PHP", "symbol": "\\App\\Service\\UserService::find()"}
     """.trimIndent()
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
@@ -51,13 +51,14 @@ class FindImplementationsTool : AbstractMcpTool() {
 
         Target (mutually exclusive):
         - file + line + column: position-based lookup (necessary for fresh search, ignored when cursor is provided)
-        - language + symbol: fully qualified symbol reference (currently supported for Java only; necessary for fresh search, ignored when cursor is provided)
+        - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()}; necessary for fresh search, ignored when cursor is provided)
         - cursor: pagination cursor from a previous response
 
         Parameters: scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files), pageSize (optional, default: 100, max: 500).
 
         Example: {"file": "src/Repository.java", "line": 8, "column": 18}
         Example: {"language": "Java", "symbol": "com.example.Repository", "scope": "project_and_libraries"}
+        Example: {"language": "PHP", "symbol": "\\App\\Contracts\\Repository"}
     """.trimIndent()
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
@@ -35,10 +35,11 @@ class FindSuperMethodsTool : AbstractMcpTool() {
 
         Target (mutually exclusive):
         - file + line + column: position-based lookup (position can be anywhere within the method body)
-        - language + symbol: fully qualified symbol reference (currently supported for Java only)
+        - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
         Example: {"file": "src/UserServiceImpl.java", "line": 25, "column": 10}
         Example: {"language": "Java", "symbol": "com.example.UserServiceImpl#getUser(String)"}
+        Example: {"language": "PHP", "symbol": "\\App\\Service\\UserService::find()"}
     """.trimIndent()
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -62,13 +62,14 @@ class FindUsagesTool : AbstractMcpTool() {
 
         Target (mutually exclusive):
         - file + line + column: position-based lookup (necessary for fresh search, ignored when cursor is provided)
-        - language + symbol: fully qualified symbol reference (currently supported for Java only; necessary for fresh search, ignored when cursor is provided)
+        - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()}; necessary for fresh search, ignored when cursor is provided)
         - cursor: pagination cursor from a previous response
 
         Parameters: scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files), pageSize (optional, default: 100, max: 500).
 
         Example: {"file": "src/UserService.java", "line": 25, "column": 18}
         Example: {"language": "Java", "symbol": "com.example.UserService#findUser(String)", "scope": "project_and_libraries"}
+        Example: {"language": "PHP", "symbol": "\\App\\Service\\UserService::find()"}
     """.trimIndent()
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -11,7 +11,7 @@ Complete parameter reference for all IDE MCP tools. All tools use JSON-RPC via M
 | `line` | integer | **1-based** line number |
 | `column` | integer | **1-based** column number. Place on the symbol name, not whitespace. For dotted expressions like `json.dumps()` or `os.path.join()`, point to the member token (`dumps`, `join`) when targeting the member definition. |
 | `language` | string | Language of the symbol (e.g., `"Java"`, `"PHP"`). Required when using `symbol`. |
-| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::$property`. |
+| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::CONSTANT`, `\\App\\Service\\UserService::$property`. PHP properties require the `$property` form; plain `::name` resolves constants/methods only. |
 
 **Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
 

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -11,7 +11,7 @@ Complete parameter reference for all IDE MCP tools. All tools use JSON-RPC via M
 | `line` | integer | **1-based** line number |
 | `column` | integer | **1-based** column number. Place on the symbol name, not whitespace. For dotted expressions like `json.dumps()` or `os.path.join()`, point to the member token (`dumps`, `join`) when targeting the member definition. |
 | `language` | string | Language of the symbol (e.g., `"Java"`, `"PHP"`). Required when using `symbol`. |
-| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::CONSTANT`, `\\App\\Service\\UserService::$property`. PHP properties require the `$property` form; plain `::name` resolves constants/methods only. |
+| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::CONSTANT`, `\\App\\Service\\UserService::$property`, `\\App\\Service\\StatusEnum::ACTIVE`. PHP properties require the `$property` form; plain `::name` resolves enum cases (on enum types), constants, or methods. |
 
 **Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
 

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -10,10 +10,10 @@ Complete parameter reference for all IDE MCP tools. All tools use JSON-RPC via M
 | `file` | string | For project files, path relative to project root (e.g., `src/main/App.java`). `ide_read_file` and some read-only position-based navigation tools also accept dependency/library paths returned by the plugin as absolute paths or `jar://` URLs; check each tool section because support is tool-specific. |
 | `line` | integer | **1-based** line number |
 | `column` | integer | **1-based** column number. Place on the symbol name, not whitespace. For dotted expressions like `json.dumps()` or `os.path.join()`, point to the member token (`dumps`, `join`) when targeting the member definition. |
-| `language` | string | Language of the symbol (e.g., `"Java"`). Required when using `symbol`. |
-| `symbol` | string | Fully qualified symbol reference. Format: `com.example.ClassName`, `com.example.ClassName#memberName`. |
+| `language` | string | Language of the symbol (e.g., `"Java"`, `"PHP"`). Required when using `symbol`. |
+| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::$property`. |
 
-**Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Currently supported for Java only. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
+**Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
 
 ## Response Format
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpSymbolReferenceHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpSymbolReferenceHandlerUnitTest.kt
@@ -1,0 +1,37 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.php
+
+import junit.framework.TestCase
+
+class PhpSymbolReferenceHandlerUnitTest : TestCase() {
+
+    fun testPhpSymbolPatternAcceptsSupportedFormats() {
+        val validSymbols = listOf(
+            "\\App\\Service\\UserService",
+            "App\\Service\\UserService",
+            "\\App\\Service\\UserService::find",
+            "\\App\\Service\\UserService::find()",
+            "\\App\\Service\\UserService::find(int, string)",
+            "\\App\\Service\\UserService::\$repository",
+            "\\App\\Service\\UserService::ROLE_ADMIN"
+        )
+
+        validSymbols.forEach { symbol ->
+            assertTrue("Expected PHP symbol pattern to accept: $symbol", PhpSymbolReferenceHandler.PHP_SYMBOL_PATTERN.matches(symbol))
+        }
+    }
+
+    fun testPhpSymbolPatternRejectsUnsupportedFormats() {
+        val invalidSymbols = listOf(
+            "",
+            "\\App\\Service\\",
+            "\\App\\Service\\UserService::",
+            "\\App\\Service\\UserService#find",
+            "\\App\\Service\\UserService::\$",
+            "\\App\\Service\\UserService::123INVALID"
+        )
+
+        invalidSymbols.forEach { symbol ->
+            assertFalse("Expected PHP symbol pattern to reject: $symbol", PhpSymbolReferenceHandler.PHP_SYMBOL_PATTERN.matches(symbol))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpSymbolReferenceHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpSymbolReferenceHandlerUnitTest.kt
@@ -1,8 +1,12 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.php
 
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.FakePsiElement
 import junit.framework.TestCase
 
 class PhpSymbolReferenceHandlerUnitTest : TestCase() {
+
+    private val helper = TestPhpHandler()
 
     fun testPhpSymbolPatternAcceptsSupportedFormats() {
         val validSymbols = listOf(
@@ -12,7 +16,8 @@ class PhpSymbolReferenceHandlerUnitTest : TestCase() {
             "\\App\\Service\\UserService::find()",
             "\\App\\Service\\UserService::find(int, string)",
             "\\App\\Service\\UserService::\$repository",
-            "\\App\\Service\\UserService::ROLE_ADMIN"
+            "\\App\\Service\\UserService::ROLE_ADMIN",
+            "\\App\\Service\\StatusEnum::ACTIVE"
         )
 
         validSymbols.forEach { symbol ->
@@ -33,5 +38,113 @@ class PhpSymbolReferenceHandlerUnitTest : TestCase() {
         invalidSymbols.forEach { symbol ->
             assertFalse("Expected PHP symbol pattern to reject: $symbol", PhpSymbolReferenceHandler.PHP_SYMBOL_PATTERN.matches(symbol))
         }
+    }
+
+    fun testDeclaredOnlyMethodLookupIgnoresInheritedMethods() {
+        val parentMethod = FakePhpMethod("save")
+        val parentClass = FakePhpClass("\\App\\BaseRepo", ownMethods = listOf(parentMethod))
+        val childClass = FakePhpClass(
+            "\\App\\ChildRepo",
+            ownMethods = emptyList(),
+            inheritedMethods = listOf(parentMethod),
+            superClass = parentClass
+        )
+
+        assertNull("Declared-only lookup must not return inherited methods", helper.findOwn(childClass, "save"))
+        assertSame("Inherited lookup should still support direct symbol resolution", parentMethod, helper.findInherited(childClass, "SAVE"))
+        assertEquals("\\App\\BaseRepo", helper.findNearestClassDeclarationFqn(childClass, "save"))
+    }
+
+    fun testInterfaceHierarchyLookupReportsDeclaringInterface() {
+        val parentMethod = FakePhpMethod("handle")
+        val parentInterface = FakePhpClass("\\App\\Handler", ownMethods = listOf(parentMethod))
+        val childInterface = FakePhpClass(
+            "\\App\\ChildHandler",
+            ownMethods = emptyList(),
+            interfaces = arrayOf(parentInterface)
+        )
+
+        assertNull("Declared-only lookup must not return inherited interface methods", helper.findOwn(childInterface, "handle"))
+        assertEquals("\\App\\Handler", helper.findNearestInterfaceDeclarationFqn(childInterface, "HANDLE"))
+    }
+
+    fun testEnumCaseLookup() {
+        val caseActive = FakePhpEnumCase("ACTIVE")
+        val caseInactive = FakePhpEnumCase("INACTIVE")
+        val enumClass = FakePhpClass(
+            "\\App\\StatusEnum",
+            enumCases = listOf(caseActive, caseInactive)
+        )
+
+        assertSame("Enum case lookup must find ACTIVE", caseActive, helper.findEnumCase(enumClass, "ACTIVE"))
+        assertSame("Enum case lookup must find INACTIVE", caseInactive, helper.findEnumCase(enumClass, "INACTIVE"))
+        assertNull("Enum case lookup must return null for non-existent case", helper.findEnumCase(enumClass, "NONEXISTENT"))
+        assertNull("Enum case lookup must return null for method name on enum", helper.findEnumCase(enumClass, "someMethod"))
+    }
+
+    fun testEnumCaseLookupOnNonEnumType() {
+        // A regular class without getEnumCases() should not cause errors
+        val regularClass = FakePhpClass("\\App\\RegularService")
+        assertNull("Enum case lookup on regular class must return null", helper.findEnumCase(regularClass, "ANYTHING"))
+    }
+
+    private class TestPhpHandler : BasePhpHandler<Unit>() {
+        override val languageId = "PHP"
+
+        override fun canHandle(element: PsiElement): Boolean = true
+
+        override fun isAvailable(): Boolean = true
+
+        fun findOwn(phpClass: PsiElement, methodName: String): PsiElement? =
+            findOwnMethodInClass(phpClass, methodName)
+
+        fun findInherited(phpClass: PsiElement, methodName: String): PsiElement? =
+            findMethodInClass(phpClass, methodName)
+
+        fun findNearestClassDeclarationFqn(phpClass: PsiElement, methodName: String): String? =
+            findOwnMethodInClassHierarchy(phpClass, methodName)?.declaringClass?.let { getFQN(it) }
+
+        fun findNearestInterfaceDeclarationFqn(iface: PsiElement, methodName: String): String? =
+            findOwnMethodInInterfaceHierarchy(iface, methodName)?.declaringClass?.let { getFQN(it) }
+
+        fun findEnumCase(phpClass: PsiElement, caseName: String): PsiElement? =
+            findEnumCaseInClass(phpClass, caseName)
+    }
+
+    private class FakePhpClass(
+        private val fqn: String,
+        private val ownMethods: List<PsiElement> = emptyList(),
+        private val inheritedMethods: List<PsiElement> = emptyList(),
+        private val superClass: PsiElement? = null,
+        private val interfaces: Array<PsiElement> = emptyArray(),
+        private val enumCases: List<PsiElement> = emptyList()
+    ) : FakePsiElement() {
+        override fun getParent(): PsiElement? = null
+
+        override fun getName(): String = fqn.substringAfterLast("\\")
+
+        fun getFQN(): String = fqn
+
+        fun getOwnMethods(): Array<PsiElement> = ownMethods.toTypedArray()
+
+        fun getMethods(): Array<PsiElement> = (ownMethods + inheritedMethods).toTypedArray()
+
+        fun getSuperClass(): PsiElement? = superClass
+
+        fun getImplementedInterfaces(): Array<PsiElement> = interfaces
+
+        fun getEnumCases(): Array<PsiElement> = enumCases.toTypedArray()
+    }
+
+    private class FakePhpMethod(private val methodName: String) : FakePsiElement() {
+        override fun getParent(): PsiElement? = null
+
+        override fun getName(): String = methodName
+    }
+
+    private class FakePhpEnumCase(private val caseName: String) : FakePsiElement() {
+        override fun getParent(): PsiElement? = null
+
+        override fun getName(): String = caseName
     }
 }


### PR DESCRIPTION
Closes #179

## Summary
- add `PhpSymbolReferenceHandler` for PHP `language` + `symbol` lookup
- support class/interface/trait FQNs plus methods, properties, and constants
- update symbol-reference tool descriptions and skill reference docs
- add unit coverage for accepted/rejected PHP symbol formats

## Validation
- `./gradlew test --tests "*UnitTest*"`
- manually tested in PhpStorm via MCP HTTP endpoint for PHP class/interface/trait/method/property definitions, references, super methods, call hierarchy, and implementations

Note: per project instructions, platform tests were not run locally.

## AI Disclosure
Written by DeepSeek V4 Flash, supervised by GPT‑5.5, and accepted by the human who had the GitHub token.