### PR TITLE
Add outputSchema to tools list

### DIFF
--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
@@ -8,6 +8,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandEntry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandHistoryService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandStatus
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.*
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -99,10 +100,24 @@ class JsonRpcHandler @JvmOverloads constructor(
     private fun processToolsList(request: JsonRpcRequest): JsonRpcResponse {
         val tools = toolRegistry.getToolDefinitions()
         val result = ToolsListResult(tools = tools)
+        val encodedResult = json.encodeToJsonElement(result)
+        val cleanedResult = if(!McpSettings.getInstance().toolsOutputOutputSchema){
+            JsonObject(
+                encodedResult.jsonObject.mapValues { (_, value) ->
+                    when (value) {
+                        is JsonArray -> JsonArray(value.map { item ->
+                            if (item is JsonObject) JsonObject(item.filterKeys { it != "outputSchema" })
+                            else item
+                        })
+                        else -> value
+                    }
+                }
+            )
+        } else encodedResult
 
         return JsonRpcResponse(
             id = request.id,
-            result = json.encodeToJsonElement(result)
+            result = cleanedResult
         )
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/models/McpModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/models/McpModels.kt
@@ -9,7 +9,8 @@ import kotlinx.serialization.json.JsonObject
 data class ToolDefinition(
     val name: String,
     val description: String,
-    val inputSchema: JsonObject
+    val inputSchema: JsonObject,
+    val outputSchema: JsonObject? = null
 )
 
 @Serializable

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -36,7 +36,8 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
         var responseFormat: ResponseFormat = ResponseFormat.JSON,
         var disabledTools: MutableSet<String> = mutableSetOf("ide_build_project", "ide_file_structure", "ide_find_symbol", "ide_read_file", "ide_get_active_file", "ide_open_file", "ide_reformat_code", "ide_optimize_imports", "ide_convert_java_to_kotlin"),
         var serverPort: Int = -1, // -1 means use IDE-specific default
-        var serverHost: String = McpConstants.DEFAULT_SERVER_HOST
+        var serverHost: String = McpConstants.DEFAULT_SERVER_HOST,
+        var toolsOutputOutputSchema: Boolean = false
     )
 
     private var state = State()
@@ -62,6 +63,10 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
     var responseFormat: ResponseFormat
         get() = state.responseFormat
         set(value) { state.responseFormat = value }
+
+    var toolsOutputOutputSchema: Boolean
+        get() = state.toolsOutputOutputSchema
+        set(value) { state.toolsOutputOutputSchema = value }
 
     var disabledTools: Set<String>
         get() = state.disabledTools.toSet()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -33,7 +33,6 @@ import java.awt.event.FocusEvent
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
-import java.util.function.Supplier
 import javax.swing.BoxLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -50,6 +49,7 @@ class McpSettingsConfigurable : Configurable {
     private var syncExternalChangesCheckBox: JBCheckBox? = null
     private var availableProjectsModeComboBox: ComboBox<McpSettings.AvailableProjectsMode>? = null
     private var responseFormatComboBox: ComboBox<McpSettings.ResponseFormat>? = null
+    private var toolsOutputOutputSchemaCheckBox: JBCheckBox? = null
     private val toolCheckBoxes = mutableMapOf<String, JBCheckBox>()
     private var uiDisposable: Disposable? = null
 
@@ -111,6 +111,9 @@ class McpSettingsConfigurable : Configurable {
                 value?.let(::responseFormatLabel).orEmpty()
             }
         }
+        toolsOutputOutputSchemaCheckBox = JBCheckBox(McpBundle.message("settings.toolsOutputOutputSchema")).apply {
+            toolTipText = McpBundle.message("settings.toolsOutputOutputSchema.tooltip")
+        }
 
         val warningLabel = JBLabel(McpBundle.message("settings.syncExternalChanges.warning")).apply {
             foreground = JBColor.RED
@@ -137,6 +140,7 @@ class McpSettingsConfigurable : Configurable {
             .addLabeledComponent(JBLabel(McpBundle.message("settings.maxHistorySize") + ":"), maxHistorySizeSpinner!!, 1, false)
             .addLabeledComponent(JBLabel(McpBundle.message("settings.availableProjectsMode") + ":"), availableProjectsModeComboBox!!, 1, false)
             .addLabeledComponent(JBLabel(McpBundle.message("settings.responseFormat") + ":"), responseFormatComboBox!!, 1, false)
+            .addComponent(toolsOutputOutputSchemaCheckBox!!, 1)
             .addComponent(syncPanel, 1)
             .addSeparator(10)
             .addComponent(JBLabel(McpBundle.message("settings.tools.title")), 5)
@@ -183,7 +187,8 @@ class McpSettingsConfigurable : Configurable {
             maxHistorySizeSpinner?.value != settings.maxHistorySize ||
             syncExternalChangesCheckBox?.isSelected != settings.syncExternalChanges ||
             availableProjectsModeComboBox?.selectedItem != settings.availableProjectsMode ||
-            responseFormatComboBox?.selectedItem != settings.responseFormat) {
+            responseFormatComboBox?.selectedItem != settings.responseFormat ||
+            toolsOutputOutputSchemaCheckBox?.isSelected != settings.toolsOutputOutputSchema) {
             return true
         }
 
@@ -243,6 +248,7 @@ class McpSettingsConfigurable : Configurable {
         settings.responseFormat =
             responseFormatComboBox?.selectedItem as? McpSettings.ResponseFormat
                 ?: McpSettings.ResponseFormat.JSON
+        settings.toolsOutputOutputSchema = toolsOutputOutputSchemaCheckBox?.isSelected ?: false
 
         val disabledTools = mutableSetOf<String>()
         for ((toolName, checkbox) in toolCheckBoxes) {
@@ -330,6 +336,7 @@ class McpSettingsConfigurable : Configurable {
         syncExternalChangesCheckBox?.isSelected = settings.syncExternalChanges
         availableProjectsModeComboBox?.selectedItem = settings.availableProjectsMode
         responseFormatComboBox?.selectedItem = settings.responseFormat
+        toolsOutputOutputSchemaCheckBox?.isSelected = settings.toolsOutputOutputSchema
         
         hostValidationErrorLabel?.isVisible = false
         hostValidationIcon?.isVisible = false
@@ -427,6 +434,7 @@ class McpSettingsConfigurable : Configurable {
         syncExternalChangesCheckBox = null
         availableProjectsModeComboBox = null
         responseFormatComboBox = null
+        toolsOutputOutputSchemaCheckBox = null
         toolCheckBoxes.clear()
         uiDisposable?.let { Disposer.dispose(it) }
         uiDisposable = null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/McpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/McpTool.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.json.JsonObject
  * Interface for MCP (Model Context Protocol) tools that can be invoked by AI assistants.
  *
  * MCP tools provide specific IDE functionality to external clients through the MCP protocol.
- * Each tool has a unique name, description, input schema, and execution logic.
+ * Each tool has a unique name, description, input schema, optional output schema, and execution logic.
  *
  * ## Implementing a Custom Tool
  *
@@ -99,6 +99,16 @@ interface McpTool {
      * @see com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
      */
     val inputSchema: JsonObject
+
+    /**
+     * Optional JSON Schema defining the tool's structured success output.
+     *
+     * Tools that return structured JSON should provide this schema so MCP clients can
+     * understand the shape of successful responses. Tools that only return plain text
+     * or have no stable structured response may leave this as null.
+     */
+    val outputSchema: JsonObject?
+        get() = null
 
     /**
      * Executes the tool with the given arguments.

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -147,7 +147,8 @@ class ToolRegistry {
                 ToolDefinition(
                     name = tool.name,
                     description = tool.description,
-                    inputSchema = tool.inputSchema
+                    inputSchema = tool.inputSchema,
+                    outputSchema = tool.outputSchema
                 )
             }
     }
@@ -163,7 +164,8 @@ class ToolRegistry {
             ToolDefinition(
                 name = tool.name,
                 description = tool.description,
-                inputSchema = tool.inputSchema
+                inputSchema = tool.inputSchema,
+                outputSchema = tool.outputSchema
             )
         }
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/GetActiveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/GetActiveFileTool.kt
@@ -6,6 +6,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ActiveFileInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.GetActiveFileResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
@@ -29,6 +30,39 @@ class GetActiveFileTool : AbstractMcpTool() {
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()
         .projectPath()
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "activeFiles", "Active editor files visible in the IDE.", items = SchemaBuilder.tool()
+                .stringProperty("file", "Project-relative path of the active file.", required = true)
+                .intProperty(
+                    "line",
+                    "1-based caret line number, when an editor caret is available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "column",
+                    "1-based caret column number, when an editor caret is available.",
+                    required = true,
+                    nullable = true
+                )
+                .stringProperty(
+                    "selectedText",
+                    "Selected text in the editor, when present.",
+                    required = true,
+                    nullable = true
+                )
+                .booleanProperty("hasSelection", "Whether the active editor has selected text.", required = true)
+                .stringProperty(
+                    "language",
+                    "File type or language name for the active file, when known.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true
+        )
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/OpenFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/OpenFileTool.kt
@@ -33,6 +33,12 @@ class OpenFileTool : AbstractMcpTool() {
         .intProperty("column", "1-based column number to navigate to. Requires line to be specified.")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .stringProperty("file", "Project-relative path of the opened file.", required = true)
+        .booleanProperty("opened", "Whether the file was opened successfully.", required = true)
+        .stringProperty("message", "Human-readable open file status message.", required = true)
+        .build()
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val filePath = requiredStringArg(arguments, "file").getOrElse {
             return createErrorResult(it.message ?: "Missing required parameter: file")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsTool.kt
@@ -10,6 +10,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.IntentionInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TestResultInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TestSummary
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.TestResultsCollector
 import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.codeInsight.intention.IntentionManager
@@ -80,6 +81,141 @@ class GetDiagnosticsTool : AbstractMcpTool() {
         .enumProperty(ParamNames.TEST_RESULT_FILTER, "Filter test results: 'failed' (default) or 'all'.", listOf("failed", "all"))
         .intProperty(ParamNames.MAX_BUILD_ERRORS, "Max build errors to return. Default: 100, max: 500.")
         .intProperty(ParamNames.MAX_TEST_RESULTS, "Max test results to return. Default: 100, max: 500.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "problems", "Code analysis problems for the requested file or range.", SchemaBuilder.tool()
+                .stringProperty("message", "Problem or diagnostic message.", required = true)
+                .stringProperty("severity", "Problem severity, such as ERROR or WARNING.", required = true)
+                .stringProperty("file", "Project-relative file path containing the problem.", required = true)
+                .intProperty("line", "1-based start line of the problem.", required = true)
+                .intProperty("column", "1-based start column of the problem.", required = true)
+                .intProperty(
+                    "endLine",
+                    "1-based end line of the problem, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "endColumn",
+                    "1-based end column of the problem, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true, nullable = true
+        )
+        .arrayProperty(
+            "intentions", "Available intentions and quick fixes for the requested position.", SchemaBuilder.tool()
+                .stringProperty("name", "Intention or quick-fix name.", required = true)
+                .stringProperty(
+                    "description",
+                    "Intention or quick-fix description, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true, nullable = true
+        )
+        .intProperty("problemCount", "Number of reported code analysis problems.", required = true, nullable = true)
+        .intProperty(
+            "intentionCount",
+            "Number of reported intentions and quick fixes.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("analysisFresh", "Whether code analysis data was fresh.", required = true, nullable = true)
+        .booleanProperty("analysisTimedOut", "Whether code analysis timed out.", required = true, nullable = true)
+        .stringProperty(
+            "analysisMessage",
+            "Additional code analysis status message, when available.",
+            required = true,
+            nullable = true
+        )
+        .arrayProperty(
+            "buildErrors", "Build errors and warnings from the last build output.", SchemaBuilder.tool()
+                .stringProperty("category", "Build message category, such as ERROR or WARNING.", required = true)
+                .stringProperty("message", "Build diagnostic text.", required = true)
+                .stringProperty(
+                    "file",
+                    "Project-relative file path for the build message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "line",
+                    "1-based line number for the build message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "column",
+                    "1-based column number for the build message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true, nullable = true
+        )
+        .intProperty("buildErrorCount", "Number of build errors reported.", required = true, nullable = true)
+        .intProperty("buildWarningCount", "Number of build warnings reported.", required = true, nullable = true)
+        .booleanProperty(
+            "buildErrorsTruncated",
+            "Whether build diagnostics were truncated.",
+            required = true,
+            nullable = true
+        )
+        .intProperty(
+            "buildTimestamp",
+            "Timestamp of the build diagnostics, when available.",
+            required = true,
+            nullable = true
+        )
+        .arrayProperty(
+            "testResults", "Test results from open test run tabs.", SchemaBuilder.tool()
+                .stringProperty("name", "Test name.", required = true)
+                .stringProperty("suite", "Test suite name, when available.", required = true, nullable = true)
+                .stringProperty("status", "Test status, such as passed, failed, or ignored.", required = true)
+                .intProperty(
+                    "durationMs",
+                    "Test duration in milliseconds, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .stringProperty(
+                    "errorMessage",
+                    "Failure or error message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .stringProperty("stacktrace", "Failure stack trace, when available.", required = true, nullable = true)
+                .stringProperty(
+                    "file",
+                    "Project-relative test file path, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty("line", "1-based test line number, when available.", required = true, nullable = true)
+                .build(), required = true, nullable = true
+        )
+        .property(
+            "testSummary", SchemaBuilder.tool()
+                .intProperty("total", "Total number of tests reported.", required = true)
+                .intProperty("passed", "Number of passed tests.", required = true)
+                .intProperty("failed", "Number of failed tests.", required = true)
+                .intProperty("ignored", "Number of ignored or skipped tests.", required = true)
+                .stringProperty(
+                    "runConfigName",
+                    "Test run configuration name, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true, nullable = true
+        )
+        .booleanProperty(
+            "testResultsTruncated",
+            "Whether test results were truncated.",
+            required = true,
+            nullable = true
+        )
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
@@ -308,7 +444,7 @@ class GetDiagnosticsTool : AbstractMcpTool() {
         intentions: MutableList<IntentionInfo>
     ) {
         IntentionManager.getInstance()
-            .getAvailableIntentions()
+            .availableIntentions
             .take(MAX_INTENTIONS)
             .forEach { action ->
                 try {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
@@ -62,9 +62,54 @@ class CallHierarchyTool : AbstractMcpTool() {
         .scopeProperty("Search scope. Default: project_files.")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .property("element", callElementRef, required = true)
+        .arrayProperty(
+            "calls",
+            "Top-level caller or callee nodes in the call hierarchy.",
+            items = callElementRef,
+            required = true
+        )
+        .build()
+        .withCallElementDefinition()
+
     companion object {
         private const val DEFAULT_DEPTH = 3
         private const val MAX_DEPTH = 5
+        private const val CALL_ELEMENT_REF = "#/\$defs/callElement"
+
+        private val callElementRef: JsonObject = buildJsonObject {
+            put("\$ref", CALL_ELEMENT_REF)
+        }
+
+        private val callElement: JsonObject = SchemaBuilder.tool()
+            .stringProperty("name", "Callable name or signature.", required = true)
+            .stringProperty("file", "Project-relative file path containing the callable.", required = true)
+            .intProperty("line", "1-based line number of the callable.", required = true)
+            .intProperty("column", "1-based column number of the callable.", required = true)
+            .stringProperty(
+                "language",
+                "Programming language for the callable, when known.",
+                required = true,
+                nullable = true
+            )
+            .arrayProperty(
+                "children",
+                "Nested caller or callee nodes in the call hierarchy.",
+                items = callElementRef,
+                required = true,
+                nullable = true
+            )
+            .build()
+
+        private fun JsonObject.withCallElementDefinition(): JsonObject = buildJsonObject {
+            for ((key, value) in this@withCallElementDefinition) {
+                put(key, value)
+            }
+            put("\$defs", buildJsonObject {
+                put("callElement", callElement)
+            })
+        }
     }
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
@@ -41,6 +41,12 @@ class FileStructureTool : AbstractMcpTool() {
         .file(description = "Path to file relative to project root (e.g., 'src/main/java/com/example/MyClass.java'). REQUIRED.")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .stringProperty("file", "Project-relative file path that was analyzed.", required = true)
+        .stringProperty("language", "Language of the analyzed file.", required = true)
+        .stringProperty("structure", "Text representation of the file structure.", required = true)
+        .build()
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val file = requiredStringArg(arguments, "file").getOrElse {
             return createErrorResult(it.message ?: "Missing required parameter: file")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
@@ -13,6 +13,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindClassResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SymbolMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.ChooseByNameContributorEx
@@ -83,6 +84,28 @@ class FindClassTool : AbstractMcpTool() {
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "classes",
+            "Classes and interfaces matching the search query.",
+            items = ToolResultSchemas.symbolMatch,
+            required = true
+        )
+        .intProperty("totalCount", "Total number of matching classes returned for this page.", required = true)
+        .stringProperty("query", "Original class search query.", required = true)
+        .stringProperty(
+            "nextCursor",
+            "Cursor for the next result page, when more results are available.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("hasMore", "Whether more matching classes are available.", required = true)
+        .intProperty("totalCollected", "Total number of matching classes collected for pagination.", required = true)
+        .intProperty("offset", "Zero-based offset of this page in the collected results.", required = true)
+        .intProperty("pageSize", "Number of results requested for this page.", required = true)
+        .booleanProperty("stale", "Whether the cached pagination data may be stale.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
@@ -49,6 +49,19 @@ class FindDefinitionTool : AbstractMcpTool() {
         .intProperty(ParamNames.MAX_PREVIEW_LINES, "Maximum lines for fullElementPreview. Truncates large classes/functions. Default: 50, Max: 500. Only used when fullElementPreview=true.")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .stringProperty("file", "Project-relative file path of the definition.", required = true)
+        .intProperty("line", "1-based line number of the definition.", required = true)
+        .intProperty("column", "1-based column number of the definition.", required = true)
+        .stringProperty("preview", "Code preview or full element text for the definition.", required = true)
+        .stringProperty("symbolName", "Name of the resolved symbol.", required = true)
+        .stringArrayProperty(
+            "astPath",
+            "Structural path to the resolved definition in the syntax tree.",
+            required = true
+        )
+        .build()
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val fullElementPreview = arguments[ParamNames.FULL_ELEMENT_PREVIEW]?.jsonPrimitive?.content?.toBoolean() ?: false
         val maxPreviewLines = (arguments[ParamNames.MAX_PREVIEW_LINES]?.jsonPrimitive?.int ?: DEFAULT_MAX_PREVIEW_LINES)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
@@ -11,6 +11,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindFileResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.ChooseByNameContributorEx
@@ -73,6 +74,29 @@ class FindFileTool : AbstractMcpTool() {
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "files", "Files matching the search query.", SchemaBuilder.tool()
+                .stringProperty("name", "File name.", required = true)
+                .stringProperty("path", "Project-relative file path.", required = true)
+                .stringProperty("directory", "Project-relative containing directory.", required = true)
+                .build(), required = true
+        )
+        .intProperty("totalCount", "Total number of matching files returned for this page.", required = true)
+        .stringProperty("query", "Original file search query.", required = true)
+        .stringProperty(
+            "nextCursor",
+            "Cursor for the next result page, when more results are available.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("hasMore", "Whether more matching files are available.", required = true)
+        .intProperty("totalCollected", "Total number of matching files collected for pagination.", required = true)
+        .intProperty("offset", "Zero-based offset of this page in the collected results.", required = true)
+        .intProperty("pageSize", "Number of results requested for this page.", required = true)
+        .booleanProperty("stale", "Whether the cached pagination data may be stale.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
@@ -12,6 +12,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ImplementationLocation
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ImplementationResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiModificationTracker
@@ -68,6 +69,36 @@ class FindImplementationsTool : AbstractMcpTool() {
         .scopeProperty("Search scope. Default: project_files.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "implementations", "Implementations found for the target symbol.", SchemaBuilder.tool()
+                .stringProperty("name", "Implementing class or method name.", required = true)
+                .stringProperty("file", "Project-relative file path containing the implementation.", required = true)
+                .intProperty("line", "1-based line number of the implementation.", required = true)
+                .intProperty("column", "1-based column number of the implementation.", required = true)
+                .stringProperty("kind", "Implementation kind, such as class or method.", required = true)
+                .stringProperty(
+                    "language",
+                    "Programming language for the implementation, when known.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true
+        )
+        .intProperty("totalCount", "Total number of implementations returned for this page.", required = true)
+        .stringProperty(
+            "nextCursor",
+            "Cursor for the next result page, when more results are available.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("hasMore", "Whether more implementations are available.", required = true)
+        .intProperty("totalCollected", "Total number of implementations collected for pagination.", required = true)
+        .intProperty("offset", "Zero-based offset of this page in the collected results.", required = true)
+        .intProperty("pageSize", "Number of results requested for this page.", required = true)
+        .booleanProperty("stale", "Whether the cached pagination data may be stale.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
@@ -10,6 +10,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.MethodInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SuperMethodInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SuperMethodsResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.intellij.openapi.project.Project
 import kotlinx.serialization.json.JsonObject
 
@@ -43,25 +44,87 @@ class FindSuperMethodsTool : AbstractMcpTool() {
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()
         .projectPath()
-        .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
+        .file(
+            required = false,
+            description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup."
+        )
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .property(
+            "method", SchemaBuilder.tool()
+                .stringProperty("name", "Method name.", required = true)
+                .stringProperty("signature", "Method signature.", required = true)
+                .stringProperty("containingClass", "Class or type that contains the method.", required = true)
+                .stringProperty("file", "Project-relative file path containing the method.", required = true)
+                .intProperty("line", "1-based line number of the method.", required = true)
+                .intProperty("column", "1-based column number of the method.", required = true)
+                .stringProperty(
+                    "language",
+                    "Programming language for the method, when known.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true
+        )
+        .arrayProperty(
+            "hierarchy", "Super method hierarchy from immediate parent to root.", SchemaBuilder.tool()
+                .stringProperty("name", "Super method name.", required = true)
+                .stringProperty("signature", "Super method signature.", required = true)
+                .stringProperty(
+                    "containingClass",
+                    "Class or interface that declares the super method.",
+                    required = true
+                )
+                .stringProperty("containingClassKind", "Kind of the declaring type.", required = true)
+                .stringProperty(
+                    "file",
+                    "Project-relative file path containing the super method, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "line",
+                    "1-based line number of the super method, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "column",
+                    "1-based column number of the super method, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .booleanProperty("isInterface", "Whether the declaring type is an interface.", required = true)
+                .intProperty("depth", "Inheritance depth from the original method.", required = true)
+                .stringProperty(
+                    "language",
+                    "Programming language for the super method, when known.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true
+        )
+        .intProperty("totalCount", "Number of super methods in the hierarchy.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         requireSmartMode(project)
 
         return suspendingReadAction {
-            val element = resolveElementFromArguments(project, arguments, allowLibraryFilesForPosition = true).getOrElse {
-                return@suspendingReadAction createErrorResult(it.message ?: ErrorMessages.COULD_NOT_RESOLVE_SYMBOL)
-            }
+            val element =
+                resolveElementFromArguments(project, arguments, allowLibraryFilesForPosition = true).getOrElse {
+                    return@suspendingReadAction createErrorResult(it.message ?: ErrorMessages.COULD_NOT_RESOLVE_SYMBOL)
+                }
 
             // Find appropriate handler for this element's language
             val handler = LanguageHandlerRegistry.getSuperMethodsHandler(element)
             if (handler == null) {
                 return@suspendingReadAction createErrorResult(
                     "No super methods handler available for language: ${element.language.id}. " +
-                    "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForSuperMethods()}"
+                            "Supported languages: ${LanguageHandlerRegistry.getSupportedLanguagesForSuperMethods()}"
                 )
             }
 
@@ -75,32 +138,34 @@ class FindSuperMethodsTool : AbstractMcpTool() {
             }
 
             // Convert handler result to tool result
-            createJsonResult(SuperMethodsResult(
-                method = MethodInfo(
-                    name = superMethodsData.method.name,
-                    signature = superMethodsData.method.signature,
-                    containingClass = superMethodsData.method.containingClass,
-                    file = superMethodsData.method.file,
-                    line = superMethodsData.method.line,
-                    column = superMethodsData.method.column,
-                    language = superMethodsData.method.language
-                ),
-                hierarchy = superMethodsData.hierarchy.map { superMethod ->
-                    SuperMethodInfo(
-                        name = superMethod.name,
-                        signature = superMethod.signature,
-                        containingClass = superMethod.containingClass,
-                        containingClassKind = superMethod.containingClassKind,
-                        file = superMethod.file,
-                        line = superMethod.line,
-                        column = superMethod.column,
-                        isInterface = superMethod.isInterface,
-                        depth = superMethod.depth,
-                        language = superMethod.language
-                    )
-                },
-                totalCount = superMethodsData.hierarchy.size
-            ))
+            createJsonResult(
+                SuperMethodsResult(
+                    method = MethodInfo(
+                        name = superMethodsData.method.name,
+                        signature = superMethodsData.method.signature,
+                        containingClass = superMethodsData.method.containingClass,
+                        file = superMethodsData.method.file,
+                        line = superMethodsData.method.line,
+                        column = superMethodsData.method.column,
+                        language = superMethodsData.method.language
+                    ),
+                    hierarchy = superMethodsData.hierarchy.map { superMethod ->
+                        SuperMethodInfo(
+                            name = superMethod.name,
+                            signature = superMethod.signature,
+                            containingClass = superMethod.containingClass,
+                            containingClassKind = superMethod.containingClassKind,
+                            file = superMethod.file,
+                            line = superMethod.line,
+                            column = superMethod.column,
+                            isInterface = superMethod.isInterface,
+                            depth = superMethod.depth,
+                            language = superMethod.language
+                        )
+                    },
+                    totalCount = superMethodsData.hierarchy.size
+                )
+            )
         }
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
@@ -13,6 +13,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindSymbolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SymbolMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiModificationTracker
@@ -63,6 +64,28 @@ class FindSymbolTool : AbstractMcpTool() {
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "symbols",
+            "Symbols matching the search query.",
+            items = ToolResultSchemas.symbolMatch,
+            required = true
+        )
+        .intProperty("totalCount", "Total number of matching symbols returned for this page.", required = true)
+        .stringProperty("query", "Original symbol search query.", required = true)
+        .stringProperty(
+            "nextCursor",
+            "Cursor for the next result page, when more results are available.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("hasMore", "Whether more matching symbols are available.", required = true)
+        .intProperty("totalCollected", "Total number of matching symbols collected for pagination.", required = true)
+        .intProperty("offset", "Zero-based offset of this page in the collected results.", required = true)
+        .intProperty("pageSize", "Number of results requested for this page.", required = true)
+        .booleanProperty("stale", "Whether the cached pagination data may be stale.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -13,6 +13,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindUsagesResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.UsageLocation
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
@@ -80,6 +81,36 @@ class FindUsagesTool : AbstractMcpTool() {
         .intProperty("maxResults", "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_MAX_RESULTS, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_MAX_RESULTS, max: $MAX_PAGE_SIZE.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "usages", "Usages found for the target symbol.", SchemaBuilder.tool()
+                .stringProperty("file", "Project-relative file path containing the usage.", required = true)
+                .intProperty("line", "1-based line number of the usage.", required = true)
+                .intProperty("column", "1-based column number of the usage.", required = true)
+                .stringProperty("context", "Source context surrounding the usage.", required = true)
+                .stringProperty(
+                    "type",
+                    "Usage category, such as method_call, field_access, or import.",
+                    required = true
+                )
+                .stringArrayProperty("astPath", "Structural path to the usage in the syntax tree.", required = true)
+                .build(), required = true
+        )
+        .intProperty("totalCount", "Total number of usages returned for this page.", required = true)
+        .booleanProperty("truncated", "Whether the result set was truncated.", required = true)
+        .stringProperty(
+            "nextCursor",
+            "Cursor for the next result page, when more results are available.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("hasMore", "Whether more usages are available.", required = true)
+        .intProperty("totalCollected", "Total number of usages collected for pagination.", required = true)
+        .intProperty("offset", "Zero-based offset of this page in the collected results.", required = true)
+        .intProperty("pageSize", "Number of results requested for this page.", required = true)
+        .booleanProperty("stale", "Whether the cached pagination data may be stale.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/ReadFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/ReadFileTool.kt
@@ -39,6 +39,26 @@ class ReadFileTool : AbstractMcpTool() {
         .intProperty(ParamNames.END_LINE, "Ending line number (1-based, inclusive).")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .stringProperty("file", "Resolved file path that was read.", required = true)
+        .stringProperty("content", "File content returned for the requested range.", required = true)
+        .stringProperty("language", "Language or file type of the file, when known.", required = true, nullable = true)
+        .intProperty("lineCount", "Total number of lines in the returned content.", required = true)
+        .intProperty(
+            "startLine",
+            "1-based starting line returned, when a range was requested.",
+            required = true,
+            nullable = true
+        )
+        .intProperty(
+            "endLine",
+            "1-based ending line returned, when a range was requested.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("isLibraryFile", "Whether the file came from a library or dependency.", required = true)
+        .build()
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val filePath = arguments[ParamNames.FILE]?.jsonPrimitive?.content
         val qualifiedName = arguments[ParamNames.QUALIFIED_NAME]?.jsonPrimitive?.content

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
@@ -10,6 +10,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SearchTextResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TextMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
@@ -69,6 +70,31 @@ class SearchTextTool : AbstractMcpTool() {
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "matches", "Text matches found for the query.", SchemaBuilder.tool()
+                .stringProperty("file", "Project-relative file path containing the text match.", required = true)
+                .intProperty("line", "1-based line number of the match.", required = true)
+                .intProperty("column", "1-based column number of the match.", required = true)
+                .stringProperty("context", "Source context surrounding the match.", required = true)
+                .stringProperty("contextType", "Context category, such as code, comments, or strings.", required = true)
+                .build(), required = true
+        )
+        .intProperty("totalCount", "Total number of text matches returned for this page.", required = true)
+        .stringProperty("query", "Original text search query.", required = true)
+        .stringProperty(
+            "nextCursor",
+            "Cursor for the next result page, when more results are available.",
+            required = true,
+            nullable = true
+        )
+        .booleanProperty("hasMore", "Whether more text matches are available.", required = true)
+        .intProperty("totalCollected", "Total number of text matches collected for pagination.", required = true)
+        .intProperty("offset", "Zero-based offset of this page in the collected results.", required = true)
+        .intProperty("pageSize", "Number of results requested for this page.", required = true)
+        .booleanProperty("stale", "Whether the cached pagination data may be stale.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
@@ -56,6 +56,38 @@ class TypeHierarchyTool : AbstractMcpTool() {
         .scopeProperty("Search scope. Default: project_files.")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .property("element", typeElementRef, required = true)
+        .arrayProperty("supertypes", "Recursive supertype hierarchy for the target type.", items = typeElementRef, required = true)
+        .arrayProperty("subtypes", "Project subtypes of the target type.", items = typeElementRef, required = true)
+        .build()
+        .withTypeElementDefinition()
+
+    companion object {
+        private const val TYPE_ELEMENT_REF = "#/\$defs/typeElement"
+
+        private val typeElementRef: JsonObject = buildJsonObject {
+            put("\$ref", TYPE_ELEMENT_REF)
+        }
+
+        private val typeElement: JsonObject = SchemaBuilder.tool()
+            .stringProperty("name", "Type name.", required = true)
+            .stringProperty("file", "Project-relative file path for this type, when available.", required = true, nullable = true)
+            .stringProperty("kind", "Type kind, such as class, interface, enum, or trait.", required = true)
+            .stringProperty("language", "Programming language for this type, when known.", required = true, nullable = true)
+            .arrayProperty("supertypes", "Direct or recursive supertypes for this type.", items = typeElementRef, required = true, nullable = true)
+            .build()
+
+        private fun JsonObject.withTypeElementDefinition(): JsonObject = buildJsonObject {
+            for ((key, value) in this@withTypeElementDefinition) {
+                put(key, value)
+            }
+            put("\$defs", buildJsonObject {
+                put("typeElement", typeElement)
+            })
+        }
+    }
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         requireSmartMode(project)
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/BuildProjectTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/BuildProjectTool.kt
@@ -9,6 +9,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.BuildMessage
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.BuildProjectResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.BuildListenerUtils
 import com.intellij.ide.trustedProjects.TrustedProjects
 import com.intellij.openapi.Disposable
@@ -61,6 +62,40 @@ class BuildProjectTool : AbstractMcpTool() {
         .booleanProperty(ParamNames.REBUILD, "Full rebuild instead of incremental build. Default: false.")
         .booleanProperty(ParamNames.INCLUDE_RAW_OUTPUT, "Include raw build output log in response. Default: false.")
         .intProperty(ParamNames.TIMEOUT_SECONDS, "Timeout in seconds. Must be a positive integer. No timeout if omitted.")
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("success", "Whether the build completed without errors.", required = true)
+        .booleanProperty("aborted", "Whether the build was aborted before completion.", required = true)
+        .intProperty("errors", "Number of build errors, when known.", required = true, nullable = true)
+        .intProperty("warnings", "Number of build warnings, when known.", required = true, nullable = true)
+        .arrayProperty(
+            "buildMessages", "Structured build diagnostics emitted by the build.", SchemaBuilder.tool()
+                .stringProperty("category", "Build message category, such as ERROR or WARNING.", required = true)
+                .stringProperty("message", "Build diagnostic text.", required = true)
+                .stringProperty(
+                    "file",
+                    "Project-relative file path for the build message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "line",
+                    "1-based line number for the build message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "column",
+                    "1-based column number for the build message, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true
+        )
+        .booleanProperty("truncated", "Whether build messages or raw output were truncated.", required = true)
+        .stringProperty("rawOutput", "Raw build output log, when requested.", required = true, nullable = true)
+        .intProperty("durationMs", "Build duration in milliseconds.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetIndexStatusTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetIndexStatusTool.kt
@@ -29,6 +29,17 @@ class GetIndexStatusTool : AbstractMcpTool() {
         .projectPath()
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("isDumbMode", "Whether the IDE is currently in dumb mode.", required = true)
+        .booleanProperty("isIndexing", "Whether indexing is currently active.", required = true)
+        .numberProperty(
+            "indexingProgress",
+            "Indexing progress from 0.0 to 1.0, when available.",
+            required = true,
+            nullable = true
+        )
+        .build()
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val dumbService = DumbService.getInstance(project)
         val isDumb = dumbService.isDumb

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/SyncFilesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/SyncFilesTool.kt
@@ -10,11 +10,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonObject
 
 class SyncFilesTool : AbstractMcpTool() {
 
@@ -31,13 +28,16 @@ class SyncFilesTool : AbstractMcpTool() {
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()
         .projectPath()
-        .property("paths", buildJsonObject {
-            put("type", "array")
-            putJsonObject("items") {
-                put("type", "string")
-            }
-            put("description", "File or directory paths relative to project root to sync. If omitted, syncs the entire project.")
-        })
+        .stringArrayProperty(
+            "paths",
+            "File or directory paths relative to project root to sync. If omitted, syncs the entire project."
+        )
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .stringArrayProperty("syncedPaths", "Project-relative paths that were synchronized.", required = true)
+        .booleanProperty("syncedAll", "Whether the entire project was synchronized.", required = true)
+        .stringProperty("message", "Human-readable synchronization status message.", required = true)
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
@@ -2,6 +2,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -105,13 +106,53 @@ class ConvertJavaToKotlinTool : AbstractRefactoringTool() {
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()
         .projectPath()
-        .property("files", buildJsonObject {
-            put("type", "array")
-            putJsonObject("items") {
-                put("type", "string")
-            }
-            put("description", "Java files to convert (relative to project root).")
-        }, required = true)
+        .stringArrayProperty("files", "Java files to convert (relative to project root).", required = true)
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .arrayProperty(
+            "files", "Per-file Java to Kotlin conversion results.", SchemaBuilder.tool()
+                .stringProperty("requestedPath", "Requested Java file path.", required = true)
+                .enumProperty(
+                    "status",
+                    "Conversion status for the requested file.",
+                    values = listOf("CONVERTED", "SKIPPED", "FAILED"),
+                    required = true
+                )
+                .stringProperty(
+                    "kotlinFile",
+                    "Generated Kotlin file path, when conversion succeeded.",
+                    required = true,
+                    nullable = true
+                )
+                .intProperty(
+                    "linesConverted",
+                    "Number of source lines converted, when available.",
+                    required = true,
+                    nullable = true
+                )
+                .booleanProperty(
+                    "javaFileDeleted",
+                    "Whether the original Java file was deleted, when applicable.",
+                    required = true,
+                    nullable = true
+                )
+                .stringProperty(
+                    "reason",
+                    "Reason the file was skipped or failed, when applicable.",
+                    required = true,
+                    nullable = true
+                )
+                .build(), required = true
+        )
+        .property(
+            "summary", SchemaBuilder.tool()
+                .intProperty("totalRequested", "Total number of requested Java files.", required = true)
+                .intProperty("converted", "Number of files converted successfully.", required = true)
+                .intProperty("skipped", "Number of files skipped.", required = true)
+                .intProperty("failed", "Number of files that failed conversion.", required = true)
+                .build(), required = true
+        )
         .build()
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -75,6 +75,13 @@ open class MoveFileTool : AbstractRefactoringTool() {
         .stringProperty("destination", "Target directory path relative to project root. The file will be moved into this directory. Created automatically if it doesn't exist. REQUIRED.", required = true)
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("success", "Whether the refactoring completed successfully.", required = true)
+        .stringArrayProperty("affectedFiles", "Project-relative files affected by the refactoring.", required = true)
+        .intProperty("changesCount", "Number of files or references changed by the refactoring.", required = true)
+        .stringProperty("message", "Human-readable refactoring status message.", required = true)
+        .build()
+
     internal enum class MoveBackend {
         GENERIC_FILE_MOVE,
         PHP_SEMANTIC_MOVE

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -46,6 +46,17 @@ class OptimizeImportsTool : AbstractMcpTool() {
         .file()
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("success", "Whether import optimization completed successfully.", required = true)
+        .stringArrayProperty(
+            "affectedFiles",
+            "Project-relative files affected by import optimization.",
+            required = true
+        )
+        .intProperty("changesCount", "Number of files changed by import optimization.", required = true)
+        .stringProperty("message", "Human-readable import optimization status message.", required = true)
+        .build()
+
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val file = requiredStringArg(arguments, ParamNames.FILE).getOrElse {
             return createErrorResult(it.message ?: "Missing required parameter: file")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -66,6 +66,13 @@ class ReformatCodeTool : AbstractMcpTool() {
         .booleanProperty(ParamNames.REARRANGE_CODE, "Rearrange code members according to arrangement rules. Default: true.")
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("success", "Whether code reformatting completed successfully.", required = true)
+        .stringArrayProperty("affectedFiles", "Project-relative files affected by code reformatting.", required = true)
+        .intProperty("changesCount", "Number of files changed by code reformatting.", required = true)
+        .stringProperty("message", "Human-readable reformatting status message.", required = true)
+        .build()
+
     /**
      * Data class holding validated reformat parameters from Phase 1.
      */

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -98,6 +98,13 @@ class RenameSymbolTool : AbstractMcpTool() {
         )
         .build()
 
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("success", "Whether the rename completed successfully.", required = true)
+        .stringArrayProperty("affectedFiles", "Project-relative files affected by the rename.", required = true)
+        .intProperty("changesCount", "Number of files or references changed by the rename.", required = true)
+        .stringProperty("message", "Human-readable rename status message.", required = true)
+        .build()
+
     /**
      * Data class holding validated rename parameters from Phase 1.
      */

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.ToolResultSchemas
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.command.WriteCommandAction
@@ -78,6 +79,49 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             put("default", false)
             put("description", "Force deletion even if usages exist. Default: false. Use with caution!")
         })
+        .build()
+
+    override val outputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("success", "Whether safe delete completed successfully.")
+        .stringArrayProperty("affectedFiles", "Project-relative files affected by safe delete.")
+        .intProperty("changesCount", "Number of files or references changed by safe delete.")
+        .stringProperty("message", "Human-readable safe delete status message.")
+        .booleanProperty("canDelete", "Whether the target can be deleted without forcing.")
+        .stringProperty("elementName", "Name of the symbol considered for deletion.")
+        .stringProperty("elementType", "Kind of symbol considered for deletion.")
+        .intProperty("usageCount", "Number of usages blocking symbol deletion.")
+        .stringProperty("fileName", "Name of the file considered for deletion.")
+        .intProperty("symbolCount", "Number of symbols found in the file.")
+        .intProperty("externalUsageCount", "Number of external usages blocking file deletion.")
+        .arrayProperty(
+            "blockingUsages", "Usages that prevent safe deletion.", items = SchemaBuilder.tool()
+                .stringProperty("file", "Project-relative file path containing the usage.", required = true)
+                .intProperty("line", "1-based line number of the usage.", required = true)
+                .intProperty("column", "1-based column number of the usage.", required = true)
+                .stringProperty("context", "Source context surrounding the usage.", required = true)
+                .build()
+        )
+        .stringProperty("error", "Error explaining why no target symbol could be deleted.")
+        .property(
+            "position",
+            SchemaBuilder.tool()
+                .intProperty("line", "1-based requested line number.", required = true)
+                .intProperty("column", "1-based requested column number.", required = true)
+                .stringProperty("elementType", "PSI element type at the requested position.", required = true)
+                .build()
+        )
+        .arrayProperty(
+            "suggestions",
+            "Nearby symbols that may be valid safe delete targets.",
+            items = SchemaBuilder.tool()
+                .stringProperty("name", "Suggested symbol name.", required = true)
+                .stringProperty("type", "Suggested symbol type.", required = true)
+                .intProperty("line", "1-based line number of the suggested symbol.", required = true)
+                .intProperty("column", "1-based column number of the suggested symbol.", required = true)
+                .intProperty("distance", "Distance from the requested position.", required = true)
+                .build()
+        )
+        .stringProperty("hint", "Hint for selecting a valid symbol position.")
         .build()
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/SchemaBuilder.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/SchemaBuilder.kt
@@ -5,6 +5,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
 import kotlinx.serialization.json.*
+import kotlinx.serialization.json.put
 
 class SchemaBuilder private constructor() {
     private val properties = linkedMapOf<String, JsonObject>()
@@ -67,38 +68,101 @@ class SchemaBuilder private constructor() {
         }
     }
 
-    fun stringProperty(name: String, description: String, required: Boolean = false) = apply {
+    fun stringProperty(
+        name: String,
+        description: String,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) = apply {
+        properties[name] = typedSchema(SchemaConstants.TYPE_STRING, description, nullable)
+        if (required) requiredFields.add(name)
+    }
+
+    fun stringProperty(name: String, description: String, required: Boolean) =
+        stringProperty(name, description, required, nullable = false)
+
+    fun intProperty(
+        name: String,
+        description: String,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) = apply {
+        properties[name] = typedSchema(SchemaConstants.TYPE_INTEGER, description, nullable)
+        if (required) requiredFields.add(name)
+    }
+
+    fun intProperty(name: String, description: String, required: Boolean) =
+        intProperty(name, description, required, nullable = false)
+
+    fun numberProperty(
+        name: String,
+        description: String,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) = apply {
+        properties[name] = typedSchema("number", description, nullable)
+        if (required) requiredFields.add(name)
+    }
+
+    fun booleanProperty(
+        name: String,
+        description: String,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) = apply {
+        properties[name] = typedSchema(SchemaConstants.TYPE_BOOLEAN, description, nullable)
+        if (required) requiredFields.add(name)
+    }
+
+    fun booleanProperty(name: String, description: String, required: Boolean) =
+        booleanProperty(name, description, required, nullable = false)
+
+    fun enumProperty(
+        name: String,
+        description: String,
+        values: List<String>,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) = apply {
         properties[name] = buildJsonObject {
+            putType(SchemaConstants.TYPE_STRING, nullable)
+            put(SchemaConstants.DESCRIPTION, description)
+            putJsonArray("enum") {
+                values.forEach { add(JsonPrimitive(it)) }
+                if (nullable) add(JsonNull)
+            }
+        }
+        if (required) requiredFields.add(name)
+    }
+
+    fun enumProperty(name: String, description: String, values: List<String>, required: Boolean) =
+        enumProperty(name, description, values, required, nullable = false)
+
+    fun arrayProperty(
+        name: String,
+        description: String,
+        items: JsonObject,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) = apply {
+        properties[name] = buildJsonObject {
+            putType(SchemaConstants.TYPE_ARRAY, nullable)
+            put(SchemaConstants.DESCRIPTION, description)
+            put("items", items)
+        }
+        if (required) requiredFields.add(name)
+    }
+
+    fun stringArrayProperty(
+        name: String,
+        description: String,
+        required: Boolean = false,
+        nullable: Boolean = false
+    ) =
+        arrayProperty(name, description, items = buildJsonObject {
             put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
-            put(SchemaConstants.DESCRIPTION, description)
-        }
-        if (required) requiredFields.add(name)
-    }
+        }, required = required, nullable = nullable)
 
-    fun intProperty(name: String, description: String, required: Boolean = false) = apply {
-        properties[name] = buildJsonObject {
-            put(SchemaConstants.TYPE, SchemaConstants.TYPE_INTEGER)
-            put(SchemaConstants.DESCRIPTION, description)
-        }
-        if (required) requiredFields.add(name)
-    }
-
-    fun booleanProperty(name: String, description: String, required: Boolean = false) = apply {
-        properties[name] = buildJsonObject {
-            put(SchemaConstants.TYPE, SchemaConstants.TYPE_BOOLEAN)
-            put(SchemaConstants.DESCRIPTION, description)
-        }
-        if (required) requiredFields.add(name)
-    }
-
-    fun enumProperty(name: String, description: String, values: List<String>, required: Boolean = false) = apply {
-        properties[name] = buildJsonObject {
-            put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
-            put(SchemaConstants.DESCRIPTION, description)
-            putJsonArray("enum") { values.forEach { add(JsonPrimitive(it)) } }
-        }
-        if (required) requiredFields.add(name)
-    }
 
     fun scopeProperty(description: String, required: Boolean = false) = apply {
         enumProperty(
@@ -109,10 +173,13 @@ class SchemaBuilder private constructor() {
         )
     }
 
-    fun property(name: String, schema: JsonObject, required: Boolean = false) = apply {
-        properties[name] = schema
+    fun property(name: String, schema: JsonObject, required: Boolean = false, nullable: Boolean = false) = apply {
+        properties[name] = if (nullable) schema.withNullableType() else schema
         if (required) requiredFields.add(name)
     }
+
+    fun property(name: String, schema: JsonObject, required: Boolean) =
+        property(name, schema, required, nullable = false)
 
     fun build(): JsonObject = buildJsonObject {
         put(SchemaConstants.TYPE, SchemaConstants.TYPE_OBJECT)
@@ -134,3 +201,33 @@ class SchemaBuilder private constructor() {
         fun tool() = SchemaBuilder()
     }
 }
+
+private fun typedSchema(type: String, description: String, nullable: Boolean = false): JsonObject = buildJsonObject {
+    putType(type, nullable)
+    put(SchemaConstants.DESCRIPTION, description)
+}
+
+private fun JsonObject.withNullableType(): JsonObject = buildJsonObject {
+    for ((key, value) in this@withNullableType) {
+        if (key == SchemaConstants.TYPE && value is JsonPrimitive && value.isString) {
+            putJsonArray(SchemaConstants.TYPE) {
+                add(value)
+                add(JsonPrimitive("null"))
+            }
+        } else {
+            put(key, value)
+        }
+    }
+}
+
+private fun JsonObjectBuilder.putType(type: String, nullable: Boolean) {
+    if (nullable) {
+        putJsonArray(SchemaConstants.TYPE) {
+            add(JsonPrimitive(type))
+            add(JsonPrimitive("null"))
+        }
+    } else {
+        put(SchemaConstants.TYPE, type)
+    }
+}
+

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/ToolResultSchemas.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/ToolResultSchemas.kt
@@ -1,0 +1,33 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema
+
+import kotlinx.serialization.json.JsonObject
+
+object ToolResultSchemas {
+
+    val symbolMatch: JsonObject = SchemaBuilder.tool()
+        .stringProperty("name", "Symbol display name.", required = true)
+        .stringProperty(
+            "qualifiedName",
+            "Fully qualified symbol name, when available.",
+            required = true,
+            nullable = true
+        )
+        .stringProperty("kind", "Symbol kind, such as class, method, field, or function.", required = true)
+        .stringProperty("file", "Project-relative file path containing the symbol.", required = true)
+        .intProperty("line", "1-based line number of the symbol.", required = true)
+        .intProperty("column", "1-based column number of the symbol.", required = true)
+        .stringProperty(
+            "containerName",
+            "Containing class, object, or namespace name, when available.",
+            required = true,
+            nullable = true
+        )
+        .stringProperty(
+            "language",
+            "Programming language for the symbol, when known.",
+            required = true,
+            nullable = true
+        )
+        .build()
+
+}

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -87,6 +87,8 @@ settings.responseFormat.tooltip=<html>Controls the format used for structured MC
 The JSON-RPC transport envelope stays JSON in both modes.</html>
 settings.responseFormat.json=JSON (default)
 settings.responseFormat.toon=TOON
+settings.toolsOutputOutputSchema=Tools Result Output Output Schema
+settings.toolsOutputOutputSchema.tooltip=<html>When enabled, the output of tool definitions will include the output schema.</html>
 settings.syncExternalChanges=Sync external file changes before operations
 settings.syncExternalChanges.warning=WARNING: This option significantly slows down every operation. Only enable if absolutely necessary.
 settings.syncExternalChanges.tooltip=<html><b style="color:red;">WARNING: SIGNIFICANT PERFORMANCE IMPACT</b><br><br>\

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/models/McpModelsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/models/McpModelsUnitTest.kt
@@ -109,7 +109,8 @@ class McpModelsUnitTest : TestCase() {
         val definition = ToolDefinition(
             name = "test_tool",
             description = "A test tool",
-            inputSchema = schema
+            inputSchema = schema,
+            outputSchema = schema
         )
 
         val serialized = json.encodeToString(definition)
@@ -118,6 +119,22 @@ class McpModelsUnitTest : TestCase() {
         assertEquals("test_tool", deserialized.name)
         assertEquals("A test tool", deserialized.description)
         assertNotNull(deserialized.inputSchema)
+        assertNotNull(deserialized.outputSchema)
+        assertTrue(serialized.contains("\"outputSchema\""))
+    }
+
+    fun testToolDefinitionOmitsMissingOutputSchema() {
+        val schema = buildJsonObject { put("type", "object") }
+
+        val serialized = json.encodeToString(
+            ToolDefinition(
+                name = "test_tool",
+                description = "A test tool",
+                inputSchema = schema
+            )
+        )
+
+        assertFalse(serialized.contains("\"outputSchema\""))
     }
 
     // ServerInfo tests

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
@@ -770,6 +770,9 @@ class ToolsTest : BasePlatformTestCase() {
 
             assertNotNull("Definition should have inputSchema", definition.inputSchema)
             assertEquals(SchemaConstants.TYPE_OBJECT, definition.inputSchema[SchemaConstants.TYPE]?.jsonPrimitive?.content)
+
+            assertNotNull("Definition should have outputSchema", definition.outputSchema)
+            assertEquals(SchemaConstants.TYPE_OBJECT, definition.outputSchema?.get(SchemaConstants.TYPE)?.jsonPrimitive?.content)
         }
     }
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -16,11 +16,13 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindImple
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSuperMethodsTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSymbolTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.ReadFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.SyncFilesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ConvertJavaToKotlinTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.MoveFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.OptimizeImportsTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ReformatCodeTool
@@ -38,6 +40,40 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class ToolsUnitTest : TestCase() {
+    fun testAllKnownToolsHaveOutputSchemas() {
+        val tools = listOf(
+            BuildProjectTool(),
+            CallHierarchyTool(),
+            ConvertJavaToKotlinTool(),
+            GetDiagnosticsTool(),
+            FileStructureTool(),
+            FindClassTool(),
+            FindDefinitionTool(),
+            FindFileTool(),
+            FindImplementationsTool(),
+            FindUsagesTool(),
+            FindSuperMethodsTool(),
+            FindSymbolTool(),
+            GetActiveFileTool(),
+            GetIndexStatusTool(),
+            MoveFileTool(),
+            OpenFileTool(),
+            OptimizeImportsTool(),
+            ReadFileTool(),
+            RenameSymbolTool(),
+            SafeDeleteTool(),
+            ReformatCodeTool(),
+            SearchTextTool(),
+            SyncFilesTool(),
+            TypeHierarchyTool()
+        )
+
+        assertEquals(ToolNames.ALL.sorted(), tools.map { it.name }.sorted())
+        tools.forEach { tool ->
+            assertNotNull("${tool.name} should have outputSchema", tool.outputSchema)
+        }
+    }
+
     private fun assertHasScopeAndNoLegacyFilters(properties: kotlinx.serialization.json.JsonObject?) {
         val scopeProperty = properties?.get(ParamNames.SCOPE)?.jsonObject
         assertNotNull("Should have scope property", scopeProperty)
@@ -193,6 +229,20 @@ class ToolsUnitTest : TestCase() {
         assertNotNull("Should have column property", properties?.get(ParamNames.COLUMN))
         assertNotNull("Should have className property", properties?.get(ParamNames.CLASS_NAME))
         assertHasScopeAndNoLegacyFilters(properties)
+
+        val outputSchema = tool.outputSchema!!
+        val typeElementRef = "#/\$defs/typeElement"
+        val outputProperties = outputSchema[SchemaConstants.PROPERTIES]?.jsonObject!!
+        assertEquals(typeElementRef, outputProperties["element"]?.jsonObject?.get("\$ref")?.jsonPrimitive?.content)
+        assertEquals(typeElementRef, outputProperties["supertypes"]?.jsonObject?.get("items")?.jsonObject?.get("\$ref")?.jsonPrimitive?.content)
+        assertEquals(typeElementRef, outputProperties["subtypes"]?.jsonObject?.get("items")?.jsonObject?.get("\$ref")?.jsonPrimitive?.content)
+
+        val typeElement = outputSchema["\$defs"]?.jsonObject?.get("typeElement")?.jsonObject!!
+        val supertypes = typeElement[SchemaConstants.PROPERTIES]?.jsonObject?.get("supertypes")?.jsonObject!!
+        assertEquals(
+            typeElementRef,
+            supertypes["items"]?.jsonObject?.get("\$ref")?.jsonPrimitive?.content
+        )
     }
 
     fun testCallHierarchyToolSchema() {
@@ -211,6 +261,19 @@ class ToolsUnitTest : TestCase() {
         assertNotNull("Should have language property", properties?.get(ParamNames.LANGUAGE))
         assertNotNull("Should have symbol property", properties?.get(ParamNames.SYMBOL))
         assertHasScopeAndNoLegacyFilters(properties)
+
+        val outputSchema = tool.outputSchema!!
+        val callElementRef = "#/\$defs/callElement"
+        val outputProperties = outputSchema[SchemaConstants.PROPERTIES]?.jsonObject!!
+        assertEquals(callElementRef, outputProperties["element"]?.jsonObject?.get("\$ref")?.jsonPrimitive?.content)
+        assertEquals(callElementRef, outputProperties["calls"]?.jsonObject?.get("items")?.jsonObject?.get("\$ref")?.jsonPrimitive?.content)
+
+        val callElement = outputSchema["\$defs"]?.jsonObject?.get("callElement")?.jsonObject!!
+        val children = callElement[SchemaConstants.PROPERTIES]?.jsonObject?.get("children")?.jsonObject!!
+        assertEquals(
+            callElementRef,
+            children["items"]?.jsonObject?.get("\$ref")?.jsonPrimitive?.content
+        )
     }
 
     fun testFindImplementationsToolSchema() {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/SchemaBuilderUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/SchemaBuilderUnitTest.kt
@@ -100,6 +100,24 @@ class SchemaBuilderUnitTest : TestCase() {
         assertEquals(SchemaConstants.TYPE_BOOLEAN, prop[SchemaConstants.TYPE]?.jsonPrimitive?.content)
     }
 
+    fun testNullableProperty() {
+        val schema = SchemaBuilder.tool()
+            .stringProperty("message", "Nullable message.", required = true, nullable = true)
+            .build()
+
+        val properties = schema[SchemaConstants.PROPERTIES]?.jsonObject!!
+        val typeValues = properties["message"]
+            ?.jsonObject
+            ?.get(SchemaConstants.TYPE)
+            ?.jsonArray
+            ?.map { it.jsonPrimitive.content }
+
+        assertEquals(listOf(SchemaConstants.TYPE_STRING, "null"), typeValues)
+
+        val required = schema[SchemaConstants.REQUIRED]?.jsonArray?.map { it.jsonPrimitive.content }!!
+        assertTrue("nullable property should still be required when requested", required.contains("message"))
+    }
+
     fun testProjectPathNotRequired() {
         val schema = SchemaBuilder.tool()
             .projectPath()


### PR DESCRIPTION
### Description

The property is described at https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema

This is added mainly to work with other mcp tooling such as cloudflare code mode or alternatives such as [pctx](https://github.com/portofcontext/pctx)

Also add an option to toggle this (and default to turned off) to preserve current behavior.

### AI Disclosure

The output schemas are created by Codex and proofread by me.