### PR TITLE
Add project lifecycle management (ACTIVE/BACKGROUND/DORMANT/CLOSED)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp
 .claude
 local.properties
 docs/superpowers
+.idea/
+scripts/build-install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added — Project lifecycle management
+
+Automatic sleep/wake management for IntelliJ projects used as MCP servers. When multiple
+projects are open simultaneously, idle ones consume memory unnecessarily and leave editors
+open for no reason. Lifecycle management addresses this with a four-state machine driven
+by window focus and MCP activity.
+
+**States:** `active` (full IDE, Power Save off) → `background` (Power Save on, MCP
+functional) → `dormant` (editors closed, PSI caches freed, index retained) → `closed`
+(project fully closed). Projects enroll automatically on first MCP use and auto-reopen
+transparently when an MCP tool targets a closed project — callers see normal results
+after a short indexing delay, with no changes required in existing tools.
+
+- **`ide_set_project_mode`** — explicitly set a managed project's lifecycle mode (`active`, `background`, `dormant`, `closed`).
+- **`ide_get_project_modes`** — list all MCP-managed projects and their current modes, including those we closed.
+- **`ide_project_status`** — combined snapshot: every open project and every managed project in one table, with open/managed/mode per row.
+- **`ide_release_project`** — unenroll a project, restoring full IDE behaviour and disabling Power Save Mode. Accepts an optional `path` argument to release a closed managed project without needing it to be open.
+- **`ide_set_all_project_modes`** — set all managed projects to the same mode at once (active, background, or dormant).
+- **`ide_enroll_all_projects`** — enroll every currently open project in lifecycle management at once; already-managed projects are skipped.
+- **`ide_release_all_projects`** — release every managed project (including closed ones) from lifecycle management at once.
+- **`ide_set_lifecycle_log_file`** — enable or disable writing lifecycle events to the persistent log file on disk (`mcp-lifecycle.log`, written alongside `idea.log`). The in-memory ring buffer is always active regardless. *(disabled by default)*
+- **Lifecycle settings** — configurable timing thresholds (focus→background, background→dormant, dormant→closed) and a master enable/disable toggle in Settings → Index MCP Server.
+- **Interactive project list in Settings** — the lifecycle settings panel now shows all known projects (open and closed managed) with a checkbox per project (checked = enrolled), an X button to release individual projects, and "Enroll All Open" / "Release All" buttons. Changes take effect immediately without clicking Apply.
+- **"MCP: Open Project" action** — searchable popup (Cmd+Shift+A) listing managed projects by state; selecting one opens or wakes it.
+- **"MCP: Show Project States" action** — opens the lifecycle settings panel from the keyboard.
+
+**Enrollment on semantic use, not on open/close** — `ide_open_project` and `ide_close_project` are infrastructure tools and do not trigger lifecycle enrollment. Enrollment happens on the first real semantic tool call (find references, diagnostics, refactoring, etc.) after a project is open.
+
+**MCP availability guarantee** — the lifecycle manager never closes the last open managed project. When only one managed project remains open and its close timer fires, it is kept in `dormant` state instead.
+
+See `docs/lifecycle-management.md` for design rationale, API notes, and threading details.
+
+### Added — Lifecycle event log
+
+- **`ide_lifecycle_log`** — query recent lifecycle events from an in-memory ring buffer. Records every state transition, project open/close, focus change, timer firing, and MCP-triggered wake for all IntelliJ projects (not just managed ones). Each event includes a `trigger` field that identifies the cause: `timer:focus`, `timer:inactivity`, `timer:close`, `focus_gained`, `focus_lost`, `mcp_call`, `auto_open`, or `user`. Parameters: `limit` (default 50), `project` (path substring filter). Response includes `log_file` — the path to a persistent log file. No restart required.
+- **Event log buffer size** — configurable in Settings → Index MCP Server → Lifecycle (default 500, range 100–10,000).
+
+See `docs/lifecycle-log.md` for design rationale and the trigger taxonomy.
+
+### Fixed
+- `IndexNotReadyException` from `ide_diagnostics` and other tools now logged at DEBUG instead of ERROR when the IDE index is not ready.
+- Rethrow `ProcessCanceledException` instead of logging as ERROR when a project is disposed mid-call.
+- MCP server watchdog restarts the server if it stops unexpectedly between tool calls.
+- Detect compiled elements before rename to avoid assertion crash in `ide_refactor_rename`.
 
 ## [4.22.0] - 2026-06-12
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,5 +542,19 @@ Only update `pluginVersion` in `gradle.properties` when the user explicitly asks
 
 ---
 
+## Smoke Test Protocol
+
+After any `./gradlew buildPlugin` → install → restart cycle, offer to run the smoke
+test at `docs/smoke-test-protocol.md`. It covers HTTP-level behaviour, tool registration,
+and end-to-end paths that the automated test suite cannot catch.
+
+**Offer the smoke test when changes touch:** HTTP transport (`KtorMcpServer.kt`,
+`JsonRpcHandler.kt`), tool registration (`ToolRegistry.kt`, `McpServerService.kt`),
+or any tool covered by the protocol.
+
+**Skip for:** documentation-only, test-only, or `gradle.properties` version-bump changes.
+
+---
+
 **Template Source**: [JetBrains IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
 - Never run platform tests on your own

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ These tools activate based on installed language plugins:
 - **Safe Delete** - Remove code with usage checking (Java/Kotlin only)
 - **Java to Kotlin Conversion** - Convert Java to Kotlin using Intellij's built-in converter (Java only)
 
+**Project Lifecycle Management**
+
+When working across many projects simultaneously, idle ones consume memory unnecessarily and leave editors open for no reason. Lifecycle management automatically sleeps and wakes projects based on window focus and MCP activity — no configuration required.
+
+- **Automatic sleep/wake** - Projects move from active → background (Power Save on) → dormant (editors closed, PSI cache freed) → closed (fully unloaded), and auto-reopen transparently on the next MCP call
+- **`ide_project_status`** - Combined snapshot of every open and managed project
+- **`ide_set_project_mode`** / **`ide_get_project_modes`** - Explicit mode control
+- **`ide_release_project`** - Unenroll a project from lifecycle management
+- **`ide_lifecycle_log`** - Timestamped event log with trigger reasons, for diagnosing unexpected behaviour. The ring buffer is always active; file output enables via Help → Diagnostic Tools → Debug Log Settings
+
 ### Why Use This Plugin?
 
 Unlike simple text-based code analysis, this plugin gives AI assistants access to:
@@ -74,6 +84,7 @@ Perfect for AI-assisted development workflows where accuracy and safety matter.
 - [Client Configuration](#client-configuration)
 - [Available Tools](#available-tools)
 - [Multi-Project Support](#multi-project-support)
+- [Lifecycle Management](#lifecycle-management)
 - [Tool Window](#tool-window)
 - [Error Codes](#error-codes)
 - [Requirements](#requirements)
@@ -225,7 +236,7 @@ Each JetBrains IDE has a unique default port and server name to allow running mu
 
 ## Available Tools
 
-The plugin provides **21 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
+The plugin provides **38 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
 
 ### Universal Tools
 
@@ -277,6 +288,34 @@ PHP file structure support requires the PHP plugin and is available in PhpStorm 
 | `ide_refactor_safe_delete` | Safely delete an element, checking for usages first (Java/Kotlin only) |
 
 > **Note**: Refactoring tools modify source files. All changes support undo via <kbd>Ctrl/Cmd+Z</kbd>.
+
+### Project Lifecycle Management Tools
+
+`ide_project_status` is enabled by default. All other lifecycle tools are disabled by default — enable them in Settings → Tools → Index MCP Server.
+
+| Tool | Description | Default |
+|------|-------------|---------|
+| `ide_project_status` | Combined snapshot: every open project and every managed project with open/managed/mode per row | Enabled |
+| `ide_set_project_mode` | Set a project's lifecycle mode: `active`, `background`, `dormant`, or `closed` | Disabled |
+| `ide_get_project_modes` | List all managed projects and their current modes, including closed ones | Disabled |
+| `ide_set_all_project_modes` | Set all managed projects to the same mode at once (active/background/dormant) | Disabled |
+| `ide_enroll_all_projects` | Enroll every currently open project in lifecycle management | Disabled |
+| `ide_release_project` | Unenroll a project from lifecycle management | Disabled |
+| `ide_release_all_projects` | Release every managed project (including closed ones) from lifecycle management | Disabled |
+| `ide_lifecycle_log` | Query recent lifecycle events from a ring buffer; each event has a `trigger` field explaining the cause | Disabled |
+
+**Lifecycle modes** — transitions are automatic, driven by window focus and MCP activity:
+
+| Mode | Power Save | Editors | PSI Cache | Auto-transition |
+|------|-----------|---------|-----------|-----------------|
+| `active` | off | open | loaded | focus lost for N min → background |
+| `background` | on | open | loaded | N min idle → dormant |
+| `dormant` | on | closed | freed | N min idle → closed |
+| `closed` | — | — | freed | next MCP call → background (auto-reopens) |
+
+Timing thresholds are configurable in Settings. Projects enroll automatically on first MCP use and auto-reopen when an MCP tool targets a closed project — existing tools require no changes.
+
+**MCP availability guarantee:** the lifecycle manager never closes the last open managed project — it stays in `dormant` (memory mostly freed, MCP still reachable). If all projects are somehow closed (e.g., the user manually closes the last window), any MCP tool call without a `project_path` automatically reopens a managed-closed project to restore access.
 
 ### Tool Availability by IDE
 
@@ -334,6 +373,25 @@ The plugin supports **workspace projects** where a single IDE window contains mu
 
 When an error occurs, the response returns `available_projects`. By default this includes workspace sub-projects so AI agents can discover valid module content roots. If you want smaller error payloads, switch **Project list in error responses** to **Compact** in plugin settings to return only top-level project roots.
 
+## Lifecycle Management
+
+When you use the plugin across multiple projects simultaneously — common when an AI agent is working across a monorepo — open projects compete for memory even when they're not being actively used. Lifecycle management handles this automatically.
+
+Projects enroll on their first MCP tool call and are notified via balloon. From that point, transitions happen based on focus and MCP activity:
+
+1. **Focus lost** → after 2 minutes, Power Save Mode on (`background`)
+2. **No MCP calls** → after 2 more minutes, editors close and PSI cache is freed (`dormant`)
+3. **Still idle** → after 10 minutes, project window closes entirely (`closed`)
+4. **Next MCP call** → project reopens automatically, indexes, and responds normally
+
+No changes are needed in existing MCP tools — `ProjectResolver` handles the reopen transparently. The auto-reopen typically takes 5–15 seconds on first open; subsequent opens are faster.
+
+The lifecycle manager never closes the last open managed project: it stays dormant (memory mostly freed, MCP still reachable). If all projects are closed by other means, any tool call automatically reopens one managed project to restore MCP access.
+
+Use `ide_project_status` to see the current state of all projects at a glance, and `ide_lifecycle_log` to see what happened and why — useful when a project closed unexpectedly. Each log event has a `trigger` field: `timer:inactivity`, `timer:close`, `focus_gained`, `mcp_call`, `auto_open`, `user`, etc.
+
+Timing thresholds are configurable in Settings → Index MCP Server → Project Lifecycle Management.
+
 ## Tool Window
 
 The plugin adds an "Index MCP Server" tool window (bottom panel) that shows:
@@ -390,6 +448,12 @@ Configure the plugin at <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP 
 | Project List in Error Responses | Expanded | Controls `available_projects` detail for invalid/missing `project_path` errors. `Expanded` includes workspace sub-projects; `Compact` returns only top-level project roots |
 | Sync External Changes | false | Sync external file changes before operations (**WARNING: significant performance impact**) |
 | Disabled Tools | 7 tools | Per-tool enable/disable toggles. Some tools are disabled by default to keep the tool list focused |
+| **Lifecycle Management** | | |
+| Enable lifecycle management | true | Master toggle for the automatic sleep/wake state machine |
+| Active → Background (minutes) | 2 | Focus-loss grace period before switching to Power Save Mode |
+| Background → Dormant (minutes) | 2 | MCP-idle time before closing editors and freeing PSI caches |
+| Dormant → Closed (minutes) | 10 | Idle time before fully closing the project window |
+| Event log buffer size | 500 | How many events `ide_lifecycle_log` retains in memory (100–10,000) |
 
 ## Requirements
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -48,6 +48,26 @@ These tools activate based on available language plugins:
 | `ide_convert_java_to_kotlin` | Convert Java files to Kotlin using the IDE converter *(disabled by default)* |
 | `ide_refactor_safe_delete` | Safely delete with usage check |
 
+### Project Lifecycle Management Tools
+
+These tools work in all supported JetBrains IDEs and are enabled by default.
+
+| Tool | Description | Default |
+|------|-------------|---------|
+| `ide_project_status` | Combined view of all open and managed projects with mode per row | Enabled |
+| `ide_set_project_mode` | Set a project's lifecycle mode (active/background/dormant/closed) | Disabled |
+| `ide_get_project_modes` | List all managed projects and their current modes | Disabled |
+| `ide_set_all_project_modes` | Set all managed open projects to the same mode | Disabled |
+| `ide_enroll_all_projects` | Enroll all currently open projects in lifecycle management | Disabled |
+| `ide_release_project` | Remove a project from lifecycle management | Disabled |
+| `ide_release_all_projects` | Release all managed projects from lifecycle management at once | Disabled |
+| `ide_lifecycle_log` | Query recent lifecycle events with trigger reasons | Disabled |
+| `ide_set_power_save_mode` | Toggle Power Save Mode directly | Enabled |
+| `ide_close_project` | Close a project window | Enabled |
+| `ide_open_project` | Open a project by path and wait for indexing | Enabled |
+| `ide_install_plugin` | Install a plugin zip into the IDE | Enabled |
+| `ide_restart` | Restart the IDE | Enabled |
+
 ---
 
 ## Table of Contents
@@ -84,6 +104,20 @@ These tools activate based on available language plugins:
   - [ide_find_implementations](#ide_find_implementations)
   - [ide_find_super_methods](#ide_find_super_methods)
   - [ide_file_structure](#ide_file_structure)
+- [Project Lifecycle Management](#project-lifecycle-management)
+  - [ide_project_status](#ide_project_status)
+  - [ide_set_project_mode](#ide_set_project_mode)
+  - [ide_get_project_modes](#ide_get_project_modes)
+  - [ide_set_all_project_modes](#ide_set_all_project_modes)
+  - [ide_release_project](#ide_release_project)
+  - [ide_release_all_projects](#ide_release_all_projects)
+  - [ide_enroll_all_projects](#ide_enroll_all_projects)
+  - [ide_lifecycle_log](#ide_lifecycle_log)
+  - [ide_set_power_save_mode](#ide_set_power_save_mode)
+  - [ide_close_project](#ide_close_project)
+  - [ide_open_project](#ide_open_project)
+  - [ide_install_plugin](#ide_install_plugin)
+  - [ide_restart](#ide_restart)
 - [Java-Specific Refactoring Tools](#java-specific-refactoring-tools)
   - [ide_convert_java_to_kotlin](#ide_convert_java_to_kotlin)
   - [ide_refactor_safe_delete](#ide_refactor_safe_delete)
@@ -2078,3 +2112,260 @@ Before calling index-dependent tools, you can check the index status:
 ```
 
 If `isDumbMode` is `true`, wait and retry later.
+
+---
+
+## Project Lifecycle Management
+
+When working across multiple projects simultaneously, idle ones consume memory unnecessarily. Lifecycle management automatically sleeps and wakes projects based on window focus and MCP activity. Projects enroll on first MCP use and auto-reopen when targeted by an MCP call — existing tools require no changes.
+
+**Lifecycle modes:**
+
+| Mode | Power Save | Editors | PSI Cache | Memory |
+|------|-----------|---------|-----------|--------|
+| `active` | off | open | loaded | full |
+| `background` | on | open | loaded | reduced |
+| `dormant` | on | closed | released via GC | low |
+| `closed` | — | — | freed | none (auto-reopens on next MCP call) |
+
+---
+
+### ide_project_status
+
+Combined snapshot of every open project and every managed project.
+
+**Parameters:** `project_path` (optional routing hint)
+
+**Returns:** `projects` array (name, path, open, managed, mode per row) and `summary` object (total, open, managed, open_not_managed, managed_closed counts).
+
+```json
+{ "name": "ide_project_status", "arguments": {} }
+```
+
+---
+
+### ide_set_project_mode
+
+Set a project's lifecycle mode explicitly.
+
+**Parameters:**
+- `mode` (required): `active`, `background`, `dormant`, or `closed`
+- `project_path` (optional)
+
+```json
+{ "name": "ide_set_project_mode", "arguments": { "mode": "background" } }
+```
+
+Setting `closed` fully closes the project window. The project auto-reopens on the next MCP call targeting it.
+
+---
+
+### ide_get_project_modes
+
+List all managed projects and their current modes.
+
+**Parameters:** `project_path` (optional)
+
+**Returns:** `managed_projects` array (name, path, mode) and `total` count. Includes projects currently closed by the lifecycle manager.
+
+```json
+{ "name": "ide_get_project_modes", "arguments": {} }
+```
+
+---
+
+### ide_set_all_project_modes
+
+Set all currently open managed projects to the same mode at once.
+
+**Parameters:**
+- `mode` (required): `active`, `background`, or `dormant` — `closed` is not accepted (closing all projects would make MCP unreachable)
+- `project_path` (optional)
+
+```json
+{ "name": "ide_set_all_project_modes", "arguments": { "mode": "background" } }
+```
+
+---
+
+### ide_release_project
+
+Remove a project from lifecycle management, restoring full IDE behaviour (Power Save off, no auto-close).
+
+**Parameters:** `project_path` (optional)
+
+```json
+{ "name": "ide_release_project", "arguments": {} }
+```
+
+Calling on an unmanaged project succeeds with a "not managed" note — safe to call idempotently.
+
+Accepts an optional `path` parameter to release a closed managed project without needing it to be open.
+
+---
+
+### ide_release_all_projects
+
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+
+Release every managed project (including closed ones) from lifecycle management at once. Also disables Power Save Mode globally.
+
+**Parameters:** `project_path` (optional routing hint)
+
+```json
+{ "name": "ide_release_all_projects", "arguments": {} }
+```
+
+---
+
+### ide_enroll_all_projects
+
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+
+Enroll every currently open project in lifecycle management. Projects already managed are skipped.
+
+**Parameters:** `project_path` (optional routing hint)
+
+```json
+{ "name": "ide_enroll_all_projects", "arguments": {} }
+```
+
+---
+
+### ide_lifecycle_log
+
+Query recent lifecycle events from the in-memory ring buffer (default 500 entries, configurable in Settings).
+
+**Parameters:**
+- `limit` (optional, default 50): how many events to return, newest first
+- `project` (optional): path substring filter — only events for matching projects
+- `project_path` (optional): routing hint
+
+**Returns:** `events` array, `log_file` path (always), `buffered` count.
+
+```json
+{ "name": "ide_lifecycle_log", "arguments": { "limit": 20, "project": "engine" } }
+```
+
+**Event fields:** `timestamp`, `project`, `path`, `event`, `from` (mode), `to` (mode), `trigger`.
+
+**Trigger values:**
+
+| Trigger | Meaning |
+|---------|---------|
+| `focus_gained` | User switched to this project window |
+| `focus_lost` | User switched away; focus timer started |
+| `timer:focus` | Focus timer fired → background |
+| `timer:inactivity` | Inactivity timer fired → dormant |
+| `timer:close` | Dormant timer fired → closed |
+| `mcp_call` | MCP tool call triggered this |
+| `auto_open` | Lifecycle manager reopened a closed project |
+| `user` | User action in the IDE |
+
+**Enabling file output:** The ring buffer is always active. File writes (`mcp-lifecycle.log` in the IDE log directory) require either using `ide_set_lifecycle_log_file` (see below) or enabling IntelliJ debug logging. No restart needed. The file is readable directly even when no project is open.
+
+---
+
+### ide_set_lifecycle_log_file
+
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+
+Enable or disable writing lifecycle events to the persistent log file on disk (`mcp-lifecycle.log`, written alongside `idea.log`). The in-memory ring buffer queried by `ide_lifecycle_log` is always active regardless of this setting.
+
+Use this for tail -f monitoring or post-mortem analysis when no MCP connection is available.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `enabled` | boolean | Yes | `true` to start writing to the log file, `false` to stop |
+| `project_path` | string | No | Routing hint when multiple projects are open |
+
+**Example:**
+
+```json
+{
+  "name": "ide_set_lifecycle_log_file",
+  "arguments": {
+    "enabled": true
+  }
+}
+```
+
+**Example Response:**
+
+```
+Lifecycle log file enabled. Events are being written to: /Users/you/Library/Logs/JetBrains/IntelliJIdea2026.1/mcp-lifecycle.log
+```
+
+---
+
+### ide_set_power_save_mode
+
+Toggle Power Save Mode directly.
+
+**Parameters:**
+- `enabled` (required): `true` or `false`
+- `project_path` (optional)
+
+```json
+{ "name": "ide_set_power_save_mode", "arguments": { "enabled": true } }
+```
+
+Power Save Mode suspends background inspections and code analysis while leaving the index and all MCP operations fully functional.
+
+---
+
+### ide_close_project
+
+Close an open project window and free its memory.
+
+**Parameters:** `project_path` (optional — defaults to the active project)
+
+```json
+{ "name": "ide_close_project", "arguments": {} }
+```
+
+The project can be reopened via Recent Projects or `ide_open_project`.
+
+---
+
+### ide_open_project
+
+Open a project by filesystem path and block until indexing completes, so subsequent MCP tool calls succeed immediately.
+
+**Parameters:**
+- `path` (required): filesystem path of the project directory
+- `project_path` (optional): routing hint — requires at least one project already open
+
+```json
+{ "name": "ide_open_project", "arguments": { "path": "/Users/dev/myproject" } }
+```
+
+---
+
+### ide_install_plugin
+
+Install a plugin zip into the IDE, replacing any existing version. A restart is required to load the updated plugin.
+
+**Parameters:**
+- `path` (optional): explicit path to a `.zip` file. If omitted, auto-detects `build/distributions/*.zip` in the current project — useful when developing the plugin itself.
+- `project_path` (optional)
+
+```json
+{ "name": "ide_install_plugin", "arguments": {} }
+```
+
+Typical workflow: `./gradlew buildPlugin` → `ide_install_plugin` → `ide_restart`.
+
+---
+
+### ide_restart
+
+Restart the IDE. Terminates the MCP connection immediately — no further tool calls should be made after calling this.
+
+**Parameters:** `project_path` (optional)
+
+```json
+{ "name": "ide_restart", "arguments": {} }
+```

--- a/docs/lifecycle-log.md
+++ b/docs/lifecycle-log.md
@@ -1,0 +1,94 @@
+# Lifecycle Event Log (`ide_lifecycle_log`)
+
+Adds a new tool and backing service that records every lifecycle state change — mode
+transitions, project opens/closes, focus events, timer firings, and MCP-triggered wakes
+— into a queryable ring buffer. The goal is to make the lifecycle system observable:
+when a project closes unexpectedly, or auto-open is slower than expected, or two timers
+are racing, the log shows exactly what happened and why.
+
+## What it adds
+
+**`LifecycleEventLog`** — application-level service, always running. Holds up to N events
+(default 500, configurable) in a `synchronized(ArrayDeque)`. Each entry has:
+- `timestamp` — ISO-8601 UTC
+- `project` / `path` — which project
+- `event` — `transition`, `opened`, `closed`, `enroll`, `release`, `wake`, `focus_lost`
+- `from` / `to` — mode names for transition and wake events
+- `trigger` — why it happened: `timer:focus`, `timer:inactivity`, `timer:close`,
+  `focus_gained`, `focus_lost`, `mcp_call`, `auto_open`, `user`
+
+**`ide_lifecycle_log`** tool — returns recent events (newest first) from the ring buffer.
+Parameters: `limit` (default 50, max = buffer size), `project` (path substring filter).
+Response includes `log_file` (the path to the on-disk log) and `buffered` (current count).
+
+**`ProjectLifecycleListener`** — `ProjectManagerListener` that logs open/close events for
+projects _not_ managed by `ProjectModeService`. Managed projects log their own events
+directly in `ProjectModeService`. Uses `projectClosing` (not deprecated) for close events;
+open events are captured in `ProjectFocusActivity` which already runs for every project.
+
+**Settings** — "Event log buffer size" spinner added to the Lifecycle section in
+Settings → Index MCP Server (range 100–10,000, default 500). The buffer size is read on
+each `log()` call so changes take effect without restart.
+
+## Design: two-tier logging
+
+The ring buffer is **always populated** — `ide_lifecycle_log` is useful without any
+configuration. The on-disk file (`mcp-lifecycle.log` in IntelliJ's log directory,
+alongside `idea.log`) is written **only when `LOG.isDebugEnabled` is true**.
+
+This follows IntelliJ's standard pattern for optional verbose logging: users enable it
+per-category via Help → Diagnostic Tools → Debug Log Settings by adding:
+
+```
+#com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+```
+
+No restart is required — `isDebugEnabled` is evaluated on each `log()` call. When debug
+is off (production default), there is zero I/O overhead: the ring-buffer write is a
+single lock acquisition and deque append.
+
+The file is useful for the stuck case: if the lifecycle manager closes all managed
+projects, MCP becomes unreachable (no project context to route through). The log file
+can still be read directly — `cat mcp-lifecycle.log` — to understand what happened
+without needing a live MCP connection.
+
+## Trigger taxonomy
+
+The `trigger` field on every event tells you _why_ something happened:
+
+| Trigger | Meaning |
+|---------|---------|
+| `focus_gained` | User switched to this project window |
+| `focus_lost` | User switched away; focus timer started |
+| `timer:focus` | Focus timer expired; project moved to background |
+| `timer:inactivity` | Inactivity timer expired; project moved to dormant |
+| `timer:close` | Dormant timer expired; project closed |
+| `mcp_call` | An MCP tool call triggered this (wake, enroll, explicit mode set) |
+| `auto_open` | Lifecycle manager reopened a closed project for an MCP call |
+| `user` | User action in the IDE (open/close outside lifecycle manager) |
+
+## Instrumentation points
+
+Every state change in `ProjectModeService` passes a `trigger: String` parameter to
+`transition()`. Timer alarm lambdas pass their own trigger string
+(`"timer:focus"` / `"timer:inactivity"` / `"timer:close"`). `ProjectFocusActivity`
+passes `"focus_gained"`. All other direct calls default to `"mcp_call"`.
+
+`markReopened()` only logs an `"opened"` event when the path was actually in
+`closedProjectPaths` (i.e., we actually reopened something, not just called the method
+redundantly during startup).
+
+## API notes
+
+None beyond what is noted in the lifecycle management PR. `LOG.isDebugEnabled` is the
+standard IntelliJ `Logger` API; no platform internals are used here.
+
+## Testing
+
+- `LifecycleUnitTest` — tool name, schema shape (no required fields), description
+  content, `lifecycleLogBufferSize` default and round-trip through `McpSettings`.
+- `smoke-tests/mcp-protocol.md` F6 — ring buffer structure, path filter, limit,
+  file-gating behaviour (verify no file writes before debug is enabled, then verify
+  writes appear immediately after enabling, without restart).
+- `smoke-tests/mcp-protocol.md` F7 — state machine end-to-end: enroll via MCP call,
+  set dormant, wake via tool call, verify full event sequence in the log.

--- a/docs/lifecycle-management.md
+++ b/docs/lifecycle-management.md
@@ -1,0 +1,119 @@
+# Project Lifecycle Management
+
+Adds automatic sleep/wake management for IntelliJ projects opened as MCP servers. When
+multiple projects are open simultaneously as MCP servers — a common pattern when an AI
+agent is working across a monorepo — idle projects consume unnecessary memory, keep Power
+Save Mode toggled awkwardly, and leave editors open for no reason. This PR adds a
+four-state machine that manages that automatically.
+
+## What it adds
+
+**Four lifecycle states per managed project:**
+
+| State | Power Save | Editors | PSI cache | Auto-transition |
+|-------|-----------|---------|-----------|-----------------|
+| `active` | off | open | loaded | focus lost → background |
+| `background` | on | open | loaded | 2 min idle → dormant |
+| `dormant` | on | closed | dropped | 10 min idle → closed |
+| `closed` | — | — | freed | next MCP call → background |
+
+Projects enroll automatically on their first MCP tool call and are never enrolled
+silently — the user sees a balloon notification and can release any project via
+`ide_release_project`.
+
+**New tools:**
+- `ide_set_project_mode` — set a project's mode explicitly
+- `ide_set_all_project_modes` — bulk-set all managed projects (active/background/dormant only — closed requires a live Project object)
+- `ide_get_project_modes` — list all managed projects and their current modes
+- `ide_project_status` — combined view: all open projects + all managed projects in one table
+- `ide_release_project` — unenroll a project, restore full IDE behaviour
+
+**Supporting tools added in the same batch:**
+- `ide_set_power_save_mode` — toggle Power Save Mode directly (useful without lifecycle)
+- `ide_close_project` — close a project window explicitly
+- `ide_open_project` — open a project by path and block until indexing completes
+- `ide_install_plugin` / `ide_restart` — plugin development workflow tools
+
+**Settings** (Settings → Index MCP Server → Project Lifecycle Management):
+- Master enable/disable toggle
+- Configurable timing thresholds for each transition
+- Live display of all managed projects and their current states
+
+**IDE actions** (searchable via Cmd+Shift+A):
+- "MCP: Open Project" — popup listing managed projects by state
+- "MCP: Show Project States" — opens the settings panel
+
+## Design
+
+### MCP availability guarantee
+
+The lifecycle manager never closes the last open managed project. When only one managed
+project remains and its close timer fires, it is kept in `dormant` (editors closed,
+memory mostly freed) rather than fully closed. This ensures the MCP HTTP server always
+has a project to route requests through.
+
+If all projects are nevertheless closed (the user manually closes the last window),
+`resolveOrOpen` detects this: when called with `projectPath = null` and `openProjects`
+is empty, it picks a project from `closedProjectPaths` and reopens it before routing
+the call. This is a last-resort trampoline — subsequent calls with a specific
+`project_path` will route to the right project via the existing auto-open path.
+
+### Auto-open from CLOSED
+
+`ProjectResolver.resolveOrOpen()` extends the existing `resolve()` with a recovery path:
+when a project_path refers to a project we closed, it reopens it and waits for smart mode
+before returning. This means every existing MCP tool transparently handles closed projects
+with no changes required in the tool itself.
+
+The open runs under `NonCancellable` so that an HTTP request timeout cannot abort a
+half-opened project. Without this, a slow-to-index project would leave IntelliJ in a
+state where the project appears "already opened" to subsequent calls but our lifecycle
+registry still shows it as closed. The `wasClosedByUs` flag on `ProjectModeService`
+tracks which projects we closed so we don't accidentally auto-open user-closed projects.
+
+### Threading
+
+All mode state changes in `ProjectModeService` are synchronous (plain `ConcurrentHashMap`
+writes). Side effects (closing editors, dropping PSI caches, closing the project window,
+toggling Power Save Mode) are deferred to `invokeLater` because they require the EDT.
+This means tests can assert mode state immediately after `transition()` without async
+machinery.
+
+Alarms use `Alarm.ThreadToUse.POOLED_THREAD` and are owned by `ProjectModeService`
+(which implements `Disposable`) so they are cleaned up correctly on plugin unload.
+
+### `participatesInLifecycle = false`
+
+Several tools set `participatesInLifecycle = false` on `AbstractMcpTool`:
+
+- **`ide_open_project` and `ide_close_project`** — infrastructure tools. Opening a project
+  to inspect it should not commit it to lifecycle management; enrollment signals intent to
+  do real work. Enrollment happens on the first semantic tool call (find references,
+  diagnostics, refactoring) after the project is open.
+- **`ProjectStatusTool`, `ReleaseProjectTool`, `LifecycleLogTool`, `GetProjectModesTool`** —
+  observer tools. Calling these to check lifecycle state should not auto-enroll the project
+  or reset its inactivity timer, as that would contradict their purpose.
+
+## API notes
+
+**`OpenProjectTask` reflection** — `forceOpenInNewFrame` and `showWelcomeScreen` are
+constructor parameters marked `@Internal` in the IntelliJ SDK. We set them via
+reflection rather than the constructor to avoid binary incompatibility when JetBrains
+changes the parameter list across versions. If auto-open breaks after an IntelliJ
+upgrade, check `openTask()` in `ProjectResolver` first.
+
+**`projectClosing` vs `projectClosed`** — `ProjectManagerListener.projectClosed` is
+deprecated in 2025.x; we use `projectClosing` instead. `projectOpened` is also
+deprecated; open events are captured via `ProjectFocusActivity` (a `ProjectActivity`
+that runs for every project on open) to avoid the deprecated API entirely.
+
+## Testing
+
+- `LifecycleUnitTest` (extends `TestCase`) — schema validation, enum completeness,
+  settings defaults, tool name constants. Runs in milliseconds, no platform required.
+- `ProjectModeServiceTest` (extends `BasePlatformTestCase`) — state machine behaviour:
+  transitions, alarm scheduling, persistence across `loadState`.
+- `LifecycleToolsTest` (extends `BasePlatformTestCase`) — tool execution: mode setting,
+  validation errors, auto-enroll, wake-from-dormant, bulk operations.
+- `smoke-tests/mcp-protocol.md` — HTTP-level protocol tests covering the install-restart
+  cycle and every new tool including the auto-open path (F8).

--- a/docs/smoke-test-protocol.md
+++ b/docs/smoke-test-protocol.md
@@ -1,0 +1,177 @@
+# Smoke Test
+
+Run this sequence of MCP tool calls after installing a new build of the plugin to verify all tools load and respond correctly. These tests exercise the API surface without performing destructive operations — `ide_restart` is intentionally excluded since it terminates the MCP connection.
+
+Reconnect Claude Code to the IDE after restart before running (`/mcp` → reconnect, or restart Claude Code).
+
+---
+
+## 1. Baseline — index ready
+
+```
+ide_index_status
+```
+**Expect:** `isDumbMode: false`. If true, wait and retry — indexing is still running.
+
+---
+
+## 2. Power Save Mode round-trip
+
+```
+ide_set_power_save_mode { "enabled": true }
+ide_set_power_save_mode { "enabled": false }
+```
+**Expect:** Both return success. After the second call, Power Save Mode is off.
+
+---
+
+## 3. Project window management — error paths
+
+```
+ide_open_project { "path": "/nonexistent/path" }
+```
+**Expect:** Error response — project does not exist.
+
+```
+ide_close_project
+```
+**Expect:** Success — schedules close of the active project. Do not run this during active development; it closes the window.
+
+---
+
+## 4. Lifecycle management
+
+```
+ide_project_status
+```
+**Expect:** Success. Response contains `projects` array and `summary` object with open/managed/mode per project.
+
+```
+ide_get_project_modes
+```
+**Expect:** Success. Either "No projects managed" or a list of enrolled projects with their current mode.
+
+```
+ide_lifecycle_log { "limit": 10 }
+```
+**Expect:** Success. Response contains `events` array (may be empty immediately after restart), `log_file` path, and `buffered` count. Each event has `timestamp`, `project`, `path`, `event`, `trigger` fields.
+
+```
+ide_set_project_mode { "mode": "dormant" }
+```
+**Expect:** Success. Project transitions to DORMANT (editors closed, PSI cache freed).
+
+```
+ide_lifecycle_log { "limit": 5 }
+```
+**Expect:** Events include a `transition` entry with `"from": "background"`, `"to": "dormant"`, `"trigger": "mcp_call"`.
+
+```
+ide_set_all_project_modes { "mode": "background" }
+```
+**Expect:** Success. All managed open projects set to BACKGROUND.
+
+```
+ide_set_project_mode { "mode": "active" }
+```
+**Expect:** Success. Project returns to ACTIVE mode (Power Save OFF).
+
+```
+ide_release_project
+```
+**Expect:** Success. Project removed from lifecycle management.
+
+---
+
+## 5. Plugin installation — validation paths
+
+```
+ide_install_plugin { "path": "/nonexistent/plugin.zip" }
+```
+**Expect:** Error — "File not found".
+
+```
+ide_install_plugin { "path": "/some/file.jar" }
+```
+**Expect:** Error — must be a .zip file.
+
+```
+ide_install_plugin
+```
+Run from within a Gradle plugin project that has been built (`./gradlew buildPlugin`).
+**Expect:** Success — finds `build/distributions/*.zip`, installs it, reports "restart required".
+
+---
+
+## 6. Self-installation loop (full end-to-end)
+
+This is the primary workflow these tools are designed to enable:
+
+```bash
+# 1. Make a code change to the plugin
+# 2. Build
+./gradlew buildPlugin
+
+# 3. Install via MCP (no path needed)
+ide_install_plugin
+
+# 4. Restart (connection drops — this is expected)
+ide_restart
+
+# 5. After IntelliJ restarts, reconnect Claude Code and re-run step 1 of this smoke test
+```
+
+All steps except the bash build are MCP calls. An AI coding agent can execute this loop without human intervention beyond the initial plugin install.
+
+---
+
+## 7. Monitoring — reading the lifecycle log for anomalies
+
+Enable file output once (no restart needed):
+
+> IntelliJ → Help → Diagnostic Tools → Debug Log Settings → add `#com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle`
+
+Then watch the log:
+
+```bash
+tail -f ~/Library/Logs/JetBrains/IntelliJIdea*/mcp-lifecycle.log
+```
+
+Or query via MCP:
+
+```
+ide_lifecycle_log { "limit": 30 }
+```
+
+### Anomaly patterns to watch for
+
+| Pattern in log | What it means |
+|----------------|---------------|
+| `timer:focus` waking a `dormant` project | Focus alarm fires after inactivity alarm — the two timers are racing. |
+| Projects cycling `background→dormant→background` repeatedly | Inactivity and focus timers leapfrogging each other. |
+| `auto_open` immediately followed by `timer:inactivity→dormant` | Project auto-opened but no MCP call followed. |
+| A project showing `timer:close→closed` you didn't expect | The dormant-to-closed window may be too short for your workflow. |
+| `last_project_kept` trigger in the log | The lifecycle manager would have closed a project but held it dormant because it was the last open managed project. Normal and expected. |
+| No `auto_open` after routing an MCP call to a managed-closed project | `wasClosedByUs` check not matching — likely a path normalisation mismatch. |
+
+---
+
+## 8. MCP availability — verifying the last-project and auto-recovery guarantees
+
+### 8a. Last-project stays dormant
+
+1. Enroll exactly one project: `ide_set_project_mode { "mode": "background" }`
+2. Wait for `timer:inactivity` → dormant, then `timer:close` fires
+3. Check the lifecycle log — PASS: log shows `last_project_kept` trigger instead of `dormant→closed`
+4. PASS: `ide_project_status` still returns `open: true` for the project in `dormant` mode
+
+### 8b. Auto-recovery when all projects are manually closed
+
+1. Manually close the last IntelliJ project window (File → Close Project)
+2. Call any MCP tool **without** `project_path`:
+   ```
+   ide_index_status
+   ```
+3. PASS: tool succeeds — a managed-closed project was auto-opened to restore routing
+4. FAIL: `no_project_open` error with no recovery — means no managed projects were in `closedProjectPaths`
+   (this can happen if the user closed projects that were never enrolled)

--- a/smoke-tests/mcp-protocol.md
+++ b/smoke-tests/mcp-protocol.md
@@ -1,0 +1,282 @@
+# MCP Plugin Smoke Test Protocol
+
+Run this after every `ide_install_plugin` + `ide_restart` cycle to verify the new
+build works before committing or raising a PR.
+
+---
+
+## Meta-protocol
+
+### How to call the server
+
+Do NOT rely on the Claude session's MCP tool schema — it is captured at session start
+and goes stale the moment the plugin restarts. Call the server directly via HTTP:
+
+```bash
+curl -s -X POST http://127.0.0.1:29170/index-mcp/streamable-http \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"<tool>","arguments":{...}}}'
+```
+
+Port 29170 is IntelliJ IDEA. Other IDEs: see `IdeProductInfo.kt` for the full map.
+
+### The install-restart-verify cycle
+
+1. `./gradlew buildPlugin` — produces `build/distributions/<name>-<version>.zip`
+2. Call `ide_install_plugin` with `project_path` pointing to this project
+3. Call `ide_restart` — waits for "Restarting IDE." response
+4. Poll the server until it responds (typically 15–30s):
+   ```bash
+   curl -s --max-time 3 http://127.0.0.1:29170/index-mcp/streamable-http \
+     -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+   ```
+5. Confirm restart actually happened: `restarter.log` in `~/Library/Logs/JetBrains/IntelliJIdea*/`
+   must have a new timestamped entry. If not, the restart was intercepted — see fallback below.
+6. **Reinstall the companion skill** — click "Get Companion Skill" in the Index MCP Server
+   tool window (bottom panel), or run:
+   ```bash
+   mkdir -p ~/.claude/skills/ide-index-mcp
+   cp -r <plugin-project>/src/main/resources/skill/ide-index-mcp/. ~/.claude/skills/ide-index-mcp/
+   ```
+   The skill content changes with each plugin build. Without this step, AI assistants may
+   use the wrong IntelliJ MCP server (`mcp__intellij__*` instead of `mcp__intellij-index__*`)
+   because the routing guidance is stale or missing.
+7. Run the tests below.
+
+### Diagnosing "old code still running"
+
+The new code is not loaded if error messages exactly match what was seen before the
+install. Compare error text — even one word difference means the new code is running.
+Check the installed jar timestamp:
+```bash
+ls -la ~/Library/Application\ Support/JetBrains/IntelliJIdea*/plugins/jetbrains-index-mcp-plugin/lib/*.jar
+```
+
+### Fallback when `ide_restart` doesn't fire
+
+`app.restart(true)` is async. If `restarter.log` shows no new entry after 10s:
+```bash
+pkill -x "idea"; sleep 3; open "/Applications/IntelliJ IDEA.app"
+```
+
+### MCP availability guarantees
+
+The lifecycle manager never closes the last open managed project — it stays in `dormant`
+to keep MCP reachable. If all projects are somehow closed anyway (e.g., the user manually
+closes the last window), calling any tool **without** `project_path` automatically reopens
+a managed-closed project. MCP self-heals without user intervention.
+
+If no managed projects were ever enrolled (nothing in `closedProjectPaths`), automatic
+recovery cannot happen. In that case open a project manually:
+```bash
+open -a "IntelliJ IDEA" /path/to/any/project
+```
+Check the log file directly for events that occurred while all projects were closed:
+```bash
+cat ~/Library/Logs/JetBrains/IntelliJIdea*/mcp-lifecycle.log
+```
+File writes require debug logging to be enabled — see F6 below.
+
+---
+
+## Test cases
+
+Use `project_path` on every call — multiple projects are typically open.
+
+```bash
+PP=/path/to/jetbrains-index-mcp-plugin   # adjust to actual path
+```
+
+---
+
+### 1. Plugin alive — `ide_index_status`
+
+- Call: `ide_index_status` with `project_path`
+- PASS: response contains `isDumbMode` field (true or false)
+- FAIL: error or no response
+
+---
+
+### 2. `ide_set_power_save_mode` — round trip
+
+- Call with `enabled: true` → PASS: success, message contains "enabled"
+- Call with `enabled: false` → PASS: success, message contains "disabled"
+- Call with no `enabled` param → PASS: `isError: true`, message contains "enabled"
+- FAIL on any: crash, hang, or generic error
+
+---
+
+### 3. `ide_open_project` — validation
+
+- Call with `path: "/nonexistent/path"` and `project_path`
+- PASS: `isError: true`, message contains "Failed to open" or the path
+- FAIL: HTTP 500 with empty body (unhandled exception), or hangs
+
+---
+
+### 4. `ide_install_plugin` — error paths
+
+**4a. Nonexistent zip:**
+- Call with `path: "/nonexistent/plugin.zip"`, `project_path`
+- PASS: `isError: true`, message contains "not found"
+
+**4b. Wrong extension:**
+- Call with `path: "/some/file.jar"`, `project_path`
+- PASS: `isError: true`, message contains ".zip"
+- FAIL: message says "not found" — means extension is checked AFTER existence
+
+**4c. No build output:**
+- Call with no `path`, `project_path` pointing to a project without `build/distributions/`
+- PASS: `isError: true`, message contains "buildPlugin" or "No plugin zip"
+
+---
+
+### 5. `ide_install_plugin` — auto-detect from this project
+
+- Call with no `path`, `project_path` pointing to this project (after `./gradlew buildPlugin`)
+- PASS: `isError: false`, message contains "installed from" and a plugin ID
+- FAIL (zip format): "Could not read plugin ID from META-INF/plugin.xml" — means
+  `readPluginId` is searching the zip root but plugin.xml is inside `lib/<plugin>.jar`
+  (Gradle Plugin 2.x format). Fix: update `readPluginId` to walk nested jars.
+- FAIL (no zip): "No plugin zip found" — run `./gradlew buildPlugin` first
+
+---
+
+### 6. `ide_restart` — silent restart
+
+- After install, call `ide_restart` with `project_path`
+- PASS: response received with "Restarting IDE.", then `restarter.log` gains a new
+  timestamped entry within 15s
+- FAIL: response received but no `restarter.log` entry — likely a save-dialog prompt
+  intercepted the restart. Fix: `saveAll()` before `restart(true)`, called via `edtAction {}`
+
+---
+
+## Fork-only tests
+
+> These tests cover tools added in this fork and are not relevant to the upstream project.
+
+### F1. `ide_get_project_modes`
+
+- Call with `project_path`
+- PASS: `isError: false`, response contains `managed_projects` array and `total` count
+
+---
+
+### F2. `ide_set_project_mode` — validation
+
+- Call with `mode: "INVALID_MODE"` → PASS: error listing valid modes (active, background, dormant, closed)
+- Call with no `mode` → PASS: error mentioning "mode"
+- Call with `mode: "background"` → PASS: success
+- Call with `mode: "active"` → PASS: success
+
+---
+
+### F3. `ide_set_all_project_modes` — validation and bulk
+
+- Call with `mode: "closed"` → PASS: error — closed is not valid for this tool
+- Call with `mode: "background"` → PASS: success, response reports count of projects changed
+- Call with `mode: "active"` → PASS: restores active state
+
+---
+
+### F4. `ide_release_project` — idempotency
+
+- Enroll project first: call `ide_set_project_mode` with `mode: "active"`
+- Call `ide_release_project` → PASS: success, response contains project name
+- Call `ide_release_project` again → PASS: success, response contains "not managed"
+- FAIL on second call: response says "released" again — means `AbstractMcpTool.execute()`
+  re-enrolled the project before `doExecute` checked managed state. Fix: set
+  `participatesInLifecycle = false` on `ReleaseProjectTool`.
+
+---
+
+### F5. `ide_project_status` — combined view
+
+- Call with `project_path`
+- PASS: `isError: false`, response contains `projects` array and `summary` object
+- PASS: the project we routed through appears with `"open": true`
+- PASS: `summary` contains `open`, `managed`, `open_not_managed`, `managed_closed` keys
+- FAIL: `isError: true` when only one project is open — this tool should work with a
+  single open project and no `project_path` argument
+
+**No-project-path variant (single project open):**
+- Call with no `project_path`
+- PASS: same structure as above; the one open project is selected automatically
+
+---
+
+### F6. `ide_lifecycle_log` — ring buffer and log file
+
+**6a. Basic response structure:**
+- Call with `project_path`, `limit: 5`
+- PASS: `isError: false`, response contains `events` array, `log_file` string, `buffered` integer
+- PASS: `log_file` path ends with `mcp-lifecycle.log`
+- PASS: `buffered` ≥ 0 (may be 0 immediately after restart before any events)
+- PASS: each event in `events` has `timestamp`, `project`, `path`, `event`, `trigger` fields
+
+**6b. Path filter:**
+- Call with `project: "nonexistent-xyz"` → PASS: `events` array is empty, not an error
+- Call with `project: "<basename of project_path>"` → PASS: only events for that project
+
+**6c. Limit:**
+- Call with `limit: 1` → PASS: at most 1 event returned
+- Call with `limit: 500` → PASS: up to 500 events, no error
+
+**6d. File gating:**
+- Before enabling debug logging, verify no new lines appear in the log file after MCP
+  tool calls (the ring buffer fills but the file does not)
+- Enable via Help → Diagnostic Tools → Debug Log Settings:
+  add `#com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle`
+- Make a tool call to generate a lifecycle event
+- PASS: new line appears in the log file within seconds, no restart needed
+- FAIL: no new line — check that the category was entered correctly (leading `#` required)
+
+---
+
+### F7. Lifecycle state machine — transitions visible in log
+
+This verifies the full enroll → transition → log pipeline end-to-end.
+
+1. Call any code intelligence tool (e.g. `ide_index_status`) with `project_path` to
+   trigger auto-enroll if not already managed
+2. Call `ide_set_project_mode` with `mode: "dormant"` and `project_path`
+3. Call `ide_lifecycle_log` with `project_path`
+4. PASS: events include a `transition` event with `"from": "background"` (or `"active"`),
+   `"to": "dormant"`, `"trigger": "mcp_call"`
+5. Call `ide_index_status` again with `project_path` (any tool call wakes a dormant project)
+6. Call `ide_lifecycle_log` again
+7. PASS: events include a `wake` event with `"from": "dormant"`, `"to": "background"`,
+   `"trigger": "mcp_call"`
+
+**Expected event sequence (newest first):**
+```json
+{ "event": "wake",       "from": "dormant",     "to": "background", "trigger": "mcp_call" }
+{ "event": "transition", "from": "background",   "to": "dormant",    "trigger": "mcp_call" }
+{ "event": "enroll",     "trigger": "mcp_call" }
+```
+
+---
+
+### F8. Auto-open from CLOSED — end-to-end
+
+This is the core lifecycle feature. It is the slowest test (5–15s for indexing).
+
+1. Call `ide_set_project_mode` with `mode: "closed"` and `project_path`
+   - PASS: success; the project window closes
+2. Immediately call `ide_index_status` with `project_path` (the now-closed project)
+   - The call should block while the project reopens and indexes
+   - PASS (after 5–30s): `isError: false`, `isDumbMode: false`
+   - FAIL: `isError: true` with `"no_project_open"` — means `resolveOrOpen` is not
+     recognising the path as a managed-closed project. Check `wasClosedByUs` returns true
+     and that `reopenAndAwaitSmartMode` completes without the HTTP timeout aborting it.
+3. Call `ide_lifecycle_log` with `project_path`
+4. PASS: events include `"event": "opened"`, `"trigger": "auto_open"` for the project
+5. PASS: `ide_project_status` now shows that project as `"open": true`
+
+**Timing note:** If step 2 times out (curl `--max-time` exceeded), the project may
+still be opening in the background. Wait 10s and retry the call — it should succeed
+immediately if indexing completed. The `NonCancellable` wrapper in `reopenAndAwaitSmartMode`
+ensures the open completes even if the first HTTP call timed out.

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/actions/OpenManagedProjectAction.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/actions/OpenManagedProjectAction.kt
@@ -1,0 +1,118 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.actions
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.intellij.ide.impl.OpenProjectTask
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ex.ProjectManagerEx
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.ui.SimpleListCellRenderer
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.nio.file.Path
+import kotlin.coroutines.resume
+
+class OpenManagedProjectAction : AnAction("MCP: Open Project") {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val currentProject = e.project ?: return
+        val modeService = ProjectModeService.getInstance()
+        val allModes = modeService.getAllManagedModes()
+
+        if (allModes.isEmpty()) {
+            Messages.showInfoMessage(
+                currentProject,
+                "No projects are currently managed by MCP lifecycle.",
+                "MCP: Open Project"
+            )
+            return
+        }
+
+        val entries = allModes.entries
+            .sortedBy { (_, mode) ->
+                when (mode) {
+                    ProjectMode.CLOSED -> 0
+                    ProjectMode.DORMANT -> 1
+                    ProjectMode.BACKGROUND -> 2
+                    ProjectMode.ACTIVE -> 3
+                }
+            }
+            .map { (path, mode) -> ManagedProjectEntry(path, path.substringAfterLast("/"), mode) }
+
+        val popup = JBPopupFactory.getInstance()
+            .createPopupChooserBuilder(entries)
+            .setTitle("MCP Managed Projects")
+            .setRenderer(ManagedProjectRenderer())
+            .setItemChosenCallback { entry -> openOrWake(entry, modeService) }
+            .createPopup()
+
+        val frame = WindowManager.getInstance().getFrame(currentProject)
+        if (frame != null) popup.showInCenterOf(frame) else popup.showInFocusCenter()
+    }
+
+    private fun openOrWake(entry: ManagedProjectEntry, modeService: ProjectModeService) {
+        when (entry.mode) {
+            ProjectMode.CLOSED -> {
+                // openProjectAsync is a suspend function — run it on a pooled thread.
+                ApplicationManager.getApplication().executeOnPooledThread {
+                    runBlocking {
+                        val openTask = OpenProjectTask.build().withForceOpenInNewFrame(true)
+                        val opened = ProjectManagerEx.getInstanceEx().openProjectAsync(
+                            Path.of(entry.path), openTask
+                        ) ?: return@runBlocking
+                        modeService.markReopened(entry.path)
+                        suspendCancellableCoroutine { continuation ->
+                            ApplicationManager.getApplication().invokeLater({
+                                if (!opened.isDisposed) {
+                                    DumbService.getInstance(opened).runWhenSmart {
+                                        if (!continuation.isCompleted) continuation.resume(Unit)
+                                    }
+                                } else {
+                                    continuation.cancel()
+                                }
+                            }, ModalityState.nonModal())
+                        }
+                        modeService.transition(opened, ProjectMode.ACTIVE)
+                    }
+                }
+            }
+            else -> {
+                ProjectManager.getInstance().openProjects
+                    .find { it.basePath == entry.path }
+                    ?.let { project ->
+                        if (!modeService.isManaged(project)) modeService.enroll(project)
+                        modeService.transition(project, ProjectMode.ACTIVE)
+                    }
+            }
+        }
+    }
+
+    data class ManagedProjectEntry(val path: String, val name: String, val mode: ProjectMode)
+
+    private class ManagedProjectRenderer : SimpleListCellRenderer<ManagedProjectEntry>() {
+        override fun customize(
+            list: javax.swing.JList<out ManagedProjectEntry>,
+            value: ManagedProjectEntry?,
+            index: Int,
+            selected: Boolean,
+            hasFocus: Boolean
+        ) {
+            value ?: return
+            val modeLabel = when (value.mode) {
+                ProjectMode.ACTIVE -> "[active]"
+                ProjectMode.BACKGROUND -> "[background]"
+                ProjectMode.DORMANT -> "[dormant]"
+                ProjectMode.CLOSED -> "[closed]"
+            }
+            text = "${value.name}  $modeLabel"
+            toolTipText = value.path
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/actions/ShowProjectStatesAction.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/actions/ShowProjectStatesAction.kt
@@ -1,0 +1,16 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+
+/**
+ * Opens the MCP settings panel directly.
+ * Accessible via Cmd+Shift+A → "MCP: Show Project States".
+ */
+class ShowProjectStatesAction : AnAction("MCP: Show Project States") {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        ShowSettingsUtil.getInstance().showSettingsDialog(e.project, "Index MCP Server")
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
@@ -43,6 +43,17 @@ object ToolNames {
     const val OPEN_PROJECT = "ide_open_project"
     const val SET_POWER_SAVE_MODE = "ide_set_power_save_mode"
 
+    // Lifecycle management
+    const val ENROLL_ALL_PROJECTS = "ide_enroll_all_projects"
+    const val GET_PROJECT_MODES = "ide_get_project_modes"
+    const val LIFECYCLE_LOG = "ide_lifecycle_log"
+    const val LIFECYCLE_LOG_FILE = "ide_set_lifecycle_log_file"
+    const val PROJECT_STATUS = "ide_project_status"
+    const val RELEASE_ALL_PROJECTS = "ide_release_all_projects"
+    const val RELEASE_PROJECT = "ide_release_project"
+    const val SET_ALL_PROJECT_MODES = "ide_set_all_project_modes"
+    const val SET_PROJECT_MODE = "ide_set_project_mode"
+
     /**
      * All known tool names, sorted alphabetically.
      * Keep this list in sync when adding or removing tool name constants.
@@ -53,6 +64,7 @@ object ToolNames {
         CLOSE_PROJECT,
         CONVERT_JAVA_TO_KOTLIN,
         DIAGNOSTICS,
+        ENROLL_ALL_PROJECTS,
         FILE_STRUCTURE,
         FIND_CLASS,
         FIND_DEFINITION,
@@ -62,19 +74,27 @@ object ToolNames {
         FIND_SUPER_METHODS,
         FIND_SYMBOL,
         GET_ACTIVE_FILE,
+        GET_PROJECT_MODES,
         INDEX_STATUS,
         INSTALL_PLUGIN,
+        LIFECYCLE_LOG,
         REFACTOR_MOVE,
         OPEN_FILE,
         OPEN_PROJECT,
         OPTIMIZE_IMPORTS,
+        PROJECT_STATUS,
         READ_FILE,
         REFACTOR_RENAME,
         REFACTOR_SAFE_DELETE,
         REFORMAT_CODE,
+        RELEASE_ALL_PROJECTS,
+        RELEASE_PROJECT,
         RESTART_IDE,
         SEARCH_TEXT,
+        SET_ALL_PROJECT_MODES,
+        LIFECYCLE_LOG_FILE,
         SET_POWER_SAVE_MODE,
+        SET_PROJECT_MODE,
         SYNC_FILES,
         TYPE_HIERARCHY
     )

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/LifecycleEventLog.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/LifecycleEventLog.kt
@@ -1,0 +1,94 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+// Design note: the ring buffer is always populated — it is cheap (one lock + deque write per
+// event) and makes ide_lifecycle_log useful without any setup. The file write is gated on
+// LOG.isDebugEnabled, which maps to IntelliJ's own debug-logging infrastructure: enable it
+// per-session via Help → Diagnostic Tools → Debug Log Settings, adding the category
+// "#com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle". No IDE restart required.
+// This is the standard IntelliJ approach: zero overhead in production, full tracing on demand.
+@Service(Service.Level.APP)
+class LifecycleEventLog {
+
+    data class Entry(
+        val timestampMs: Long = System.currentTimeMillis(),
+        val project: String,
+        val path: String,
+        /** open, closed, transition, enroll, release, wake */
+        val event: String,
+        val from: String? = null,
+        val to: String? = null,
+        /** focus_gained, focus_lost, timer:focus, timer:inactivity, timer:close, mcp_call, auto_open, user */
+        val trigger: String
+    ) {
+        fun toJson(): JsonObject = buildJsonObject {
+            put("timestamp", ISO.format(Instant.ofEpochMilli(timestampMs).atOffset(ZoneOffset.UTC)))
+            put("project", project)
+            put("path", path)
+            put("event", event)
+            from?.let { put("from", it) }
+            to?.let { put("to", it) }
+            put("trigger", trigger)
+        }
+
+        fun toLogLine(): String {
+            val ts = ISO.format(Instant.ofEpochMilli(timestampMs).atOffset(ZoneOffset.UTC))
+            val modeChange = if (from != null && to != null) ": $from→$to" else ""
+            return "$ts [$trigger] $project$modeChange  ($path)"
+        }
+    }
+
+    private val buffer = ArrayDeque<Entry>()
+    val logFilePath: Path = Path.of(PathManager.getLogPath(), "mcp-lifecycle.log")
+
+    fun log(entry: Entry) {
+        val capacity = runCatching { McpSettings.getInstance().lifecycleLogBufferSize }
+            .getOrDefault(DEFAULT_CAPACITY)
+        synchronized(buffer) {
+            if (buffer.size >= capacity) buffer.removeFirst()
+            buffer.addLast(entry)
+        }
+        val writeToFile = LOG.isDebugEnabled ||
+            runCatching { McpSettings.getInstance().lifecycleLogToFile }.getOrDefault(false)
+        if (writeToFile) {
+            runCatching {
+                Files.writeString(
+                    logFilePath, entry.toLogLine() + "\n",
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND
+                )
+            }
+        }
+    }
+
+    fun recent(limit: Int = 50, pathFilter: String? = null): List<Entry> {
+        val capacity = runCatching { McpSettings.getInstance().lifecycleLogBufferSize }
+            .getOrDefault(DEFAULT_CAPACITY)
+        return synchronized(buffer) { buffer.toList() }
+            .asReversed()
+            .let { if (pathFilter != null) it.filter { e -> e.path.contains(pathFilter) } else it }
+            .take(limit.coerceIn(1, capacity))
+    }
+
+    val size: Int get() = synchronized(buffer) { buffer.size }
+
+    companion object {
+        const val DEFAULT_CAPACITY = 500
+        private val LOG = logger<LifecycleEventLog>()
+        private val ISO: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+        fun getInstance(): LifecycleEventLog = service()
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectFocusActivity.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectFocusActivity.kt
@@ -1,0 +1,78 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.wm.WindowManager
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+
+class ProjectFocusActivity : ProjectActivity {
+
+    override suspend fun execute(project: Project) {
+        // Attach the focus listener via invokeLater so the frame is available.
+        // If the frame is still null (headless/test env or very early startup),
+        // retry exactly once — no infinite loop.
+        ApplicationManager.getApplication().invokeLater {
+            registerFocusListener(project, retry = true)
+        }
+        val modeService = ProjectModeService.getInstance()
+        if (McpSettings.getInstance().lifecycleEnabled && modeService.isManaged(project)) {
+            modeService.markReopened(project.basePath ?: return)
+            modeService.resetInactivityTimer(project)
+        } else {
+            LifecycleEventLog.getInstance().log(
+                LifecycleEventLog.Entry(
+                    project = project.name,
+                    path = project.basePath ?: "",
+                    event = "opened",
+                    trigger = "user"
+                )
+            )
+        }
+        // A new project window is open — some pendingClose projects may now be eligible to close.
+        modeService.flushPendingCloses()
+    }
+
+    private fun registerFocusListener(project: Project, retry: Boolean = false) {
+        if (project.isDisposed) return
+        val frame = WindowManager.getInstance().getFrame(project) ?: run {
+            // Frame not ready yet. Retry once more if this is the first attempt.
+            // No further retry after that — headless/test environments never have a frame.
+            if (retry) ApplicationManager.getApplication().invokeLater {
+                registerFocusListener(project, retry = false)
+            }
+            return
+        }
+        frame.addWindowFocusListener(object : WindowAdapter() {
+            override fun windowGainedFocus(e: WindowEvent) {
+                val modeService = ProjectModeService.getInstance()
+                if (!McpSettings.getInstance().lifecycleEnabled) return
+                if (!modeService.isManaged(project)) return
+                modeService.cancelFocusAlarm(project)
+                modeService.transition(project, ProjectMode.ACTIVE, "focus_gained")
+            }
+
+            override fun windowLostFocus(e: WindowEvent) {
+                val modeService = ProjectModeService.getInstance()
+                if (!McpSettings.getInstance().lifecycleEnabled) return
+                if (!modeService.isManaged(project)) return
+                LifecycleEventLog.getInstance().log(
+                    LifecycleEventLog.Entry(
+                        project = project.name,
+                        path = project.basePath ?: "",
+                        event = "focus_lost",
+                        trigger = "focus_lost"
+                    )
+                )
+                modeService.scheduleFocusTransition(project)
+            }
+        })
+    }
+
+    companion object {
+        private val LOG = logger<ProjectFocusActivity>()
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectLifecycleListener.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectLifecycleListener.kt
@@ -1,0 +1,44 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManagerListener
+
+/**
+ * Hooks into project close events to keep [ProjectModeService] consistent.
+ *
+ * On close: if the project was managed, marks it closed and schedules a health
+ * check after the project is fully disposed (running it inside projectClosing
+ * would produce false positives because the project is still in openProjects
+ * while closedProjectPaths already contains it).
+ *
+ * Restart re-enrollment is handled by [ProjectFocusActivity], which runs when
+ * the project frame is ready and calls markReopened + resetInactivityTimer.
+ */
+class ProjectLifecycleListener : ProjectManagerListener {
+
+    override fun projectClosing(project: Project) {
+        if (project.isDefault) return
+        val modeService = runCatching { ProjectModeService.getInstance() }.getOrNull() ?: return
+
+        if (modeService.isManaged(project)) {
+            val name = project.name
+            modeService.onProjectClosedExternally(project.basePath ?: "", name)
+            // Defer health check until after the project is fully disposed — otherwise the
+            // project is still in openProjects while closedProjectPaths already contains it,
+            // which the health check would incorrectly report as a bug.
+            ApplicationManager.getApplication().invokeLater {
+                modeService.healthCheck("project_closed:$name")
+            }
+        } else {
+            LifecycleEventLog.getInstance().log(
+                LifecycleEventLog.Entry(
+                    project = project.name,
+                    path = project.basePath ?: "",
+                    event = "closed",
+                    trigger = "user"
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectMode.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectMode.kt
@@ -1,0 +1,15 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+enum class ProjectMode {
+    /** Full IntelliJ capabilities. User has the project window focused. */
+    ACTIVE,
+
+    /** Power Save Mode ON. Index and MCP fully functional. Background inspections off. */
+    BACKGROUND,
+
+    /** Power Save ON + editors closed. PSI references released via GC; index stays loaded. */
+    DORMANT,
+
+    /** Project fully closed. All memory freed. Auto-reopens on next MCP call. */
+    CLOSED
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeService.kt
@@ -1,0 +1,480 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.intellij.ide.PowerSaveMode
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ex.ProjectManagerEx
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.openapi.components.RoamingType
+import com.intellij.util.Alarm
+import java.util.concurrent.ConcurrentHashMap
+
+@Service(Service.Level.APP)
+@State(name = "McpProjectModeService", storages = [Storage("mcp-lifecycle.xml", roamingType = RoamingType.DISABLED)])
+class ProjectModeService : PersistentStateComponent<ProjectModeService.State>, Disposable {
+
+    data class State(
+        var closedProjectPaths: MutableSet<String> = ConcurrentHashMap.newKeySet(),
+        var managedProjectPaths: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    )
+
+    private var persistedState = State()
+
+    /** Live mode per project path. CLOSED paths are in persistedState only — the Project object no longer exists. */
+    private val modes = ConcurrentHashMap<String, ProjectMode>()
+
+    private val focusAlarms = ConcurrentHashMap<String, Alarm>()
+    private val inactivityAlarms = ConcurrentHashMap<String, Alarm>()
+
+    /** Paths blocked from closing by the floor — awaiting event-driven flush. */
+    private val pendingClose = ConcurrentHashMap.newKeySet<String>()
+
+    /** Single safety-net alarm that runs the health check every 30 minutes. */
+    private val healthAlarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, this)
+    private var healthAlarmStarted = false
+
+    override fun getState(): State = persistedState
+
+    override fun loadState(state: State) {
+        // IntelliJ collapses real paths to macros (e.g. $USER_HOME$) when persisting but does
+        // not expand them back automatically for plain Set<String> fields — expand explicitly.
+        persistedState = State(
+            closedProjectPaths = state.closedProjectPaths.mapTo(ConcurrentHashMap.newKeySet(), ::expandMacros),
+            managedProjectPaths = state.managedProjectPaths.mapTo(ConcurrentHashMap.newKeySet(), ::expandMacros)
+        )
+        persistedState.closedProjectPaths.forEach { modes[it] = ProjectMode.CLOSED }
+    }
+
+    private fun expandMacros(path: String): String =
+        path.replace("\$USER_HOME\$", System.getProperty("user.home"))
+
+    override fun dispose() {
+        focusAlarms.values.forEach { Disposer.dispose(it) }
+        inactivityAlarms.values.forEach { Disposer.dispose(it) }
+        Disposer.dispose(healthAlarm)
+    }
+
+    fun enroll(project: Project) {
+        val path = project.basePath ?: return
+        if (persistedState.managedProjectPaths.contains(path)) return
+        persistedState.managedProjectPaths.add(path)
+        // Start in ACTIVE if the project window currently has focus so the user doesn't
+        // immediately lose inspections while they're working. Otherwise start in BACKGROUND.
+        val hasFocus = WindowManager.getInstance().getFrame(project)?.isFocused == true
+        modes[path] = if (hasFocus) ProjectMode.ACTIVE else ProjectMode.BACKGROUND
+        ApplicationManager.getApplication().invokeLater { reconcilePowerSaveMode() }
+        if (!hasFocus) scheduleInactivityTransition(project)
+        val modeLabel = if (hasFocus) "active" else "background"
+        LifecycleEventLog.getInstance().log(
+            LifecycleEventLog.Entry(project = project.name, path = path, event = "enroll", trigger = "mcp_call")
+        )
+        notify(project, "MCP enrolled '${project.name}' into lifecycle management ($modeLabel). " +
+            "Project will sleep when idle.")
+
+        startHealthAlarmIfNeeded()
+        // Enrolling a new project is an opportunity to flush any projects that were
+        // blocked from closing by the floor — now that we are above the floor again.
+        flushPendingCloses()
+    }
+
+    fun release(project: Project) {
+        val path = project.basePath ?: return
+        release(path, project.name)
+        ApplicationManager.getApplication().invokeLater { reconcilePowerSaveMode() }
+    }
+
+    fun release(path: String) {
+        release(path, path.substringAfterLast("/"))
+        // Don't toggle PowerSaveMode here — other managed projects may still need it.
+        // releaseAll() handles the global reset after clearing everything.
+    }
+
+    private fun release(path: String, name: String) {
+        persistedState.managedProjectPaths.remove(path)
+        persistedState.closedProjectPaths.remove(path)
+        modes.remove(path)
+        cancelAllAlarms(path)
+        LifecycleEventLog.getInstance().log(
+            LifecycleEventLog.Entry(project = name, path = path, event = "release", trigger = "mcp_call")
+        )
+    }
+
+    fun releaseAll() {
+        persistedState.managedProjectPaths.toList().forEach { release(it) }
+        ApplicationManager.getApplication().invokeLater { PowerSaveMode.setEnabled(false) }
+    }
+
+    fun enrollAll(openProjects: List<Project>) {
+        openProjects.filter { !it.isDefault && !isManaged(it) }.forEach { enroll(it) }
+    }
+
+    fun isManaged(project: Project): Boolean =
+        project.basePath?.let { persistedState.managedProjectPaths.contains(it) } ?: false
+
+    fun isManaged(path: String): Boolean = persistedState.managedProjectPaths.contains(path)
+
+    fun getMode(project: Project): ProjectMode =
+        project.basePath?.let { getMode(it) } ?: ProjectMode.BACKGROUND
+
+    fun getMode(path: String): ProjectMode =
+        modes[path] ?: if (persistedState.closedProjectPaths.contains(path)) ProjectMode.CLOSED
+        else ProjectMode.BACKGROUND
+
+    /** Returns path → mode for all managed projects, including those we closed. */
+    fun getAllManagedModes(): Map<String, ProjectMode> =
+        persistedState.managedProjectPaths.associateWith { getMode(it) }
+
+    fun transition(project: Project, mode: ProjectMode, trigger: String = "mcp_call") {
+        val path = project.basePath ?: return
+        val previous = getMode(path)
+        if (previous == mode) return
+        modes[path] = mode
+        LOG.debug("${project.name}: $previous → $mode")
+
+        // For CLOSED, log after onClosed() resolves — it may keep the project dormant
+        // instead of closing, and we want the log to reflect the actual outcome.
+        if (mode != ProjectMode.CLOSED) {
+            LifecycleEventLog.getInstance().log(
+                LifecycleEventLog.Entry(
+                    project = project.name,
+                    path = path,
+                    event = "transition",
+                    from = previous.name.lowercase(),
+                    to = mode.name.lowercase(),
+                    trigger = trigger
+                )
+            )
+        }
+
+        when (mode) {
+            ProjectMode.ACTIVE -> onActive(project, path)
+            ProjectMode.BACKGROUND -> onBackground(project, path)
+            ProjectMode.DORMANT -> onDormant(project, path)
+            ProjectMode.CLOSED -> onClosed(project, path, previous, trigger)
+        }
+    }
+
+    /** Wakes a dormant project for an incoming MCP call without reopening editors. */
+    fun wakeForMcp(project: Project) {
+        val path = project.basePath ?: return
+        val woke = modes.replace(path, ProjectMode.DORMANT, ProjectMode.BACKGROUND)
+        if (getMode(path) == ProjectMode.CLOSED) return
+        if (woke) {
+            LifecycleEventLog.getInstance().log(
+                LifecycleEventLog.Entry(
+                    project = project.name,
+                    path = path,
+                    event = "wake",
+                    from = "dormant",
+                    to = "background",
+                    trigger = "mcp_call"
+                )
+            )
+        }
+        resetInactivityTimer(project)
+    }
+
+    fun scheduleFocusTransition(project: Project) {
+        val settings = McpSettings.getInstance()
+        if (!settings.lifecycleEnabled) return
+        val path = project.basePath ?: return
+        val alarm = focusAlarms.getOrPut(path) { Alarm(Alarm.ThreadToUse.POOLED_THREAD, this) }
+        alarm.cancelAllRequests()
+        alarm.addRequest(
+            { transition(project, ProjectMode.BACKGROUND, "timer:focus") },
+            settings.focusToBackgroundMinutes * 60_000L
+        )
+    }
+
+    fun cancelFocusAlarm(project: Project) {
+        focusAlarms[project.basePath ?: return]?.cancelAllRequests()
+    }
+
+    fun resetInactivityTimer(project: Project) {
+        val settings = McpSettings.getInstance()
+        if (!settings.lifecycleEnabled) return
+        if (getMode(project) == ProjectMode.ACTIVE) return
+        scheduleInactivityTransition(project)
+    }
+
+    private fun scheduleInactivityTransition(project: Project) {
+        val settings = McpSettings.getInstance()
+        val path = project.basePath ?: return
+        val alarm = inactivityAlarms.getOrPut(path) { Alarm(Alarm.ThreadToUse.POOLED_THREAD, this) }
+        alarm.cancelAllRequests()
+        alarm.addRequest({
+            if (!project.isDisposed && getMode(path) == ProjectMode.BACKGROUND) {
+                transition(project, ProjectMode.DORMANT, "timer:inactivity")
+            }
+        }, settings.backgroundToDormantMinutes * 60_000L)
+    }
+
+    private fun scheduleCloseTransition(project: Project) {
+        val settings = McpSettings.getInstance()
+        val path = project.basePath ?: return
+        val alarm = inactivityAlarms.getOrPut(path) { Alarm(Alarm.ThreadToUse.POOLED_THREAD, this) }
+        alarm.cancelAllRequests()
+        alarm.addRequest({
+            if (!project.isDisposed && getMode(path) == ProjectMode.DORMANT) {
+                transition(project, ProjectMode.CLOSED, "timer:close")
+            }
+        }, settings.dormantToClosedMinutes * 60_000L)
+    }
+
+    fun cancelAllAlarms(path: String) {
+        focusAlarms[path]?.cancelAllRequests()
+        inactivityAlarms[path]?.cancelAllRequests()
+    }
+
+    fun wasClosedByUs(path: String): Boolean = persistedState.closedProjectPaths.contains(path)
+
+    /** Updates the registry without touching an open project window — used when re-registering after restart. */
+    fun markClosed(path: String) {
+        persistedState.closedProjectPaths.add(path)
+        persistedState.managedProjectPaths.add(path)
+        modes[path] = ProjectMode.CLOSED
+    }
+
+    fun markReopened(path: String) {
+        val wasClosed = persistedState.closedProjectPaths.remove(path)
+        modes[path] = ProjectMode.BACKGROUND
+        if (wasClosed) {
+            val name = path.substringAfterLast("/")
+            LifecycleEventLog.getInstance().log(
+                LifecycleEventLog.Entry(project = name, path = path, event = "opened", trigger = "auto_open")
+            )
+        }
+    }
+
+    private fun onActive(project: Project, path: String) {
+        cancelAllAlarms(path)
+        ApplicationManager.getApplication().invokeLater { reconcilePowerSaveMode() }
+    }
+
+    private fun onBackground(project: Project, path: String) {
+        cancelFocusAlarm(project)
+        ApplicationManager.getApplication().invokeLater { reconcilePowerSaveMode() }
+        scheduleInactivityTransition(project)
+    }
+
+    /**
+     * PSM is IDE-global, not per-project. Reconcile it after every state change:
+     * PSM should be ON iff no managed project is currently ACTIVE.
+     * Per-event toggling causes stuck-ON bugs when project B → BACKGROUND while A
+     * is still ACTIVE (B's invokeLater enables PSM, A never re-disables it).
+     */
+    fun reconcilePowerSaveMode() {
+        val anyActive = persistedState.managedProjectPaths.any { getMode(it) == ProjectMode.ACTIVE }
+        PowerSaveMode.setEnabled(!anyActive)
+    }
+
+    private fun onDormant(project: Project, path: String) {
+        // Cancel the focus alarm — if it fires after the inactivity alarm it would
+        // immediately wake the project back to background, defeating dormant.
+        cancelFocusAlarm(project)
+        ApplicationManager.getApplication().invokeLater {
+            if (!project.isDisposed) {
+                val fem = FileEditorManager.getInstance(project)
+                fem.openFiles.forEach { fem.closeFile(it) }
+                // dropPsiCaches() is intentionally omitted: in IntelliJ 2025+ it internally
+                // calls runWriteAction, which requires a write-safe context that invokeLater
+                // scheduled from a pooled-thread Alarm does not provide. Closing editors
+                // already releases the strong PSI references; the cache reclaims via GC.
+            }
+        }
+        scheduleCloseTransition(project)
+    }
+
+    private fun onClosed(project: Project, path: String, previous: ProjectMode, trigger: String) {
+        cancelAllAlarms(path)
+
+        // Never close below the minimum. Rather than rescheduling the alarm (which hammers
+        // the log every 10 min), add to pendingClose and wait for an event-driven flush.
+        val min = runCatching { McpSettings.getInstance().minimumOpenProjects }.getOrDefault(4)
+        val openManaged = ProjectManager.getInstance().openProjects
+            .filter { !it.isDefault && isManaged(it) }
+        if (openManaged.size <= min) {
+            modes[path] = ProjectMode.DORMANT
+            pendingClose.add(path)
+            LOG.info("Keeping '${project.name}' dormant — added to pendingClose (floor=$min)")
+            LifecycleEventLog.getInstance().log(
+                LifecycleEventLog.Entry(
+                    project = project.name, path = path,
+                    event = "transition", from = previous.name.lowercase(), to = "dormant",
+                    trigger = "last_project_kept"
+                )
+            )
+            return
+        }
+
+        // Log the actual close now that we've confirmed it will happen.
+        LifecycleEventLog.getInstance().log(
+            LifecycleEventLog.Entry(
+                project = project.name, path = path,
+                event = "transition", from = previous.name.lowercase(), to = "closed",
+                trigger = trigger
+            )
+        )
+        markClosed(path)
+        ApplicationManager.getApplication().invokeLater {
+            if (!project.isDisposed) {
+                ProjectManagerEx.getInstanceEx().closeAndDispose(project)
+                LOG.info("closed: $path")
+            }
+        }
+    }
+
+    // ── pendingClose: event-driven flush ────────────────────────────────────
+
+    /** Flush projects that were blocked from closing by the floor, if they are now eligible. */
+    fun flushPendingCloses() {
+        if (pendingClose.isEmpty()) return
+        val min = runCatching { McpSettings.getInstance().minimumOpenProjects }.getOrDefault(4)
+        val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDefault }
+        val openByPath = openProjects.associateBy { normalizePath(it.basePath ?: "") }
+        var current = openProjects.filter { isManaged(it) }.size
+
+        // Remove stale entries first (project woke up or was closed externally)
+        for (path in pendingClose.toList()) {
+            val proj = openByPath[path]
+            when {
+                proj == null -> pendingClose.remove(path)
+                getMode(path) != ProjectMode.DORMANT -> pendingClose.remove(path)
+            }
+        }
+
+        // Close eligible pending projects (prefer most dormant — DORMANT only)
+        for (path in pendingClose.toList()) {
+            if (current <= min) break
+            val proj = openByPath[path] ?: continue
+            if (getMode(path) != ProjectMode.DORMANT) continue
+            pendingClose.remove(path)
+            transition(proj, ProjectMode.CLOSED, "pending_close_flushed")
+            current--
+        }
+    }
+
+    fun isInPendingClose(path: String): Boolean = pendingClose.contains(normalizePath(path))
+
+    /** Called by ProjectLifecycleListener when a project is closed externally (not by us). */
+    fun onProjectClosedExternally(path: String, name: String) {
+        val normalized = normalizePath(path)
+        if (pendingClose.remove(normalized)) {
+            // Was waiting to close — now it is; mark properly if managed
+            if (isManaged(normalized)) {
+                markClosed(normalized)
+                LifecycleEventLog.getInstance().log(
+                    LifecycleEventLog.Entry(project = name, path = normalized, event = "closed", trigger = "user")
+                )
+            }
+        }
+        flushPendingCloses()
+    }
+
+    // ── Health check ─────────────────────────────────────────────────────────
+
+    /**
+     * Verifies lifecycle invariants and logs what was observed vs what is expected.
+     * Distinguishes expected drift (floor/ceiling normal operation) from bugs
+     * (open project in closedProjectPaths, pendingClose project not dormant, etc.).
+     */
+    fun healthCheck(trigger: String) {
+        val min = runCatching { McpSettings.getInstance().minimumOpenProjects }.getOrDefault(4)
+        val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDefault }
+        val openManaged = openProjects.filter { isManaged(it) }
+        val openCount = openManaged.size
+        val pendingCount = pendingClose.size
+
+        LOG.info("Health check [trigger=$trigger]: open=$openCount, pending=$pendingCount, min=$min")
+
+        val issues = mutableListOf<String>()
+        val notes = mutableListOf<String>()
+
+        if (openCount < min && pendingCount == 0 && persistedState.managedProjectPaths.isNotEmpty()) {
+            notes.add("open count ($openCount) below minimum ($min) — some projects fully closed, pending=$pendingCount")
+        }
+
+        val openByPath = openProjects.associateBy { normalizePath(it.basePath ?: "") }
+        for (path in pendingClose.toList()) {
+            val proj = openByPath[path]
+            when {
+                proj == null -> issues.add("pendingClose '$path' not in openProjects — stale entry")
+                getMode(path) != ProjectMode.DORMANT ->
+                    issues.add("pendingClose '${proj.name}' is ${getMode(path)}, expected DORMANT")
+            }
+        }
+        for (proj in openManaged) {
+            val path = normalizePath(proj.basePath ?: "")
+            if (persistedState.closedProjectPaths.contains(path)) {
+                issues.add("'${proj.name}' is open but also in closedProjectPaths — state inconsistency")
+            }
+        }
+
+        if (issues.isEmpty() && notes.isEmpty()) {
+            LOG.debug("Health check: OK")
+        } else {
+            notes.forEach { LOG.info("  note: $it") }
+            issues.forEach { LOG.warn("  ISSUE: $it") }
+        }
+
+        val outcome = when {
+            issues.isNotEmpty() -> "bug:${issues.size} — ${issues.joinToString("; ")}"
+            notes.isNotEmpty() -> "drift:${notes.joinToString("; ")}"
+            else -> "ok"
+        }
+        LifecycleEventLog.getInstance().log(
+            LifecycleEventLog.Entry(
+                project = "health",
+                path = "",
+                event = "health_check",
+                from = "open=$openCount/pending=$pendingCount",
+                to = outcome,
+                trigger = trigger
+            )
+        )
+
+        flushPendingCloses()
+    }
+
+    private fun startHealthAlarmIfNeeded() {
+        if (!healthAlarmStarted) {
+            healthAlarmStarted = true
+            scheduleNextHealthCheck()
+        }
+    }
+
+    private fun scheduleNextHealthCheck() {
+        healthAlarm.cancelAllRequests()
+        healthAlarm.addRequest({
+            healthCheck("safety_net_30min")
+            scheduleNextHealthCheck()
+        }, 30 * 60_000L)
+    }
+
+    private fun normalizePath(path: String) = path.trimEnd('/', '\\').replace('\\', '/')
+
+    private fun notify(project: Project, message: String) {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("Index MCP Server")
+            .createNotification(message, NotificationType.INFORMATION)
+            .notify(project)
+    }
+
+    companion object {
+        private val LOG = logger<ProjectModeService>()
+        fun getInstance(): ProjectModeService = service()
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
@@ -7,10 +7,13 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandEntry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandHistoryService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandStatus
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.exceptions.IndexNotReadyException
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.*
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 
@@ -43,6 +46,10 @@ class JsonRpcHandler @JvmOverloads constructor(
     ): String? {
         val request = try {
             json.decodeFromString<JsonRpcRequest>(jsonString)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.warn("Failed to parse JSON-RPC request", e)
             return json.encodeToString(createErrorResponse(code = JsonRpcErrorCodes.PARSE_ERROR, message = ErrorMessages.PARSE_ERROR))
@@ -58,6 +65,10 @@ class JsonRpcHandler @JvmOverloads constructor(
 
         val response = try {
             routeRequest(request, protocolVersion)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.error("Error processing request: ${request.method}", e)
             createErrorResponse(request.id, JsonRpcErrorCodes.INTERNAL_ERROR, e.message ?: "Unknown error")
@@ -121,7 +132,7 @@ class JsonRpcHandler @JvmOverloads constructor(
         // Extract optional project_path from arguments
         val projectPath = arguments[ParamNames.PROJECT_PATH]?.jsonPrimitive?.contentOrNull
 
-        val projectResult = projectResolver.resolve(projectPath)
+        val projectResult = projectResolver.resolveOrOpen(projectPath)
         if (projectResult.isError) {
             return JsonRpcResponse(
                 id = request.id,
@@ -163,6 +174,22 @@ class JsonRpcHandler @JvmOverloads constructor(
                 id = request.id,
                 result = json.encodeToJsonElement(result)
             )
+        } catch (e: IndexNotReadyException) {
+            // Dumb mode is expected during indexing — log at debug, not error.
+            val duration = System.currentTimeMillis() - startTime
+            LOG.debug("Tool $toolName called while IDE is indexing: ${e.message}")
+            updateHistorySafely(project = project, commandEntry = commandEntry,
+                status = CommandStatus.ERROR, result = e.message, duration = duration)
+            return JsonRpcResponse(
+                id = request.id,
+                error = JsonRpcError(code = -32603, message = e.message ?: ErrorMessages.INDEX_NOT_READY)
+            )
+        } catch (e: ProcessCanceledException) {
+            // IntelliJ control-flow exception (e.g. project disposed mid-call) — must not be
+            // logged with LOG.error; rethrow so the coroutine machinery handles it cleanly.
+            throw e
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             val duration = System.currentTimeMillis() - startTime
             LOG.error("Tool execution failed: $toolName", e)
@@ -190,6 +217,10 @@ class JsonRpcHandler @JvmOverloads constructor(
     private fun recordHistorySafely(project: Project, commandEntry: CommandEntry) {
         try {
             recordHistory(project, commandEntry)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.warn("Failed to record command history for ${commandEntry.toolName}", e)
         }
@@ -204,6 +235,10 @@ class JsonRpcHandler @JvmOverloads constructor(
     ) {
         try {
             updateHistory(project, commandEntry.id, status, result, duration)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.warn("Failed to update command history for ${commandEntry.toolName}", e)
         }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.util.Alarm
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -46,6 +47,21 @@ class McpServerService(
     private var ktorServer: KtorMcpServer? = null
     private var serverError: ServerError? = null
 
+    // Watchdog: restarts the server if it stops unexpectedly.
+    // The reactive path (ApplicationStopped event) fires immediately; the safety-net
+    // alarm is a backup in case the reactive signal is missed.
+    @Volatile private var isShuttingDown = false
+    @Volatile private var restartAttempts = 0
+    private val watchdogAlarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, this)
+
+    companion object {
+        private val LOG = logger<McpServerService>()
+        private const val WATCHDOG_INTERVAL_MS = 30_000
+        private val RESTART_BACKOFF_MS = listOf(5_000, 15_000, 30_000)
+
+        fun getInstance(): McpServerService = service()
+    }
+
     /**
      * Represents a server error state.
      */
@@ -57,12 +73,6 @@ class McpServerService(
     @Volatile
     var isInitialized: Boolean = false
         private set
-
-    companion object {
-        private val LOG = logger<McpServerService>()
-
-        fun getInstance(): McpServerService = service()
-    }
 
     init {
         LOG.info("Initializing MCP Server Service (Protocol: ${McpConstants.MCP_PROTOCOL_VERSION})")
@@ -98,7 +108,7 @@ class McpServerService(
      * @return The result of the start operation
      */
     fun startServer(host: String, port: Int): KtorMcpServer.StartResult {
-        // Stop existing server if running
+        watchdogAlarm.cancelAllRequests()
         stopServer()
 
         LOG.info("Starting MCP Server on $host:$port")
@@ -108,7 +118,8 @@ class McpServerService(
             host = host,
             jsonRpcHandler = jsonRpcHandler,
             sseSessionManager = sseSessionManager,
-            coroutineScope = coroutineScope
+            coroutineScope = coroutineScope,
+            onUnexpectedStop = { scheduleRestart() }
         )
 
         val result = when (val startResult = server.start()) {
@@ -116,6 +127,7 @@ class McpServerService(
                 ktorServer = server
                 serverError = null
                 LOG.info("MCP Server started successfully on $host:$port")
+                scheduleWatchdog()
                 startResult
             }
             is KtorMcpServer.StartResult.PortInUse -> {
@@ -266,8 +278,45 @@ class McpServerService(
         }, ModalityState.any())
     }
 
+    private fun scheduleRestart() {
+        if (isShuttingDown) return
+        val delayMs = RESTART_BACKOFF_MS.getOrElse(restartAttempts) { RESTART_BACKOFF_MS.last() }.toLong()
+        restartAttempts++
+        LOG.warn("Scheduling MCP Server restart in ${delayMs}ms (attempt $restartAttempts)")
+        watchdogAlarm.addRequest({
+            if (!isShuttingDown) {
+                val settings = McpSettings.getInstance()
+                val result = startServer(settings.serverHost, settings.serverPort)
+                if (result is KtorMcpServer.StartResult.Success) {
+                    restartAttempts = 0
+                    LOG.info("watchdog: MCP Server restarted successfully")
+                    scheduleWatchdog()
+                } else {
+                    LOG.warn("watchdog: MCP Server restart failed ($result) — will retry")
+                    scheduleRestart()
+                }
+            }
+        }, delayMs)
+    }
+
+    private fun scheduleWatchdog() {
+        if (isShuttingDown) return
+        watchdogAlarm.addRequest({
+            if (!isShuttingDown && isInitialized) {
+                if (!isServerRunning()) {
+                    LOG.warn("watchdog: MCP Server not running — triggering restart")
+                    scheduleRestart()
+                } else {
+                    scheduleWatchdog()
+                }
+            }
+        }, WATCHDOG_INTERVAL_MS.toLong())
+    }
+
     override fun dispose() {
         LOG.info("Disposing MCP Server Service")
+        isShuttingDown = true
+        watchdogAlarm.cancelAllRequests()
         stopServer()
         sseSessionManager.closeAllSessions()
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
@@ -1,17 +1,31 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ResponseFormatter
+import com.intellij.ide.impl.OpenProjectTask
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.roots.ModuleRootManager
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
+import java.nio.file.Path
+import kotlin.coroutines.resume
 
 internal data class AvailableProjectEntry(
     val name: String,
@@ -70,6 +84,12 @@ object ProjectResolver {
     private val LOG = logger<ProjectResolver>()
     private val json = Json { encodeDefaults = true; prettyPrint = false }
 
+    // Serialises concurrent auto-opens so only one project indexes at a time.
+    // Without this, multiple Claude sessions starting simultaneously each trigger
+    // resolveOrOpen for their own closed project, causing simultaneous indexing
+    // that starves the Ktor HTTP threads and causes client timeouts.
+    private val reopenMutex = Mutex()
+
     fun normalizePath(path: String): String {
         return path.trimEnd('/', '\\').replace('\\', '/')
     }
@@ -86,12 +106,23 @@ object ProjectResolver {
 
         // No projects open
         if (openProjects.isEmpty()) {
+            val closedManaged = runCatching {
+                ProjectModeService.getInstance().getAllManagedModes()
+                    .filterValues { it == ProjectMode.CLOSED }
+                    .keys.toList()
+            }.getOrDefault(emptyList())
             return Result(
                 isError = true,
                 errorResult = buildStructuredErrorResult(
                     payload = buildJsonObject {
                         put("error", ErrorMessages.ERROR_NO_PROJECT_OPEN)
                         put("message", ErrorMessages.MSG_NO_PROJECT_OPEN)
+                        if (closedManaged.isNotEmpty()) {
+                            put("hint", "These projects were closed by the lifecycle manager and will auto-reopen if you retry with project_path set to one of them.")
+                            put("managed_closed_projects", buildJsonArray {
+                                closedManaged.forEach { add(it) }
+                            })
+                        }
                     },
                     format = responseFormat()
                 )
@@ -129,6 +160,7 @@ object ProjectResolver {
                     payload = buildJsonObject {
                         put("error", ErrorMessages.ERROR_PROJECT_NOT_FOUND)
                         put("message", ErrorMessages.msgProjectNotFound(projectPath))
+                        put("hint", diagnoseProjectPath(normalizedPath))
                         put("available_projects", buildAvailableProjectsArray(openProjects))
                     },
                     format = responseFormat()
@@ -236,6 +268,159 @@ object ProjectResolver {
         runCatching { McpSettings.getInstance().availableProjectsMode }
             .getOrDefault(McpSettings.AvailableProjectsMode.EXPANDED) ==
             McpSettings.AvailableProjectsMode.EXPANDED
+
+    /**
+     * Like [resolve], but also handles auto-opening projects that were closed by the
+     * MCP lifecycle manager. When a CLOSED managed project is targeted by project_path,
+     * this function reopens it, waits for indexing to complete, and returns it.
+     *
+     * Falls back to [resolve] for all other cases.
+     */
+    suspend fun resolveOrOpen(projectPath: String?): Result {
+        // Fast path: project is already open
+        val standard = resolve(projectPath)
+        if (!standard.isError) return standard
+
+        // Check if the path matches a project we intentionally closed
+        if (projectPath != null) {
+            val normalizedPath = normalizePath(projectPath)
+            val modeService = runCatching { ProjectModeService.getInstance() }.getOrNull()
+            val lifecycleEnabled = runCatching { McpSettings.getInstance().lifecycleEnabled }.getOrDefault(false)
+            if (lifecycleEnabled && modeService != null && modeService.wasClosedByUs(normalizedPath)) {
+                LOG.info("Auto-opening closed managed project: $normalizedPath")
+                val project = reopenAndAwaitSmartMode(normalizedPath)
+                    ?: run {
+                        LOG.warn("reopenAndAwaitSmartMode returned null for managed-closed project: $normalizedPath — ProjectManagerEx.openProjectAsync failed or was cancelled")
+                        return buildErrorResult("Failed to reopen managed project: $normalizedPath", projectPath)
+                    }
+                modeService.markReopened(normalizedPath)
+                modeService.resetInactivityTimer(project)
+                return Result(project = project)
+            }
+
+            // Path given but not resolvable — upgrade the error with path diagnosis.
+            return buildErrorResult(ErrorMessages.msgProjectNotFound(projectPath), projectPath)
+        }
+
+        // No project_path given — only attempt auto-open when there are literally no open
+        // projects. If there are open projects but we got an error above, the caller gave
+        // no project_path and multiple projects are open (MULTIPLE_PROJECTS disambiguation
+        // error), or the path was wrong. Auto-opening a random closed project would silently
+        // misroute the call; return the original disambiguation error instead.
+        val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDefault }
+        if (openProjects.isNotEmpty()) return standard
+
+        val lifecycleEnabled2 = runCatching { McpSettings.getInstance().lifecycleEnabled }.getOrDefault(false)
+        if (!lifecycleEnabled2) return standard
+
+        val modeService = runCatching { ProjectModeService.getInstance() }.getOrNull()
+        val fallbackPath = modeService?.getAllManagedModes()
+            ?.filterValues { it == com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode.CLOSED }
+            ?.keys?.firstOrNull()
+        if (fallbackPath != null) {
+            LOG.info("No open projects and no project_path — auto-opening managed project: $fallbackPath")
+            val project = reopenAndAwaitSmartMode(fallbackPath)
+            if (project != null) {
+                modeService?.markReopened(fallbackPath)
+                modeService?.resetInactivityTimer(project)
+                return Result(project = project)
+            }
+            LOG.warn("reopenAndAwaitSmartMode returned null for null-path fallback: $fallbackPath — ProjectManagerEx.openProjectAsync failed or was cancelled")
+        }
+
+        return standard
+    }
+
+    private suspend fun reopenAndAwaitSmartMode(path: String): Project? {
+        // Only serialise the openProjectAsync call itself, not the indexing wait.
+        //
+        // The burst problem: multiple Claude sessions starting simultaneously each call
+        // resolveOrOpen() for their own closed project. If all call openProjectAsync at
+        // the same instant, IntelliJ's internal file-parsing threads saturate immediately,
+        // starving Ktor HTTP workers in the same JVM and causing client timeouts.
+        //
+        // The fix: hold the Mutex only around openProjectAsync (1-5 seconds), then release
+        // it before waiting for smart mode. Projects that were already opened while a caller
+        // waited are detected by the fast-path check. Indexing of multiple projects then
+        // happens in parallel — which is IntelliJ's normal multi-project state — but the
+        // initial open calls are staggered rather than fired all at once.
+        val project = reopenMutex.withLock {
+            // Fast path: a previous queued caller already opened this project.
+            ProjectManager.getInstance().openProjects
+                .find { normalizePath(it.basePath ?: "") == normalizePath(path) }
+                ?: withContext(NonCancellable) {
+                    try {
+                        ProjectManagerEx.getInstanceEx().openProjectAsync(Path.of(path), openTask())
+                    } catch (e: Throwable) {
+                        if (e.message?.contains("already opened") == true) {
+                            ProjectManager.getInstance().openProjects
+                                .find { normalizePath(it.basePath ?: "") == normalizePath(path) }
+                        } else {
+                            LOG.warn("Failed to reopen managed project at $path: ${e.message}")
+                            null
+                        }
+                    }
+                }
+        } ?: return null
+
+        // Wait for indexing outside the Mutex so other callers can start opening their own
+        // projects in parallel. If the HTTP caller cancels (timeout), still return the project
+        // so markReopened is called and the next request succeeds without re-opening.
+        // DumbService.runWhenSmart must be called from non-modal EDT context — calling it
+        // from a pooled thread (ModalityState.ANY) triggers a suppressed-exception warning
+        // in IntelliJ 2026+.
+        runCatching {
+            suspendCancellableCoroutine { continuation ->
+                ApplicationManager.getApplication().invokeLater({
+                    if (!project.isDisposed) {
+                        DumbService.getInstance(project).runWhenSmart {
+                            if (!continuation.isCompleted) continuation.resume(Unit)
+                        }
+                    } else {
+                        continuation.cancel()
+                    }
+                }, ModalityState.nonModal())
+            }
+        }
+
+        return project
+    }
+
+    private fun openTask(): OpenProjectTask =
+        OpenProjectTask.build().withForceOpenInNewFrame(true)
+
+    private fun buildErrorResult(message: String, projectPath: String): Result {
+        val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDefault }
+        return Result(
+            isError = true,
+            errorResult = buildStructuredErrorResult(
+                payload = buildJsonObject {
+                    put("error", ErrorMessages.ERROR_PROJECT_NOT_FOUND)
+                    put("message", message)
+                    put("hint", diagnoseProjectPath(normalizePath(projectPath)))
+                    put("requested_path", projectPath)
+                    put("available_projects", buildAvailableProjectsArray(openProjects))
+                },
+                format = responseFormat()
+            )
+        )
+    }
+
+    private fun diagnoseProjectPath(normalizedPath: String): String {
+        val dir = java.io.File(normalizedPath)
+        return when {
+            !dir.exists() -> "Path does not exist on disk."
+            !dir.isDirectory -> "Path is a file, not a directory — project_path must point to a project root directory."
+            !java.io.File(dir, ".idea").exists() ->
+                "Path exists but has no .idea directory — not an IntelliJ project. " +
+                "IntelliJ can only open projects initialised with a .idea directory. " +
+                "If this is a JavaScript, Python, or other non-JVM project without IntelliJ project files, " +
+                "use language-appropriate tools (Node, npm, etc.) instead of IDE MCP tools."
+            else ->
+                "Path has a .idea directory but is not open in IntelliJ. " +
+                "Use ide_open_project to open it, or check ide_project_status to see if it is managed and closed."
+        }
+    }
 
     private fun responseFormat(): McpSettings.ResponseFormat =
         runCatching { McpSettings.getInstance().responseFormat }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServer.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServer.kt
@@ -54,10 +54,13 @@ class KtorMcpServer(
     private val host: String = McpConstants.DEFAULT_SERVER_HOST,
     private val jsonRpcHandler: JsonRpcHandler,
     private val sseSessionManager: KtorSseSessionManager,
-    private val coroutineScope: CoroutineScope
+    private val coroutineScope: CoroutineScope,
+    private val onUnexpectedStop: (() -> Unit)? = null
 ) : Disposable {
 
     private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    @Volatile private var intentionallyStopped = false
+    @Volatile private var engineRunning = false
 
     companion object {
         private val LOG = logger<KtorMcpServer>()
@@ -83,10 +86,22 @@ class KtorMcpServer(
      * @return StartResult indicating success or failure with details
      */
     fun start(): StartResult {
+        intentionallyStopped = false
         return try {
-            server = embeddedServer(CIO, port = port, host = host) {
+            val embeddedServer = embeddedServer(CIO, port = port, host = host) {
                 configureRouting()
             }
+            embeddedServer.environment.monitor.subscribe(ApplicationStarted) {
+                engineRunning = true
+            }
+            embeddedServer.environment.monitor.subscribe(ApplicationStopped) {
+                engineRunning = false
+                if (!intentionallyStopped) {
+                    LOG.warn("MCP Server stopped unexpectedly on $host:$port")
+                    onUnexpectedStop?.invoke()
+                }
+            }
+            server = embeddedServer
             server?.start(wait = false)
 
             LOG.info("MCP Server started on http://$host:$port")
@@ -112,6 +127,8 @@ class KtorMcpServer(
      * Stops the server gracefully.
      */
     fun stop() {
+        intentionallyStopped = true
+        engineRunning = false
         try {
             server?.stop(1000, 2000)
             server = null
@@ -124,8 +141,11 @@ class KtorMcpServer(
 
     /**
      * Returns whether the server is currently running.
+     * Tracks actual engine lifecycle via ApplicationStarted/ApplicationStopped events —
+     * `server != null` alone is insufficient because the Ktor engine can die internally
+     * while the server reference stays set.
      */
-    fun isRunning(): Boolean = server != null
+    fun isRunning(): Boolean = server != null && engineRunning
 
     override fun dispose() = stop()
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -38,10 +38,23 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
             "ide_build_project", "ide_close_project", "ide_file_structure", "ide_find_symbol",
             "ide_open_project", "ide_read_file", "ide_get_active_file", "ide_open_file",
             "ide_reformat_code", "ide_optimize_imports", "ide_convert_java_to_kotlin",
-            "ide_set_power_save_mode", "ide_install_plugin", "ide_restart"
+            "ide_set_power_save_mode", "ide_install_plugin", "ide_restart",
+            "ide_enroll_all_projects", "ide_get_project_modes", "ide_lifecycle_log",
+            "ide_set_lifecycle_log_file", "ide_release_all_projects",
+            "ide_release_project", "ide_set_all_project_modes", "ide_set_project_mode"
         ),
         var serverPort: Int = -1, // -1 means use IDE-specific default
-        var serverHost: String = McpConstants.DEFAULT_SERVER_HOST
+        var serverHost: String = McpConstants.DEFAULT_SERVER_HOST,
+        // Lifecycle management
+        var lifecycleEnabled: Boolean = false,
+        var focusToBackgroundMinutes: Int = 2,
+        var backgroundToDormantMinutes: Int = 2,
+        var dormantToClosedMinutes: Int = 10,
+        var lifecycleLogBufferSize: Int = 500,
+        // Set true to write events to mcp-lifecycle.log (also enabled by LOG.isDebugEnabled).
+        // Introduced in the stateless-tools PR; declared here so LifecycleEventLog can read it.
+        var lifecycleLogToFile: Boolean = false,
+        var minimumOpenProjects: Int = 4,
     )
 
     private var state = State()
@@ -79,6 +92,35 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
     var serverHost: String
         get() = state.serverHost
         set(value) { state.serverHost = value }
+
+    var lifecycleEnabled: Boolean
+        get() = state.lifecycleEnabled
+        set(value) { state.lifecycleEnabled = value }
+
+    var focusToBackgroundMinutes: Int
+        get() = state.focusToBackgroundMinutes
+        set(value) { state.focusToBackgroundMinutes = value }
+
+    var backgroundToDormantMinutes: Int
+        get() = state.backgroundToDormantMinutes
+        set(value) { state.backgroundToDormantMinutes = value }
+
+    var dormantToClosedMinutes: Int
+        get() = state.dormantToClosedMinutes
+        set(value) { state.dormantToClosedMinutes = value }
+
+    var lifecycleLogBufferSize: Int
+        get() = state.lifecycleLogBufferSize
+        set(value) { state.lifecycleLogBufferSize = value }
+
+    var lifecycleLogToFile: Boolean
+        get() = state.lifecycleLogToFile
+        set(value) { state.lifecycleLogToFile = value }
+
+    var minimumOpenProjects: Int
+        get() = state.minimumOpenProjects
+        set(value) { state.minimumOpenProjects = value }
+
 
     fun isToolEnabled(toolName: String): Boolean = toolName !in state.disabledTools
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -2,6 +2,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.settings
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpBundle
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorMcpServer
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
 import com.intellij.icons.AllIcons
@@ -52,6 +53,16 @@ class McpSettingsConfigurable : Configurable {
     private var responseFormatComboBox: ComboBox<McpSettings.ResponseFormat>? = null
     private val toolCheckBoxes = mutableMapOf<String, JBCheckBox>()
     private var uiDisposable: Disposable? = null
+
+    // Lifecycle UI fields
+    private var lifecycleEnabledCheckBox: JBCheckBox? = null
+    private var focusToBackgroundSpinner: JSpinner? = null
+    private var backgroundToDormantSpinner: JSpinner? = null
+    private var dormantToClosedSpinner: JSpinner? = null
+    private var lifecycleLogBufferSizeSpinner: JSpinner? = null
+    private var lifecycleLogToFileCheckBox: JBCheckBox? = null
+    private var minimumOpenProjectsSpinner: JSpinner? = null
+    private var managedProjectsContent: JPanel? = null
 
     private var lastHostValidation: ValidationInfo? = null
     private var hostValidationErrorLabel: JBLabel? = null
@@ -129,6 +140,7 @@ class McpSettingsConfigurable : Configurable {
         }
 
         val availableToolsPanel = createToolsPanel()
+        val lifecyclePanel = createLifecyclePanel()
 
         panel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel(McpBundle.message("settings.serverHost") + ":"), serverHostInputRow, 1, false)
@@ -139,12 +151,166 @@ class McpSettingsConfigurable : Configurable {
             .addLabeledComponent(JBLabel(McpBundle.message("settings.responseFormat") + ":"), responseFormatComboBox!!, 1, false)
             .addComponent(syncPanel, 1)
             .addSeparator(10)
+            .addComponent(JBLabel(McpBundle.message("lifecycle.section.title")), 5)
+            .addComponent(lifecyclePanel, 1)
+            .addSeparator(10)
             .addComponent(JBLabel(McpBundle.message("settings.tools.title")), 5)
             .addComponent(availableToolsPanel, 5)
             .addComponentFillVertically(JPanel(), 0)
             .panel
 
         return panel!!
+    }
+
+    private fun createLifecyclePanel(): JComponent {
+        val settings = McpSettings.getInstance()
+        lifecycleEnabledCheckBox = JBCheckBox(McpBundle.message("lifecycle.enabled.label"), settings.lifecycleEnabled)
+        focusToBackgroundSpinner = JSpinner(SpinnerNumberModel(settings.focusToBackgroundMinutes, 1, 60, 1))
+        backgroundToDormantSpinner = JSpinner(SpinnerNumberModel(settings.backgroundToDormantMinutes, 1, 60, 1))
+        dormantToClosedSpinner = JSpinner(SpinnerNumberModel(settings.dormantToClosedMinutes, 1, 120, 1))
+        lifecycleLogBufferSizeSpinner = JSpinner(SpinnerNumberModel(settings.lifecycleLogBufferSize, 100, 10000, 100))
+        lifecycleLogToFileCheckBox = JBCheckBox(McpBundle.message("lifecycle.logToFile.label"), settings.lifecycleLogToFile)
+        minimumOpenProjectsSpinner = JSpinner(SpinnerNumberModel(settings.minimumOpenProjects, 1, 20, 1))
+
+        return FormBuilder.createFormBuilder()
+            .addComponent(lifecycleEnabledCheckBox!!)
+            .addLabeledComponent(JBLabel(McpBundle.message("lifecycle.focusToBackground.label")), focusToBackgroundSpinner!!, 1, false)
+            .addLabeledComponent(JBLabel(McpBundle.message("lifecycle.backgroundToDormant.label")), backgroundToDormantSpinner!!, 1, false)
+            .addLabeledComponent(JBLabel(McpBundle.message("lifecycle.dormantToClosed.label")), dormantToClosedSpinner!!, 1, false)
+            .addLabeledComponent(JBLabel(McpBundle.message("lifecycle.minimumOpenProjects.label")), minimumOpenProjectsSpinner!!, 1, false)
+            .addLabeledComponent(JBLabel(McpBundle.message("lifecycle.logBufferSize.label")), lifecycleLogBufferSizeSpinner!!, 1, false)
+            .addComponent(lifecycleLogToFileCheckBox!!)
+            .addComponent(createManagedProjectsPanel())
+            .panel
+    }
+
+    private fun createManagedProjectsPanel(): JComponent {
+        val outer = JPanel().apply { layout = BoxLayout(this, BoxLayout.Y_AXIS) }
+
+        outer.add(JBLabel(McpBundle.message("lifecycle.managed.label")).apply {
+            border = JBUI.Borders.emptyTop(8)
+        })
+
+        val modeService = runCatching { ProjectModeService.getInstance() }.getOrNull()
+        if (modeService == null) {
+            outer.add(JBLabel(McpBundle.message("lifecycle.managed.unavailable")).apply { foreground = JBColor.GRAY })
+            return outer
+        }
+
+        val buttonRow = JPanel(FlowLayout(FlowLayout.LEFT, 0, 4)).apply {
+            val enrollAll = com.intellij.ui.components.JBLabel(McpBundle.message("lifecycle.enrollAll.button")).apply {
+                foreground = JBColor.BLUE
+                cursor = java.awt.Cursor(java.awt.Cursor.HAND_CURSOR)
+                border = JBUI.Borders.empty(0, 0, 0, 8)
+            }
+            enrollAll.addMouseListener(object : java.awt.event.MouseAdapter() {
+                override fun mouseClicked(e: java.awt.event.MouseEvent) {
+                    val open = com.intellij.openapi.project.ProjectManager.getInstance().openProjects.toList()
+                    modeService.enrollAll(open)
+                    refreshManagedProjectsPanel()
+                }
+            })
+            val releaseAll = com.intellij.ui.components.JBLabel(McpBundle.message("lifecycle.releaseAll.button")).apply {
+                foreground = JBColor.RED
+                cursor = java.awt.Cursor(java.awt.Cursor.HAND_CURSOR)
+            }
+            releaseAll.addMouseListener(object : java.awt.event.MouseAdapter() {
+                override fun mouseClicked(e: java.awt.event.MouseEvent) {
+                    modeService.releaseAll()
+                    refreshManagedProjectsPanel()
+                }
+            })
+            add(enrollAll)
+            add(releaseAll)
+        }
+        outer.add(buttonRow)
+
+        val content = JPanel().apply { layout = BoxLayout(this, BoxLayout.Y_AXIS) }
+        managedProjectsContent = content
+        refreshManagedProjectsPanel()
+
+        val scroll = javax.swing.JScrollPane(content).apply {
+            border = javax.swing.BorderFactory.createEmptyBorder()
+            preferredSize = java.awt.Dimension(preferredSize.width, 150)
+            verticalScrollBarPolicy = javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED
+            horizontalScrollBarPolicy = javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+        }
+        outer.add(scroll)
+        return outer
+    }
+
+    private fun refreshManagedProjectsPanel() {
+        val content = managedProjectsContent ?: return
+        val modeService = runCatching { ProjectModeService.getInstance() }.getOrNull() ?: return
+
+        content.removeAll()
+
+        val openProjects = com.intellij.openapi.project.ProjectManager.getInstance().openProjects
+            .filter { !it.isDefault }
+            .associateBy { it.basePath ?: "" }
+        val managedModes = modeService.getAllManagedModes()
+
+        val allPaths = (openProjects.keys + managedModes.keys).filter { it.isNotEmpty() }.toSortedSet()
+
+        if (allPaths.isEmpty()) {
+            content.add(JBLabel(McpBundle.message("lifecycle.managed.none")).apply { foreground = JBColor.GRAY })
+        } else {
+            for (path in allPaths) {
+                val openProject = openProjects[path]
+                val mode = managedModes[path]
+                val isManaged = mode != null
+                val isClosed = mode == com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode.CLOSED
+                val name = openProject?.name ?: path.substringAfterLast("/")
+
+                val row = JPanel(FlowLayout(FlowLayout.LEFT, 4, 1))
+
+                val checkbox = JBCheckBox("", isManaged).apply {
+                    isEnabled = openProject != null || isManaged
+                    addActionListener {
+                        if (isSelected) {
+                            if (openProject != null) modeService.enroll(openProject)
+                        } else {
+                            modeService.release(path)
+                        }
+                        refreshManagedProjectsPanel()
+                    }
+                }
+                row.add(checkbox)
+
+                val nameLabel = JBLabel(name).apply {
+                    if (isClosed || openProject == null) foreground = JBColor.GRAY
+                    toolTipText = path
+                }
+                row.add(nameLabel)
+
+                val modeText = when {
+                    mode != null -> "  [${mode.name.lowercase()}]"
+                    else -> "  [not managed]"
+                }
+                row.add(JBLabel(modeText).apply { foreground = JBColor.GRAY })
+
+                if (isManaged) {
+                    val xBtn = com.intellij.ui.components.JBLabel("✕").apply {
+                        foreground = JBColor.RED
+                        cursor = java.awt.Cursor(java.awt.Cursor.HAND_CURSOR)
+                        toolTipText = "Release from lifecycle management"
+                        border = JBUI.Borders.empty(0, 4, 0, 0)
+                    }
+                    xBtn.addMouseListener(object : java.awt.event.MouseAdapter() {
+                        override fun mouseClicked(e: java.awt.event.MouseEvent) {
+                            modeService.release(path)
+                            refreshManagedProjectsPanel()
+                        }
+                    })
+                    row.add(xBtn)
+                }
+
+                content.add(row)
+            }
+        }
+
+        content.revalidate()
+        content.repaint()
     }
 
     private fun createToolsPanel(): JComponent {
@@ -183,7 +349,14 @@ class McpSettingsConfigurable : Configurable {
             maxHistorySizeSpinner?.value != settings.maxHistorySize ||
             syncExternalChangesCheckBox?.isSelected != settings.syncExternalChanges ||
             availableProjectsModeComboBox?.selectedItem != settings.availableProjectsMode ||
-            responseFormatComboBox?.selectedItem != settings.responseFormat) {
+            responseFormatComboBox?.selectedItem != settings.responseFormat ||
+            lifecycleEnabledCheckBox?.isSelected != settings.lifecycleEnabled ||
+            focusToBackgroundSpinner?.value != settings.focusToBackgroundMinutes ||
+            backgroundToDormantSpinner?.value != settings.backgroundToDormantMinutes ||
+            dormantToClosedSpinner?.value != settings.dormantToClosedMinutes ||
+            lifecycleLogBufferSizeSpinner?.value != settings.lifecycleLogBufferSize ||
+            lifecycleLogToFileCheckBox?.isSelected != settings.lifecycleLogToFile ||
+            minimumOpenProjectsSpinner?.value != settings.minimumOpenProjects) {
             return true
         }
 
@@ -243,6 +416,14 @@ class McpSettingsConfigurable : Configurable {
         settings.responseFormat =
             responseFormatComboBox?.selectedItem as? McpSettings.ResponseFormat
                 ?: McpSettings.ResponseFormat.JSON
+
+        settings.lifecycleEnabled = lifecycleEnabledCheckBox?.isSelected ?: true
+        settings.focusToBackgroundMinutes = focusToBackgroundSpinner?.value as? Int ?: 2
+        settings.backgroundToDormantMinutes = backgroundToDormantSpinner?.value as? Int ?: 2
+        settings.dormantToClosedMinutes = dormantToClosedSpinner?.value as? Int ?: 10
+        settings.lifecycleLogBufferSize = lifecycleLogBufferSizeSpinner?.value as? Int ?: 500
+        settings.lifecycleLogToFile = lifecycleLogToFileCheckBox?.isSelected ?: false
+        settings.minimumOpenProjects = minimumOpenProjectsSpinner?.value as? Int ?: 4
 
         val disabledTools = mutableSetOf<String>()
         for ((toolName, checkbox) in toolCheckBoxes) {
@@ -338,6 +519,14 @@ class McpSettingsConfigurable : Configurable {
         isHostValidationPending = false
         lastHostValidation = null
 
+        lifecycleEnabledCheckBox?.isSelected = settings.lifecycleEnabled
+        focusToBackgroundSpinner?.value = settings.focusToBackgroundMinutes
+        backgroundToDormantSpinner?.value = settings.backgroundToDormantMinutes
+        dormantToClosedSpinner?.value = settings.dormantToClosedMinutes
+        lifecycleLogBufferSizeSpinner?.value = settings.lifecycleLogBufferSize
+        lifecycleLogToFileCheckBox?.isSelected = settings.lifecycleLogToFile
+        minimumOpenProjectsSpinner?.value = settings.minimumOpenProjects
+
         for ((toolName, checkbox) in toolCheckBoxes) {
             checkbox.isSelected = settings.isToolEnabled(toolName)
         }
@@ -428,6 +617,14 @@ class McpSettingsConfigurable : Configurable {
         availableProjectsModeComboBox = null
         responseFormatComboBox = null
         toolCheckBoxes.clear()
+        lifecycleEnabledCheckBox = null
+        focusToBackgroundSpinner = null
+        backgroundToDormantSpinner = null
+        dormantToClosedSpinner = null
+        lifecycleLogBufferSizeSpinner = null
+        lifecycleLogToFileCheckBox = null
+        minimumOpenProjectsSpinner = null
+        managedProjectsContent = null
         uiDisposable?.let { Disposer.dispose(it) }
         uiDisposable = null
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -10,6 +10,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ClassResolver
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
@@ -133,6 +134,15 @@ abstract class AbstractMcpTool : McpTool {
     protected open val requiresPsiSync: Boolean = true
 
     /**
+     * Whether this tool participates in lifecycle management (auto-enroll, auto-wake).
+     *
+     * Tools that explicitly manage lifecycle state (e.g., [ReleaseProjectTool]) should
+     * return false so they observe the project's actual managed state rather than
+     * triggering enrollment as a side effect of being called.
+     */
+    protected open val participatesInLifecycle: Boolean = true
+
+    /**
      * Human-readable list of languages that currently support language+symbol lookup.
      */
     protected fun supportedSymbolReferenceLanguagesDescription(): String {
@@ -222,11 +232,30 @@ abstract class AbstractMcpTool : McpTool {
      * @return A [ToolCallResult] containing the operation result or error
      */
     final override suspend fun execute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeService = ProjectModeService.getInstance()
+        if (participatesInLifecycle && McpSettings.getInstance().lifecycleEnabled) {
+            if (!modeService.isManaged(project)) {
+                modeService.enroll(project)
+            } else {
+                modeService.wakeForMcp(project)
+            }
+        }
+
         val settings = McpSettings.getInstance()
         if (requiresPsiSync && settings.syncExternalChanges) {
             ensurePsiUpToDate(project)
         }
-        return doExecute(project, arguments)
+        return try {
+            doExecute(project, arguments)
+        } catch (e: com.intellij.openapi.project.IndexNotReadyException) {
+            // The IDE entered dumb mode (reindexing) during this call. This can happen
+            // when a project has just woken from dormant or a background process triggered
+            // reindexing. The caller should check ide_index_status and retry.
+            createErrorResult(
+                "IDE index is not ready — indexing is in progress. " +
+                "Call ide_index_status to check when it completes, then retry."
+            )
+        }
     }
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -14,6 +14,15 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSymbo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.ReadFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.EnrollAllProjectsTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.GetProjectModesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.LifecycleLogTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ProjectStatusTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ReleaseAllProjectsTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ReleaseProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetAllProjectModesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetLifecycleLogFileTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetProjectModeTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CloseProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
@@ -262,6 +271,17 @@ class ToolRegistry {
         // Editor tools (universal, disabled by default)
         register(GetActiveFileTool())
         register(OpenFileTool())
+
+        // Lifecycle tools
+        register(EnrollAllProjectsTool())
+        register(GetProjectModesTool())
+        register(LifecycleLogTool())
+        register(SetLifecycleLogFileTool())
+        register(ProjectStatusTool())
+        register(ReleaseAllProjectsTool())
+        register(ReleaseProjectTool())
+        register(SetProjectModeTool())
+        register(SetAllProjectModesTool())
 
         LOG.info("Registered universal tools (available in all JetBrains IDEs)")
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/EnrollAllProjectsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/EnrollAllProjectsTool.kt
@@ -1,0 +1,42 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import kotlinx.serialization.json.JsonObject
+
+class EnrollAllProjectsTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_enroll_all_projects"
+
+    override val description = """
+        Enroll all currently open projects in MCP lifecycle management.
+
+        Projects already managed are skipped. Only open projects can be enrolled —
+        closed projects must be opened first (via ide_open_project or auto-open).
+
+        Parameters:
+        - project_path (optional): Routing hint when multiple projects are open.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool().projectPath().build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeService = ProjectModeService.getInstance()
+        val openProjects = ProjectManager.getInstance().openProjects.filter { !it.isDefault }
+        val before = openProjects.count { modeService.isManaged(it) }
+        modeService.enrollAll(openProjects)
+        val enrolled = openProjects.count { modeService.isManaged(it) } - before
+        val already = openProjects.size - enrolled
+        return createSuccessResult(
+            "Enrolled $enrolled project${if (enrolled == 1) "" else "s"}" +
+            if (already > 0) " ($already already managed)." else "."
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/GetProjectModesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/GetProjectModesTool.kt
@@ -1,0 +1,59 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class GetProjectModesTool : AbstractMcpTool() {
+
+    override val requiresPsiSync: Boolean = false
+    override val participatesInLifecycle: Boolean = false
+
+    override val name = "ide_get_project_modes"
+
+    override val description = """
+        List all MCP-managed projects and their current lifecycle mode.
+
+        Returns each managed project's path, name, and current mode
+        (active, background, dormant, or closed). Use this to decide
+        which projects need waking before starting work, or to audit
+        current memory usage patterns.
+
+        Parameters:
+        - project_path (optional): only needed when multiple projects are open; does not
+          affect which projects are listed — all managed projects are always returned.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool().projectPath().build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeService = ProjectModeService.getInstance()
+        val allModes = modeService.getAllManagedModes()
+
+        if (allModes.isEmpty()) {
+            return createSuccessResult("No projects are currently managed by MCP lifecycle. " +
+                "Projects are enrolled automatically on first MCP tool use.")
+        }
+
+        val result = buildJsonObject {
+            put("managed_projects", buildJsonArray {
+                allModes.forEach { (path, mode) ->
+                    add(buildJsonObject {
+                        put("path", path)
+                        put("name", path.substringAfterLast("/"))
+                        put("mode", mode.name.lowercase())
+                    })
+                }
+            })
+            put("total", allModes.size)
+        }
+
+        return createJsonResult(result)
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/LifecycleLogTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/LifecycleLogTool.kt
@@ -1,0 +1,66 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.LifecycleEventLog
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class LifecycleLogTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_lifecycle_log"
+
+    override val description = """
+        Return recent lifecycle events for all projects.
+
+        Records every state transition, open/close, focus change, timer firing, and MCP-triggered
+        wake in a ring buffer (last 500 events). Events cover all IntelliJ projects, not just
+        managed ones.
+
+        The same log is written to a file (see log_file in the response) that can be read directly
+        even when no project is open: `cat <log_file>` or `tail -f <log_file>`.
+
+        Use this to diagnose lifecycle health: understand why a project closed, whether auto-open
+        worked, or which projects are cycling unexpectedly.
+
+        Event types: open, closed, transition, enroll, release, wake
+        Trigger values: focus_gained, focus_lost, timer:focus, timer:inactivity, timer:close,
+                        mcp_call, auto_open, user
+
+        Parameters:
+        - limit: Number of recent events to return, newest first (default 50, max 500)
+        - project: Optional path filter — only events for projects whose path contains this string
+        - project_path: Routing hint when multiple projects are open
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .intProperty("limit", "Number of recent events to return, newest first (default 50, max 500).")
+        .stringProperty("project", "Optional path filter (substring match against project path).")
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val limit = arguments["limit"]?.jsonPrimitive?.intOrNull ?: 50
+        val pathFilter = optionalStringArg(arguments, "project")
+
+        val log = LifecycleEventLog.getInstance()
+        val events = log.recent(limit, pathFilter)
+
+        val result = buildJsonObject {
+            put("events", buildJsonArray { events.forEach { add(it.toJson()) } })
+            put("log_file", log.logFilePath.toString())
+            put("buffered", log.size)
+        }
+
+        return createJsonResult(result)
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ProjectStatusTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ProjectStatusTool.kt
@@ -1,0 +1,91 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class ProjectStatusTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_project_status"
+
+    override val description = """
+        Report the status of all known projects in one table.
+
+        Combines two sources:
+        - Open projects: every project currently loaded in the IDE
+        - Managed projects: projects enrolled in MCP lifecycle management
+
+        Each row includes whether the project is open, whether it is managed, and
+        its current lifecycle mode (active, background, dormant, closed) when managed.
+
+        Use this to answer questions like:
+        - Which open projects are not yet enrolled in lifecycle management?
+        - Which managed projects have been closed by the lifecycle manager?
+        - What is the current state of every project at a glance?
+
+        Parameters:
+        - project_path (optional): routing hint, required when multiple projects are open.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool().projectPath().build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val lifecycleEnabled = McpSettings.getInstance().lifecycleEnabled
+        val managedModes = if (lifecycleEnabled)
+            ProjectModeService.getInstance().getAllManagedModes()
+        else
+            emptyMap()
+
+        val openProjects = ProjectManager.getInstance().openProjects
+            .filter { !it.isDefault }
+            .associate { (it.basePath ?: "") to it.name }
+
+        val allPaths = (openProjects.keys + managedModes.keys).filter { it.isNotEmpty() }.toSortedSet()
+
+        val projects = allPaths.map { path ->
+            val isOpen = path in openProjects
+            val mode = managedModes[path]
+            buildJsonObject {
+                put("name", openProjects[path] ?: path.substringAfterLast("/"))
+                put("path", path)
+                put("open", isOpen)
+                put("managed", mode != null)
+                if (mode != null) put("mode", mode.name.lowercase())
+            }
+        }.sortedWith(
+            compareByDescending<JsonObject> { it["open"].toString() == "true" }
+                .thenBy { it["name"].toString().trim('"') }
+        )
+
+        val openCount = projects.count { it["open"].toString() == "true" }
+        val managedCount = projects.count { it["managed"].toString() == "true" }
+
+        val result = buildJsonObject {
+            put("projects", buildJsonArray { projects.forEach { add(it) } })
+            put("summary", buildJsonObject {
+                put("total", projects.size)
+                put("open", openCount)
+                put("managed", managedCount)
+                put("open_not_managed", projects.count {
+                    it["open"].toString() == "true" && it["managed"].toString() == "false"
+                })
+                put("managed_closed", projects.count {
+                    it["managed"].toString() == "true" && it["open"].toString() == "false"
+                })
+            })
+        }
+
+        return createJsonResult(result)
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ReleaseAllProjectsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ReleaseAllProjectsTool.kt
@@ -1,0 +1,35 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+
+class ReleaseAllProjectsTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_release_all_projects"
+
+    override val description = """
+        Release every managed project from MCP lifecycle management at once.
+
+        Works on all managed projects including those currently closed by the lifecycle
+        manager. Power Save Mode is disabled after all releases complete.
+
+        Parameters:
+        - project_path (optional): Routing hint when multiple projects are open.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool().projectPath().build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeService = ProjectModeService.getInstance()
+        val count = modeService.getAllManagedModes().size
+        modeService.releaseAll()
+        return createSuccessResult("Released $count project${if (count == 1) "" else "s"} from MCP lifecycle management.")
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ReleaseProjectTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ReleaseProjectTool.kt
@@ -1,0 +1,63 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+
+class ReleaseProjectTool : AbstractMcpTool() {
+
+    override val requiresPsiSync: Boolean = false
+    override val participatesInLifecycle: Boolean = false
+
+    override val name = "ide_release_project"
+
+    override val description = """
+        Release a project from MCP lifecycle management, returning full control to the user.
+
+        Accepts an optional path parameter to release a project that is currently closed by
+        the lifecycle manager — the project does not need to be open.
+
+        After release:
+        - Power Save Mode is disabled
+        - All lifecycle timers are cancelled
+        - The project is no longer auto-slept or auto-closed by MCP
+        - Open projects remain open with full IntelliJ capabilities
+
+        Use ide_release_all_projects to release every managed project at once.
+
+        Parameters:
+        - path (optional): Filesystem path of a closed managed project to release by path.
+          If omitted, releases the project resolved by project_path (must be open).
+        - project_path (optional): Routing hint when multiple projects are open.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .stringProperty("path", "Filesystem path of a closed managed project to release. Omit to release the routed project.")
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeService = ProjectModeService.getInstance()
+        val explicitPath = optionalStringArg(arguments, "path")
+
+        if (explicitPath != null) {
+            if (!modeService.isManaged(explicitPath)) {
+                return createSuccessResult("'$explicitPath' is not managed by MCP lifecycle — nothing to release.")
+            }
+            modeService.release(explicitPath)
+            return createSuccessResult("'${explicitPath.substringAfterLast("/")}' released from MCP lifecycle management.")
+        }
+
+        if (!modeService.isManaged(project)) {
+            return createSuccessResult("Project '${project.name}' is not managed by MCP lifecycle — nothing to release.")
+        }
+        modeService.release(project)
+        return createSuccessResult(
+            "Project '${project.name}' released from MCP lifecycle management. " +
+            "Power Save Mode disabled. Full IntelliJ capabilities restored."
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/SetAllProjectModesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/SetAllProjectModesTool.kt
@@ -1,0 +1,76 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class SetAllProjectModesTool : AbstractMcpTool() {
+
+    override val requiresPsiSync: Boolean = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_set_all_project_modes"
+
+    override val description = """
+        Set the lifecycle mode for every currently managed open project at once.
+
+        CLOSED projects are skipped — they have no open Project object and cannot
+        be transitioned directly. Use ide_open_project or ide_set_project_mode on
+        a specific project to bring a closed project back first.
+
+        When multiple projects are open, supply any one of them as project_path to
+        satisfy the JSON-RPC resolver. The mode is applied to all managed open
+        projects regardless of which project is specified.
+
+        Parameters:
+        - mode: Target mode for all managed open projects (active, background, dormant)
+        - project_path (optional): Routing hint required when multiple projects are open;
+          does not limit which projects are affected.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .enumProperty(
+            "mode",
+            "Target mode: active, background, or dormant. (closed is not supported — use ide_set_project_mode per project.)",
+            listOf("active", "background", "dormant"),
+            required = true
+        )
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeStr = arguments["mode"]?.jsonPrimitive?.content
+            ?: return createErrorResult("Missing required parameter: mode")
+
+        val mode = when (modeStr.lowercase()) {
+            "active" -> ProjectMode.ACTIVE
+            "background" -> ProjectMode.BACKGROUND
+            "dormant" -> ProjectMode.DORMANT
+            else -> return createErrorResult(
+                "Invalid mode '$modeStr'. Valid values: active, background, dormant"
+            )
+        }
+
+        val modeService = ProjectModeService.getInstance()
+        val managedPaths = modeService.getAllManagedModes().keys
+        val openProjects = ProjectManager.getInstance().openProjects
+            .filter { !it.isDefault && managedPaths.contains(it.basePath) }
+
+        if (openProjects.isEmpty()) {
+            return createSuccessResult("No managed open projects found — nothing changed.")
+        }
+
+        openProjects.forEach { modeService.transition(it, mode) }
+
+        return createSuccessResult(
+            "Set ${openProjects.size} project(s) to ${mode.name.lowercase()}: " +
+                openProjects.joinToString(", ") { it.name }
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/SetLifecycleLogFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/SetLifecycleLogFileTool.kt
@@ -1,0 +1,56 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
+
+class SetLifecycleLogFileTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_set_lifecycle_log_file"
+
+    override val description = """
+        Enable or disable writing lifecycle events to the log file on disk.
+
+        The in-memory ring buffer (queryable via ide_lifecycle_log) is always active
+        regardless of this setting. This controls whether events are also appended to
+        the persistent log file alongside idea.log, allowing tail -f monitoring and
+        post-mortem analysis even when no MCP connection is available.
+
+        File output is also enabled automatically when IntelliJ's debug logger is active
+        for the lifecycle category (Help → Diagnostic Tools → Debug Log Settings,
+        add #com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle).
+
+        Parameters:
+        - enabled (required): true to start writing to the log file, false to stop
+        - project_path (optional): routing hint when multiple projects are open
+
+        Example: { "enabled": true }
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .booleanProperty("enabled", "true to write events to the log file, false to stop.", required = true)
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val enabled = arguments["enabled"]?.jsonPrimitive?.boolean
+            ?: return createErrorResult("Missing required parameter: enabled")
+
+        McpSettings.getInstance().lifecycleLogToFile = enabled
+
+        val logFile = PathManager.getLogPath() + "/mcp-lifecycle.log"
+        return createSuccessResult(
+            if (enabled) "Lifecycle log file enabled. Events are being written to: $logFile"
+            else "Lifecycle log file disabled. Events remain in the in-memory ring buffer (ide_lifecycle_log still works)."
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/SetProjectModeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/SetProjectModeTool.kt
@@ -1,0 +1,67 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class SetProjectModeTool : AbstractMcpTool() {
+
+    override val requiresPsiSync: Boolean = false
+
+    override val name = "ide_set_project_mode"
+
+    override val description = """
+        Set the lifecycle mode for a specific managed project.
+
+        Modes:
+        - active: Full IntelliJ capabilities. Power Save OFF. Use before code review or active editing.
+        - background: Power Save ON, index and MCP fully functional. Inspections and highlighting off.
+          Default mode when MCP is working. Transitions here automatically after focus is lost.
+        - dormant: Power Save ON, editors closed, PSI caches dropped. Index stays loaded.
+          MCP calls auto-wake to background. Transitions here after 2 min of MCP inactivity.
+        - closed: Project fully closed. All memory freed. Auto-reopens on next MCP call (5-15s delay).
+          Transitions here after 10 min of MCP inactivity.
+
+        Use ide_set_all_project_modes to apply a mode to every managed project at once.
+
+        Parameters:
+        - mode: Target mode (active, background, dormant, closed)
+        - project_path: Required when multiple projects are open.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .enumProperty(
+            "mode",
+            "Target mode: active, background, dormant, or closed.",
+            listOf("active", "background", "dormant", "closed"),
+            required = true
+        )
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val modeStr = arguments["mode"]?.jsonPrimitive?.content
+            ?: return createErrorResult("Missing required parameter: mode")
+
+        val mode = when (modeStr.lowercase()) {
+            "active" -> ProjectMode.ACTIVE
+            "background" -> ProjectMode.BACKGROUND
+            "dormant" -> ProjectMode.DORMANT
+            "closed" -> ProjectMode.CLOSED
+            else -> return createErrorResult(
+                "Invalid mode '$modeStr'. Valid values: active, background, dormant, closed"
+            )
+        }
+
+        val modeService = ProjectModeService.getInstance()
+        if (!modeService.isManaged(project)) modeService.enroll(project)
+        modeService.transition(project, mode)
+
+        return createSuccessResult("Project '${project.name}' mode set to ${mode.name.lowercase()}")
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/CloseProjectTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/CloseProjectTool.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.json.JsonObject
 class CloseProjectTool : AbstractMcpTool() {
 
     override val requiresPsiSync = false
+    // Closing a project is infrastructure — enrolling-then-closing would be nonsensical.
+    override val participatesInLifecycle = false
 
     override val name = "ide_close_project"
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/OpenProjectTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/OpenProjectTool.kt
@@ -24,6 +24,10 @@ import kotlin.coroutines.resume
 class OpenProjectTool : AbstractMcpTool() {
 
     override val requiresPsiSync = false
+    // Opening a project is infrastructure — it should not auto-enroll it in lifecycle
+    // management. Enrollment happens on the first real semantic tool call (find references,
+    // diagnostics, etc.) after the project is open, which signals genuine intent to work on it.
+    override val participatesInLifecycle = false
 
     override val name = "ide_open_project"
 
@@ -33,6 +37,10 @@ class OpenProjectTool : AbstractMcpTool() {
         Blocks until the IDE is ready for code intelligence on the opened project,
         so subsequent MCP tool calls against the new project will succeed immediately.
         If the project is already open, returns successfully right away.
+
+        This tool does not enroll the project in lifecycle management. Lifecycle enrollment
+        happens automatically on the first real semantic tool call (find references,
+        diagnostics, refactoring, etc.) after the project is open — not on open/close itself.
 
         Requires at least one project to already be open (needed as the JSON-RPC context).
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiCompiledElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
@@ -40,6 +41,11 @@ class RenameSymbolTool : AbstractMcpTool() {
 
     companion object {
         private val LOG = logger<RenameSymbolTool>()
+
+        /** Exposed for testing — builds the error message returned when the target is a compiled element. */
+        fun buildCompiledElementErrorMessage(elementName: String?, path: String): String =
+            "Cannot rename: '$elementName' is defined in a compiled class file ($path), not in editable source. " +
+            "Make sure the cursor is positioned on a symbol defined in source code within this project."
     }
 
     override val name = "ide_refactor_rename"
@@ -223,6 +229,16 @@ class RenameSymbolTool : AbstractMcpTool() {
                 oldName = "",
                 error = "No renameable symbol found at the specified position"
             )
+
+        // Reject compiled elements early — RenameProcessor constructor asserts on them.
+        if (namedElement is PsiCompiledElement) {
+            val loc = namedElement.containingFile?.virtualFile?.path ?: "unknown location"
+            return RenameValidation(
+                element = DummyNamedElement,
+                oldName = "",
+                error = buildCompiledElementErrorMessage(namedElement.name, loc)
+            )
+        }
 
         val oldName = namedElement.name
             ?: return RenameValidation(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ThreadingUtils.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ThreadingUtils.kt
@@ -7,10 +7,7 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 object ThreadingUtils {
 
@@ -54,22 +51,6 @@ object ThreadingUtils {
         exception?.let { throw it }
         @Suppress("UNCHECKED_CAST")
         return result as T
-    }
-
-    suspend fun <T> runWhenSmart(
-        project: Project,
-        action: () -> T
-    ): T {
-        return suspendCancellableCoroutine { continuation ->
-            DumbService.getInstance(project).runWhenSmart {
-                try {
-                    val result = ReadAction.compute<T, Throwable>(action)
-                    continuation.resume(result)
-                } catch (e: Exception) {
-                    continuation.resumeWithException(e)
-                }
-            }
-        }
     }
 
     fun isDumbMode(project: Project): Boolean {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,19 @@
     <li><b>Safe Delete</b> - Remove code safely with usage checking (Java/Kotlin only)</li>
 </ul>
 
+<h3>Project Lifecycle Management</h3>
+<p>When working across many projects simultaneously, idle ones consume unnecessary memory and
+leave editors open for no reason. Lifecycle management automatically sleeps and wakes projects
+based on window focus and MCP activity:</p>
+<ul>
+    <li><b>Automatic sleep/wake</b> - Projects transition from active → background → dormant → closed as they sit idle, and reopen transparently on the next MCP call</li>
+    <li><b>Four modes</b> - Active (full IDE), Background (Power Save on, MCP functional), Dormant (editors closed, PSI cache freed), Closed (fully unloaded, auto-reopens in ~10s)</li>
+    <li><b>Zero-config enrollment</b> - Projects join lifecycle management automatically on their first MCP tool call</li>
+    <li><b>Explicit controls</b> - <code>ide_set_project_mode</code>, <code>ide_get_project_modes</code>, <code>ide_project_status</code>, <code>ide_release_project</code></li>
+    <li><b>Lifecycle event log</b> - <code>ide_lifecycle_log</code> shows a timestamped history of every state transition with trigger reasons, for diagnosing unexpected behaviour</li>
+    <li><b>Configurable thresholds</b> - Timing for each transition is set in Settings → Index MCP Server</li>
+</ul>
+
 <h3>Why This Plugin?</h3>
 <ul>
     <li><b>True semantic understanding</b> - Uses the IDE's AST and index, not text matching</li>
@@ -149,9 +162,20 @@ for detailed documentation and examples.</p>
         <!-- Startup Activity -->
         <postStartupActivity implementation="com.github.hechtcarmel.jetbrainsindexmcpplugin.startup.McpServerStartupActivity"/>
 
+        <!-- Lifecycle: per-project focus listener registration -->
+        <postStartupActivity implementation="com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectFocusActivity"/>
+
+        <!-- Lifecycle services are registered via @Service annotation; no XML entry needed -->
+
         <!-- Notification Group -->
         <notificationGroup id="Index MCP Server" displayType="BALLOON"/>
     </extensions>
+
+    <!-- Lifecycle: listener for non-managed project open/close events -->
+    <applicationListeners>
+        <listener class="com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectLifecycleListener"
+                  topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    </applicationListeners>
 
     <!-- Extension Point for Custom Tools -->
     <extensionPoints>
@@ -167,5 +191,15 @@ for detailed documentation and examples.</p>
             <action id="McpServer.InstallSkill" class="com.github.hechtcarmel.jetbrainsindexmcpplugin.actions.InstallSkillAction" text="Get Companion Skill" description="Install or export the companion skill for AI coding agents"/>
             <action id="McpServer.OpenSettings" class="com.github.hechtcarmel.jetbrainsindexmcpplugin.actions.OpenSettingsAction" text="Settings" description="Open MCP Server settings"/>
         </group>
+
+        <!-- Lifecycle actions — appear in Cmd+Shift+A (Find Action) -->
+        <action id="McpServer.OpenManagedProject"
+                class="com.github.hechtcarmel.jetbrainsindexmcpplugin.actions.OpenManagedProjectAction"
+                text="MCP: Open Project"
+                description="Open or wake an MCP-managed project"/>
+        <action id="McpServer.ShowProjectStates"
+                class="com.github.hechtcarmel.jetbrainsindexmcpplugin.actions.ShowProjectStatesAction"
+                text="MCP: Show Project States"
+                description="Open MCP settings to view managed project states"/>
     </actions>
 </idea-plugin>

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -144,6 +144,21 @@ tool.getFileStructure.description=Get the structure of a file (classes, methods,
 tool.getDependencies.description=Get the project dependencies
 tool.getIndexStatus.description=Get the IDE indexing status (dumb/smart mode)
 
+# Lifecycle settings
+lifecycle.section.title=Project Lifecycle Management
+lifecycle.enabled.label=Enable automatic project lifecycle management
+lifecycle.focusToBackground.label=Focus → Background (minutes):
+lifecycle.backgroundToDormant.label=Background → Dormant (minutes):
+lifecycle.dormantToClosed.label=Dormant → Closed (minutes):
+lifecycle.logBufferSize.label=Event log buffer size:
+lifecycle.logToFile.label=Write lifecycle events to log file (mcp-lifecycle.log)
+lifecycle.minimumOpenProjects.label=Minimum open projects (never auto-close below this):
+lifecycle.enrollAll.button=Enroll All Open
+lifecycle.releaseAll.button=Release All
+lifecycle.managed.label=Managed projects:
+lifecycle.managed.unavailable=Lifecycle management unavailable
+lifecycle.managed.none=No managed projects
+
 # Companion Skill
 toolWindow.getSkill=Get Companion Skill
 toolWindow.getSkill.tooltip=Install or export the companion skill for AI coding agents

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -1,23 +1,30 @@
 ---
 name: ide-index-mcp
 description: >
-  Guide for using JetBrains IDE Index MCP tools for code navigation, refactoring, and analysis.
-  TRIGGER: When ANY of these MCP tools are available in the current session: ide_find_references,
-  ide_find_definition, ide_find_class, ide_find_file, ide_search_text, ide_diagnostics,
-  ide_index_status, ide_sync_files, ide_refactor_rename, ide_move_file, ide_type_hierarchy,
-  ide_call_hierarchy, ide_find_implementations, ide_find_symbol, ide_find_super_methods,
-  ide_file_structure, ide_refactor_safe_delete, ide_reformat_code, ide_build_project,
-  ide_read_file, ide_get_active_file, ide_open_file.
-  Use when performing code navigation (find usages, go to definition, find class),
-  code analysis (diagnostics, type hierarchy, call hierarchy),
-  refactoring (rename, move, safe delete, reformat),
-  or searching code (text search, symbol search, file search).
-  Prefer IDE tools over grep/find/sed for ALL semantic code operations.
+  INVOKE IMMEDIATELY when ide_find_references, ide_find_definition, ide_find_class,
+  ide_find_file, ide_search_text, ide_diagnostics, ide_index_status, ide_sync_files,
+  ide_refactor_rename, ide_move_file, ide_type_hierarchy, ide_call_hierarchy,
+  ide_find_implementations, ide_find_symbol, ide_find_super_methods, ide_file_structure,
+  ide_refactor_safe_delete, ide_reformat_code, ide_build_project, ide_read_file,
+  ide_get_active_file, or ide_open_file are available — especially when a second
+  IntelliJ MCP (mcp__intellij__*) is also present. The two servers are NOT
+  interchangeable: always use mcp__intellij-index__ for code navigation and refactoring.
 ---
 
 # IDE Index MCP - Agent Guide
 
 The IDE Index MCP server exposes JetBrains IDE indexing and refactoring capabilities. These tools provide **semantic** code understanding superior to text-based search/replace.
+
+## Two IntelliJ MCPs — routing rule
+
+If both `mcp__intellij-index__*` (this plugin) and `mcp__intellij__*` (JetBrains built-in) are available, they are **not interchangeable**:
+
+| Need | Use |
+|------|-----|
+| Code navigation, search, diagnostics, rename, move | `mcp__intellij-index__*` |
+| Build, run, terminal, formatting | `mcp__intellij__*` only |
+
+**Always use `mcp__intellij-index__` for code intelligence. At least one project must be open in IntelliJ — if no project is open, ask the user to open one or use `ide_open_project` (disabled by default; enable in Settings → Index MCP Server).** Do not fall back to bash for semantic operations — IDE tools understand types, references, and inheritance; grep does not.
 
 ## Core Rule
 
@@ -52,6 +59,16 @@ ide_index_status -> if isDumbMode: true, wait a few seconds and retry
 ```
 
 Most tools require smart mode (IDE finished indexing). Tools that work in dumb mode: `ide_index_status`, `ide_sync_files`, `ide_reformat_code`, `ide_open_file`, `ide_get_active_file`.
+
+## If results seem incomplete or missing
+
+**Do NOT conclude the index is stale and fall back to bash.** Follow this sequence:
+
+1. Call `ide_index_status` — if `isDumbMode: true`, indexing is still running. Wait 10s and retry the original tool call.
+2. If smart mode but results seem sparse, call `ide_sync_files` then retry.
+3. Only if both steps still return empty results should you consider that the file/symbol genuinely does not exist.
+
+"Index may be stale" is never a reason to abandon IntelliJ tools and read files with bash. Sparse results during indexing are transient — retrying after `isDumbMode` clears will return full results.
 
 ## File Sync Rule
 
@@ -124,6 +141,18 @@ Omit `paths` to sync the entire project.
 9. **Assuming regex is the default in `ide_search_text`**: Regex requires `"regex": true`; otherwise the tool uses the faster exact-word index.
 
 10. **Using `ide_find_class` for methods/functions**: It searches classes only. Use `ide_search_text` for a quick word lookup.
+
+## Lifecycle Management
+
+When multiple projects are open simultaneously, the lifecycle manager automatically sleeps and wakes them based on window focus and MCP activity. Projects enroll automatically on first MCP use — no setup required.
+
+**States:** `active` (full IDE) → `background` (Power Save on) → `dormant` (editors closed, PSI cache freed) → `closed` (fully unloaded). Projects auto-reopen transparently when an MCP tool targets a closed project.
+
+`ide_project_status` is the read-only entry point — **enabled by default**. Use it to see all open and managed projects and their current modes.
+
+All lifecycle action tools are disabled by default:
+
+`ide_enroll_all_projects`, `ide_get_project_modes`, `ide_lifecycle_log`, `ide_release_all_projects`, `ide_release_project`, `ide_set_all_project_modes`, `ide_set_project_mode`
 
 ## Disabled-by-Default Tools
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
@@ -73,7 +73,17 @@ class ConstantsUnitTest : TestCase() {
             ToolNames.RESTART_IDE,
             ToolNames.CLOSE_PROJECT,
             ToolNames.OPEN_PROJECT,
-            ToolNames.SET_POWER_SAVE_MODE
+            ToolNames.SET_POWER_SAVE_MODE,
+            // Lifecycle management
+            ToolNames.ENROLL_ALL_PROJECTS,
+            ToolNames.GET_PROJECT_MODES,
+            ToolNames.LIFECYCLE_LOG,
+            ToolNames.LIFECYCLE_LOG_FILE,
+            ToolNames.PROJECT_STATUS,
+            ToolNames.RELEASE_ALL_PROJECTS,
+            ToolNames.RELEASE_PROJECT,
+            ToolNames.SET_ALL_PROJECT_MODES,
+            ToolNames.SET_PROJECT_MODE
         )
 
         for (name in expectedNames) {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
@@ -500,7 +500,17 @@ class ToolExecutionIntegrationTest : BasePlatformTestCase() {
             // Project window management tools
             ToolNames.CLOSE_PROJECT,
             ToolNames.OPEN_PROJECT,
-            ToolNames.SET_POWER_SAVE_MODE
+            ToolNames.SET_POWER_SAVE_MODE,
+            // Lifecycle management tools
+            ToolNames.ENROLL_ALL_PROJECTS,
+            ToolNames.GET_PROJECT_MODES,
+            ToolNames.LIFECYCLE_LOG,
+            ToolNames.LIFECYCLE_LOG_FILE, // ide_set_lifecycle_log_file
+            ToolNames.PROJECT_STATUS,
+            ToolNames.RELEASE_ALL_PROJECTS,
+            ToolNames.RELEASE_PROJECT,
+            ToolNames.SET_ALL_PROJECT_MODES,
+            ToolNames.SET_PROJECT_MODE
         )
         if (PluginDetectors.java.isAvailable && PluginDetectors.kotlin.isAvailable) {
             expectedTools.add(ToolNames.CONVERT_JAVA_TO_KOTLIN)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/LifecycleToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/LifecycleToolsTest.kt
@@ -1,0 +1,279 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.EnrollAllProjectsTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.GetProjectModesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ReleaseAllProjectsTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ReleaseProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetAllProjectModesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetProjectModeTool
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class LifecycleToolsTest : BasePlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private lateinit var modeService: ProjectModeService
+
+    private var previousLifecycleEnabled = false
+
+    override fun setUp() {
+        super.setUp()
+        modeService = ProjectModeService.getInstance()
+        modeService.loadState(ProjectModeService.State())
+        previousLifecycleEnabled = McpSettings.getInstance().lifecycleEnabled
+        McpSettings.getInstance().lifecycleEnabled = true
+    }
+
+    override fun tearDown() {
+        try {
+            if (modeService.isManaged(project)) modeService.release(project)
+            modeService.loadState(ProjectModeService.State())
+            McpSettings.getInstance().lifecycleEnabled = previousLifecycleEnabled
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun resultText(result: ToolCallResult): String =
+        (result.content.firstOrNull() as? ContentBlock.Text)?.text ?: ""
+
+    fun testSetProjectModeToolReturnErrorWhenModeIsMissing() = runBlocking {
+        val result = SetProjectModeTool().execute(project, buildJsonObject { })
+
+        assertTrue(result.isError)
+        assertTrue(resultText(result).contains("mode", ignoreCase = true))
+    }
+
+    fun testSetProjectModeToolReturnErrorWhenModeIsInvalid() = runBlocking {
+        val result = SetProjectModeTool().execute(project, buildJsonObject { put("mode", "TURBO_SLEEP") })
+
+        assertTrue(result.isError)
+        val text = resultText(result)
+        assertTrue(text.contains("TURBO_SLEEP", ignoreCase = true))
+        // Error must name all valid modes so the caller knows how to fix it
+        assertTrue(text.contains("active"))
+        assertTrue(text.contains("background"))
+        assertTrue(text.contains("dormant"))
+        assertTrue(text.contains("closed"))
+    }
+
+    fun testSetProjectModeToolSetsActiveMode() = runBlocking {
+        val result = SetProjectModeTool().execute(project, buildJsonObject { put("mode", "active") })
+
+        assertFalse(result.isError)
+        assertEquals(ProjectMode.ACTIVE, modeService.getMode(project))
+    }
+
+    fun testSetProjectModeToolSetsBackgroundMode() = runBlocking {
+        modeService.enroll(project)
+        modeService.transition(project, ProjectMode.ACTIVE)
+
+        val result = SetProjectModeTool().execute(project, buildJsonObject { put("mode", "background") })
+
+        assertFalse(result.isError)
+        assertEquals(ProjectMode.BACKGROUND, modeService.getMode(project))
+    }
+
+    fun testSetProjectModeToolSetsDormantMode() = runBlocking {
+        val result = SetProjectModeTool().execute(project, buildJsonObject { put("mode", "dormant") })
+
+        assertFalse(result.isError)
+        assertEquals(ProjectMode.DORMANT, modeService.getMode(project))
+    }
+
+    fun testSetProjectModeToolAutoEnrollsProject() = runBlocking {
+        assertFalse(modeService.isManaged(project))
+
+        SetProjectModeTool().execute(project, buildJsonObject { put("mode", "background") })
+
+        assertTrue(modeService.isManaged(project))
+    }
+
+    fun testSetProjectModeToolModeIsCaseInsensitive() = runBlocking {
+        val result = SetProjectModeTool().execute(project, buildJsonObject { put("mode", "ACTIVE") })
+        assertFalse(result.isError)
+        assertEquals(ProjectMode.ACTIVE, modeService.getMode(project))
+    }
+
+    fun testGetProjectModesToolReturnsHelpfulMessageWhenNothingManaged() = runBlocking {
+        val settings = McpSettings.getInstance()
+        val previouslyEnabled = settings.lifecycleEnabled
+        settings.lifecycleEnabled = false
+        try {
+            val result = GetProjectModesTool().execute(project, buildJsonObject { })
+
+            assertFalse(result.isError)
+            val text = resultText(result)
+            assertTrue(
+                text.contains("No projects", ignoreCase = true) ||
+                text.contains("none", ignoreCase = true) ||
+                text.contains("automatically", ignoreCase = true)
+            )
+        } finally {
+            settings.lifecycleEnabled = previouslyEnabled
+        }
+    }
+
+    fun testGetProjectModesToolListsManagedProjects() = runBlocking {
+        modeService.enroll(project)
+
+        val result = GetProjectModesTool().execute(project, buildJsonObject { })
+
+        assertFalse(result.isError)
+        val text = resultText(result)
+        assertTrue(text.contains(project.name) || text.contains(project.basePath ?: ""))
+        assertTrue(text.contains("background", ignoreCase = true))
+    }
+
+    fun testGetProjectModesToolShowsClosedProjects() = runBlocking {
+        val fakePath = "/fake/closed/project"
+        modeService.markClosed(fakePath)
+
+        val result = GetProjectModesTool().execute(project, buildJsonObject { })
+
+        assertFalse(result.isError)
+        val text = resultText(result)
+        assertTrue(text.contains("closed", ignoreCase = true))
+        assertTrue(text.contains(fakePath) || text.contains("project"))
+    }
+
+    fun testGetProjectModesToolIncludesCount() = runBlocking {
+        modeService.enroll(project)
+        modeService.markClosed("/another/project")
+
+        val result = GetProjectModesTool().execute(project, buildJsonObject { })
+
+        assertFalse(result.isError)
+        val parsed = json.parseToJsonElement(resultText(result)).jsonObject
+        val total = parsed["total"]?.jsonPrimitive?.content?.toIntOrNull()
+        assertNotNull("Result must include a total count", total)
+        assertEquals("Total must count all managed projects", 2, total)
+    }
+
+    fun testReleaseProjectToolOnUnmanagedProjectSucceedsWithNote() = runBlocking {
+        val settings = McpSettings.getInstance()
+        val previouslyEnabled = settings.lifecycleEnabled
+        settings.lifecycleEnabled = false
+        try {
+            assertFalse(modeService.isManaged(project))
+
+            val result = ReleaseProjectTool().execute(project, buildJsonObject { })
+
+            assertFalse(result.isError)
+            assertTrue(resultText(result).contains("not managed", ignoreCase = true))
+        } finally {
+            settings.lifecycleEnabled = previouslyEnabled
+        }
+    }
+
+    fun testReleaseProjectToolReleasesEnrolledProject() = runBlocking {
+        modeService.enroll(project)
+
+        val result = ReleaseProjectTool().execute(project, buildJsonObject { })
+
+        assertFalse(result.isError)
+        assertFalse(modeService.isManaged(project))
+    }
+
+    fun testReleaseProjectToolConfirmsProjectName() = runBlocking {
+        modeService.enroll(project)
+
+        val result = ReleaseProjectTool().execute(project, buildJsonObject { })
+
+        assertFalse(result.isError)
+        assertTrue(resultText(result).contains(project.name))
+    }
+
+    fun testSetAllProjectModesToolSetsBackgroundOnManagedProjects() = runBlocking {
+        modeService.enroll(project)
+        modeService.transition(project, ProjectMode.ACTIVE)
+
+        val result = SetAllProjectModesTool().execute(project, buildJsonObject { put("mode", "background") })
+
+        assertFalse(result.isError)
+        assertEquals(ProjectMode.BACKGROUND, modeService.getMode(project))
+    }
+
+    fun testSetAllProjectModesToolRejectsClosedMode() = runBlocking {
+        modeService.enroll(project)
+
+        val result = SetAllProjectModesTool().execute(project, buildJsonObject { put("mode", "closed") })
+
+        assertTrue("closed is not a valid mode for set_all_project_modes", result.isError)
+        val text = resultText(result)
+        assertTrue(text.contains("active"))
+        assertTrue(text.contains("background"))
+        assertTrue(text.contains("dormant"))
+    }
+
+    fun testSetAllProjectModesToolReportsCountInResult() = runBlocking {
+        modeService.enroll(project)
+
+        val result = SetAllProjectModesTool().execute(project, buildJsonObject { put("mode", "dormant") })
+
+        assertFalse(result.isError)
+        assertTrue(resultText(result).contains("1"))
+        assertTrue(resultText(result).contains(project.name))
+    }
+
+    fun testAnyToolCallAutoEnrollsProject() = runBlocking {
+        assertFalse(modeService.isManaged(project))
+
+        // Use a semantic tool (participatesInLifecycle=true) — lifecycle management tools
+        // like GetProjectModesTool have participatesInLifecycle=false by design.
+        GetIndexStatusTool().execute(project, buildJsonObject { })
+
+        assertTrue(modeService.isManaged(project))
+    }
+
+    fun testAnyToolCallWakesProjectFromDormant() = runBlocking {
+        modeService.enroll(project)
+        modeService.transition(project, ProjectMode.DORMANT)
+        assertEquals(ProjectMode.DORMANT, modeService.getMode(project))
+
+        GetIndexStatusTool().execute(project, buildJsonObject { })
+
+        assertEquals(ProjectMode.BACKGROUND, modeService.getMode(project))
+    }
+
+    fun testReleaseAllToolReleasesAllManagedProjects() = runBlocking {
+        modeService.enroll(project)
+        modeService.markClosed("/fake/closed/project")
+
+        assertTrue(modeService.isManaged(project))
+        assertTrue(modeService.isManaged("/fake/closed/project"))
+
+        ReleaseAllProjectsTool().execute(project, buildJsonObject { })
+
+        assertFalse(modeService.isManaged(project))
+        assertFalse(modeService.isManaged("/fake/closed/project"))
+    }
+
+    fun testEnrollAllToolEnrollsOpenProjects() = runBlocking {
+        assertFalse(modeService.isManaged(project))
+
+        EnrollAllProjectsTool().execute(project, buildJsonObject { })
+
+        assertTrue(modeService.isManaged(project))
+    }
+
+    fun testReleaseProjectToolByPathReleasesClosedProject() = runBlocking {
+        val closedPath = "/fake/closed/project"
+        modeService.markClosed(closedPath)
+        assertTrue(modeService.isManaged(closedPath))
+
+        ReleaseProjectTool().execute(project, buildJsonObject { put("path", closedPath) })
+
+        assertFalse(modeService.isManaged(closedPath))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/LifecycleUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/LifecycleUnitTest.kt
@@ -1,0 +1,274 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.LifecycleEventLog
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.EnrollAllProjectsTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.GetProjectModesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.LifecycleLogTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetLifecycleLogFileTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ReleaseAllProjectsTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.ReleaseProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetAllProjectModesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.lifecycle.SetProjectModeTool
+import junit.framework.TestCase
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class LifecycleUnitTest : TestCase() {
+
+    fun testProjectModeHasExactlyFourStates() {
+        val values = ProjectMode.entries
+        assertEquals(4, values.size)
+        assertTrue(values.contains(ProjectMode.ACTIVE))
+        assertTrue(values.contains(ProjectMode.BACKGROUND))
+        assertTrue(values.contains(ProjectMode.DORMANT))
+        assertTrue(values.contains(ProjectMode.CLOSED))
+    }
+
+    fun testStateDefaultsAreEmpty() {
+        val state = ProjectModeService.State()
+        assertTrue(state.closedProjectPaths.isEmpty())
+        assertTrue(state.managedProjectPaths.isEmpty())
+    }
+
+    fun testStateClosedAndManagedAreIndependentSets() {
+        val state = ProjectModeService.State()
+        state.closedProjectPaths.add("/closed/project")
+        state.managedProjectPaths.add("/managed/project")
+
+        assertFalse(state.closedProjectPaths.contains("/managed/project"))
+        assertFalse(state.managedProjectPaths.contains("/closed/project"))
+    }
+
+    fun testLifecycleSettingsDefaultValues() {
+        val state = McpSettings.State()
+        assertFalse(state.lifecycleEnabled)
+        assertEquals(2, state.focusToBackgroundMinutes)
+        assertEquals(2, state.backgroundToDormantMinutes)
+        assertEquals(10, state.dormantToClosedMinutes)
+        assertEquals(LifecycleEventLog.DEFAULT_CAPACITY, state.lifecycleLogBufferSize)
+    }
+
+    fun testMinimumOpenProjectsDefaultIs4() {
+        assertEquals(4, McpSettings.State().minimumOpenProjects)
+    }
+
+
+    fun testMinimumOpenProjectsIsConfigurable() {
+        val settings = McpSettings()
+        settings.loadState(McpSettings.State(minimumOpenProjects = 6))
+        assertEquals(6, settings.minimumOpenProjects)
+    }
+
+
+    fun testLifecycleLogBufferSizeIsConfigurable() {
+        val settings = McpSettings()
+        settings.loadState(McpSettings.State(lifecycleLogBufferSize = 2000))
+        assertEquals(2000, settings.lifecycleLogBufferSize)
+    }
+
+    fun testLifecycleSettingsRoundTrip() {
+        val settings = McpSettings()
+        settings.loadState(McpSettings.State(
+            lifecycleEnabled = false,
+            focusToBackgroundMinutes = 7,
+            backgroundToDormantMinutes = 4,
+            dormantToClosedMinutes = 15
+        ))
+
+        assertFalse(settings.lifecycleEnabled)
+        assertEquals(7, settings.focusToBackgroundMinutes)
+        assertEquals(4, settings.backgroundToDormantMinutes)
+        assertEquals(15, settings.dormantToClosedMinutes)
+    }
+
+    fun testLifecycleSettingsGetStateReflectsChanges() {
+        val settings = McpSettings()
+        settings.lifecycleEnabled = false
+        settings.dormantToClosedMinutes = 30
+
+        assertFalse(settings.getState().lifecycleEnabled)
+        assertEquals(30, settings.getState().dormantToClosedMinutes)
+    }
+
+    fun testSetProjectModeToolName() {
+        assertEquals(ToolNames.SET_PROJECT_MODE, SetProjectModeTool().name)
+    }
+
+    fun testSetProjectModeToolDescriptionMentionsAllModes() {
+        val desc = SetProjectModeTool().description
+        assertTrue(desc.contains("active"))
+        assertTrue(desc.contains("background"))
+        assertTrue(desc.contains("dormant"))
+        assertTrue(desc.contains("closed"))
+    }
+
+    fun testSetProjectModeToolModeIsRequired() {
+        val schema = SetProjectModeTool().inputSchema
+        val required = schema["required"]?.jsonArray?.map { it.jsonPrimitive.content }
+        assertNotNull(required)
+        assertTrue(required!!.contains("mode"))
+    }
+
+    fun testSetProjectModeToolModeEnumMatchesProjectMode() {
+        val schema = SetProjectModeTool().inputSchema
+        val modeEnum = schema["properties"]?.jsonObject
+            ?.get("mode")?.jsonObject
+            ?.get("enum")?.jsonArray
+            ?.map { it.jsonPrimitive.content }
+
+        assertNotNull("mode must declare an enum constraint", modeEnum)
+        assertEquals(4, modeEnum!!.size)
+        assertTrue(modeEnum.contains("active"))
+        assertTrue(modeEnum.contains("background"))
+        assertTrue(modeEnum.contains("dormant"))
+        assertTrue(modeEnum.contains("closed"))
+    }
+
+    fun testSetProjectModeToolProjectPathIsOptional() {
+        val required = SetProjectModeTool().inputSchema["required"]
+            ?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+        assertFalse(required.contains("project_path"))
+    }
+
+    fun testGetProjectModesToolName() {
+        assertEquals(ToolNames.GET_PROJECT_MODES, GetProjectModesTool().name)
+    }
+
+    fun testGetProjectModesToolHasNoRequiredFields() {
+        val required = GetProjectModesTool().inputSchema["required"]?.jsonArray
+        assertTrue(required == null || required.isEmpty())
+    }
+
+    fun testReleaseProjectToolName() {
+        assertEquals(ToolNames.RELEASE_PROJECT, ReleaseProjectTool().name)
+    }
+
+    fun testReleaseProjectToolHasNoRequiredFields() {
+        val required = ReleaseProjectTool().inputSchema["required"]?.jsonArray
+        assertTrue(required == null || required.isEmpty())
+    }
+
+    fun testToolNamesAllContainsLifecycleTools() {
+        assertTrue(ToolNames.ALL.contains(ToolNames.ENROLL_ALL_PROJECTS))
+        assertTrue(ToolNames.ALL.contains(ToolNames.GET_PROJECT_MODES))
+        assertTrue(ToolNames.ALL.contains(ToolNames.LIFECYCLE_LOG))
+        assertTrue(ToolNames.ALL.contains(ToolNames.PROJECT_STATUS))
+        assertTrue(ToolNames.ALL.contains(ToolNames.RELEASE_ALL_PROJECTS))
+        assertTrue(ToolNames.ALL.contains(ToolNames.RELEASE_PROJECT))
+        assertTrue(ToolNames.ALL.contains(ToolNames.SET_ALL_PROJECT_MODES))
+        assertTrue(ToolNames.ALL.contains(ToolNames.SET_PROJECT_MODE))
+    }
+
+    fun testEnrollAllProjectsToolName() {
+        assertEquals(ToolNames.ENROLL_ALL_PROJECTS, EnrollAllProjectsTool().name)
+    }
+
+    fun testEnrollAllProjectsToolHasNoRequiredFields() {
+        val required = EnrollAllProjectsTool().inputSchema["required"]?.jsonArray
+        assertTrue(required == null || required.isEmpty())
+    }
+
+    fun testReleaseAllProjectsToolName() {
+        assertEquals(ToolNames.RELEASE_ALL_PROJECTS, ReleaseAllProjectsTool().name)
+    }
+
+    fun testReleaseAllProjectsToolHasNoRequiredFields() {
+        val required = ReleaseAllProjectsTool().inputSchema["required"]?.jsonArray
+        assertTrue(required == null || required.isEmpty())
+    }
+
+    fun testReleaseProjectToolPathParamIsOptional() {
+        val required = ReleaseProjectTool().inputSchema["required"]
+            ?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+        assertFalse("path must be optional", required.contains("path"))
+    }
+
+    fun testLifecycleLogToolName() {
+        assertEquals(ToolNames.LIFECYCLE_LOG, LifecycleLogTool().name)
+    }
+
+    fun testSetLifecycleLogFileToolName() {
+        assertEquals(ToolNames.LIFECYCLE_LOG_FILE, SetLifecycleLogFileTool().name)
+    }
+
+    fun testSetLifecycleLogFileToolRequiresEnabled() {
+        val required = SetLifecycleLogFileTool().inputSchema["required"]?.jsonArray
+        assertNotNull("schema must have required fields", required)
+        assertTrue("enabled must be required", required!!.any { it.jsonPrimitive.content == "enabled" })
+    }
+
+    fun testLifecycleLogToolHasNoRequiredFields() {
+        val required = LifecycleLogTool().inputSchema["required"]?.jsonArray
+        assertTrue(required == null || required.isEmpty())
+    }
+
+    fun testLifecycleLogToolSchemaHasLimitAndProjectParams() {
+        val props = LifecycleLogTool().inputSchema["properties"]?.jsonObject
+        assertNotNull("schema must have a properties object", props)
+        assertNotNull("schema must include limit", props!!["limit"])
+        assertNotNull("schema must include project", props["project"])
+    }
+
+    fun testLifecycleLogToolDescriptionDocumentsKeyTriggers() {
+        val desc = LifecycleLogTool().description
+        assertTrue(desc.contains("timer:inactivity"))
+        assertTrue(desc.contains("mcp_call"))
+        assertTrue(desc.contains("auto_open"))
+        assertTrue(desc.contains("log_file"))
+    }
+
+    fun testLifecycleToolNameConstants() {
+        assertEquals("ide_enroll_all_projects", ToolNames.ENROLL_ALL_PROJECTS)
+        assertEquals("ide_get_project_modes", ToolNames.GET_PROJECT_MODES)
+        assertEquals("ide_lifecycle_log", ToolNames.LIFECYCLE_LOG)
+        assertEquals("ide_set_lifecycle_log_file", ToolNames.LIFECYCLE_LOG_FILE)
+        assertEquals("ide_project_status", ToolNames.PROJECT_STATUS)
+        assertEquals("ide_release_all_projects", ToolNames.RELEASE_ALL_PROJECTS)
+        assertEquals("ide_release_project", ToolNames.RELEASE_PROJECT)
+        assertEquals("ide_set_all_project_modes", ToolNames.SET_ALL_PROJECT_MODES)
+        assertEquals("ide_set_project_mode", ToolNames.SET_PROJECT_MODE)
+    }
+
+    fun testLifecycleToolsAreDisabledByDefault() {
+        val defaults = McpSettings.State().disabledTools
+        listOf(
+            ToolNames.ENROLL_ALL_PROJECTS, ToolNames.GET_PROJECT_MODES, ToolNames.LIFECYCLE_LOG,
+            ToolNames.LIFECYCLE_LOG_FILE, ToolNames.RELEASE_ALL_PROJECTS,
+            ToolNames.RELEASE_PROJECT, ToolNames.SET_ALL_PROJECT_MODES, ToolNames.SET_PROJECT_MODE
+        ).forEach { tool ->
+            assertTrue("$tool must be opt-in by default", defaults.contains(tool))
+        }
+    }
+
+    fun testProjectStatusIsEnabledByDefault() {
+        // ide_project_status is read-only and required for Claudes to discover project paths
+        // so they can self-navigate without asking the user to open projects manually.
+        val defaults = McpSettings.State().disabledTools
+        assertFalse("ide_project_status must be enabled by default", defaults.contains(ToolNames.PROJECT_STATUS))
+    }
+
+    fun testSetAllProjectModesToolName() {
+        assertEquals(ToolNames.SET_ALL_PROJECT_MODES, SetAllProjectModesTool().name)
+    }
+
+    fun testSetAllProjectModesToolExcludesClosedFromEnum() {
+        val schema = SetAllProjectModesTool().inputSchema
+        val modeEnum = schema["properties"]?.jsonObject
+            ?.get("mode")?.jsonObject
+            ?.get("enum")?.jsonArray
+            ?.map { it.jsonPrimitive.content }
+        assertNotNull(modeEnum)
+        assertTrue(modeEnum!!.contains("active"))
+        assertTrue(modeEnum.contains("background"))
+        assertTrue(modeEnum.contains("dormant"))
+        assertFalse("closed must not be in the enum — CLOSED projects have no Project object", modeEnum.contains("closed"))
+    }
+
+    fun testToolNamesAllIsSorted() {
+        assertEquals(ToolNames.ALL.sorted(), ToolNames.ALL)
+    }
+
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeServiceTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeServiceTest.kt
@@ -1,0 +1,426 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Tests the ProjectModeService state machine using a real application context.
+ *
+ * Focuses on correctness of the closed-project registry and mode transitions
+ * that don't require a real window (focus listeners are tested separately via
+ * integration). Side effects that touch external platform APIs (PowerSaveMode,
+ * FileEditorManager) are async via invokeLater and do not affect mode state
+ * assertions, which are synchronous.
+ */
+class ProjectModeServiceTest : BasePlatformTestCase() {
+
+    private lateinit var service: ProjectModeService
+
+    override fun setUp() {
+        super.setUp()
+        service = ProjectModeService.getInstance()
+        // Start each test with a clean state
+        service.loadState(ProjectModeService.State())
+    }
+
+    override fun tearDown() {
+        try {
+            // Release the test project so lifecycle timers don't bleed between tests
+            if (service.isManaged(project)) {
+                service.release(project)
+            }
+            // Reset persisted state
+            service.loadState(ProjectModeService.State())
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    // ── Closed-project registry ───────────────────────────────────────────────
+
+    fun testWasClosedByUsReturnsFalseForUnknownPath() {
+        assertFalse(service.wasClosedByUs("/never/seen/project"))
+    }
+
+    fun testMarkClosedMakesWasClosedByUsReturnTrue() {
+        val path = "/some/closed/project"
+        service.markClosed(path)
+        assertTrue(service.wasClosedByUs(path))
+    }
+
+    fun testMarkClosedAlsoEnrollsIntoManagedSet() {
+        // A closed project must remain tracked as managed so it can be auto-reopened
+        val path = "/some/closed/project"
+        service.markClosed(path)
+        assertTrue("Closed projects must remain in managed set", service.isManaged(path))
+    }
+
+    fun testMarkReopenedRemovesFromClosedRegistry() {
+        val path = "/some/closed/project"
+        service.markClosed(path)
+        assertTrue(service.wasClosedByUs(path))  // sanity
+
+        service.markReopened(path)
+        assertFalse(
+            "After reopening, wasClosedByUs must return false",
+            service.wasClosedByUs(path)
+        )
+    }
+
+    fun testMarkReopenedSetsModeToBg() {
+        val path = "/some/closed/project"
+        service.markClosed(path)
+        service.markReopened(path)
+        assertEquals(
+            "Reopened project should be in BACKGROUND mode",
+            ProjectMode.BACKGROUND,
+            service.getMode(path)
+        )
+    }
+
+    fun testClosedProjectRegistryRoundTrip() {
+        // Simulates what happens across an IDE restart: state is persisted and reloaded
+        val path = "/persisted/project"
+        service.markClosed(path)
+
+        val persistedState = service.getState()
+        assertTrue(persistedState.closedProjectPaths.contains(path))
+
+        // Simulate restart: create fresh service, load persisted state
+        val fresh = ProjectModeService()
+        fresh.loadState(persistedState)
+
+        assertTrue("Closed path must survive state round-trip", fresh.wasClosedByUs(path))
+        assertEquals(
+            "Mode must be CLOSED after loading state with closed path",
+            ProjectMode.CLOSED,
+            fresh.getMode(path)
+        )
+    }
+
+    // ── Mode queries ─────────────────────────────────────────────────────────
+
+    fun testGetModeReturnsBackgroundForUnknownPath() {
+        assertEquals(
+            "Unknown projects default to BACKGROUND (not managed, not closed)",
+            ProjectMode.BACKGROUND,
+            service.getMode("/not/a/real/project")
+        )
+    }
+
+    fun testGetModeReturnsClosedForClosedPath() {
+        val path = "/closed/project"
+        service.markClosed(path)
+        assertEquals(ProjectMode.CLOSED, service.getMode(path))
+    }
+
+    fun testGetModeByProjectDelegatesToPathLookup() {
+        // Ensures both overloads return consistent results
+        service.enroll(project)
+        val byProject = service.getMode(project)
+        val byPath = service.getMode(project.basePath!!)
+        assertEquals("getMode(Project) and getMode(String) must agree", byProject, byPath)
+    }
+
+    fun testGetAllManagedModesIncludesEnrolledProject() {
+        service.enroll(project)
+        val modes = service.getAllManagedModes()
+        assertTrue(
+            "Enrolled project must appear in getAllManagedModes()",
+            modes.containsKey(project.basePath)
+        )
+    }
+
+    fun testGetAllManagedModesIncludesClosedProjects() {
+        val closedPath = "/closed/project"
+        service.markClosed(closedPath)
+        val modes = service.getAllManagedModes()
+        assertTrue(
+            "Closed project must appear in getAllManagedModes()",
+            modes.containsKey(closedPath)
+        )
+        assertEquals(ProjectMode.CLOSED, modes[closedPath])
+    }
+
+    fun testGetAllManagedModesIsEmptyWhenNothingManaged() {
+        assertTrue(service.getAllManagedModes().isEmpty())
+    }
+
+    // ── Enrollment ───────────────────────────────────────────────────────────
+
+    fun testEnrollMakesProjectManaged() {
+        assertFalse(service.isManaged(project))  // sanity: not enrolled yet
+        service.enroll(project)
+        assertTrue(service.isManaged(project))
+    }
+
+    fun testEnrollSetsInitialModeToBackground() {
+        service.enroll(project)
+        assertEquals(ProjectMode.BACKGROUND, service.getMode(project))
+    }
+
+    fun testEnrollIsIdempotent() {
+        service.enroll(project)
+        service.enroll(project)  // second call must not double-enroll or throw
+        assertTrue(service.isManaged(project))
+        assertEquals(ProjectMode.BACKGROUND, service.getMode(project))
+    }
+
+    fun testReleaseMakesProjectUnmanaged() {
+        service.enroll(project)
+        service.release(project)
+        assertFalse(service.isManaged(project))
+    }
+
+    fun testReleaseRemovesFromAllManagedModes() {
+        service.enroll(project)
+        service.release(project)
+        assertFalse(service.getAllManagedModes().containsKey(project.basePath))
+    }
+
+    // ── wakeForMcp — the auto-wake mechanism ─────────────────────────────────
+
+    fun testWakeForMcpDoesNothingWhenModeIsBackground() {
+        // A project already in BACKGROUND should stay BACKGROUND and not error
+        service.enroll(project)
+        assertEquals(ProjectMode.BACKGROUND, service.getMode(project))  // sanity
+
+        service.wakeForMcp(project)
+
+        assertEquals(
+            "wakeForMcp on BACKGROUND project must leave mode unchanged",
+            ProjectMode.BACKGROUND,
+            service.getMode(project)
+        )
+    }
+
+    fun testWakeForMcpChangesDormantToBackground() {
+        // Get the project to DORMANT state. transition() side effects (editor close,
+        // PSI cache drop) are async via invokeLater and harmless on a test project
+        // with no open editors. The mode change itself is synchronous.
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+
+        assertEquals(ProjectMode.DORMANT, service.getMode(project))  // sanity
+
+        service.wakeForMcp(project)
+
+        assertEquals(
+            "wakeForMcp must change DORMANT → BACKGROUND",
+            ProjectMode.BACKGROUND,
+            service.getMode(project)
+        )
+    }
+
+    fun testWakeForMcpDoesNotAffectActiveMode() {
+        // ACTIVE projects are under user control — MCP calls should not downgrade them
+        service.enroll(project)
+        service.transition(project, ProjectMode.ACTIVE)
+
+        service.wakeForMcp(project)
+
+        assertEquals(
+            "wakeForMcp must not downgrade ACTIVE to BACKGROUND",
+            ProjectMode.ACTIVE,
+            service.getMode(project)
+        )
+    }
+
+    // ── last_project_kept regression (Bug: mode was left as CLOSED) ──────────
+
+    fun testLastProjectKeptSetsModeBackToDormantNotClosed() {
+        // When the only managed open project is about to be closed, it must be
+        // kept in DORMANT (not CLOSED) so focus events log correctly afterwards.
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+        service.transition(project, ProjectMode.CLOSED)  // blocked by last_project_kept
+
+        assertEquals(
+            "last_project_kept must reset mode to DORMANT, not leave it as CLOSED",
+            ProjectMode.DORMANT,
+            service.getMode(project)
+        )
+    }
+
+    fun testLastProjectKeptDoesNotAddToClosedRegistry() {
+        // A project kept dormant by last_project_kept is NOT closed by us — auto-open
+        // must not treat it as a managed-closed project.
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+        service.transition(project, ProjectMode.CLOSED)
+
+        assertFalse(
+            "last_project_kept must not add the project to closedProjectPaths",
+            service.wasClosedByUs(project.basePath ?: "")
+        )
+    }
+
+    // ── minimumOpenProjects floor ─────────────────────────────────────────────
+
+    fun testMinimumFloorPreventsCloseWhenAtLimit() {
+        // With the default minimum of 4 and only 1 managed open project,
+        // closing must be blocked.
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+        service.transition(project, ProjectMode.CLOSED)
+
+        // Mode should be DORMANT — the close was blocked
+        assertEquals(ProjectMode.DORMANT, service.getMode(project))
+        assertFalse(service.wasClosedByUs(project.basePath ?: ""))
+    }
+
+    // ── Regression: .idea auto-open must clear closedProjectPaths ────────────
+    // Bug: resolveOrOpen's .idea fallback didn't call markReopened, leaving the
+    // project in closedProjectPaths while open → healthCheck reported "open but in
+    // closedProjectPaths" as a bug.
+
+    fun testMarkReopenedClearsClosedPathsRegistry() {
+        val path = project.basePath ?: ""
+        service.enroll(project)
+        service.markClosed(path)
+        assertTrue("precondition: must be in closedProjectPaths", service.wasClosedByUs(path))
+
+        service.markReopened(path)
+
+        assertFalse(
+            "after markReopened: project must NOT remain in closedProjectPaths",
+            service.wasClosedByUs(path)
+        )
+    }
+
+    fun testHealthCheckReportsOkWhenOpenProjectIsNotInClosedPaths() {
+        // Invariant the bug violated: a project that is open must not be in closedProjectPaths.
+        // healthCheck must not report a bug for a normally-open enrolled project.
+        service.enroll(project)
+        // healthCheck must complete without reporting a bug
+        service.healthCheck("test_invariant")
+        // If no exception and no "open but in closedProjectPaths" — test passes.
+        // We verify the invariant holds: open project is NOT in closedProjectPaths.
+        assertFalse(
+            "enrolled open project must not be in closedProjectPaths",
+            service.wasClosedByUs(project.basePath ?: "")
+        )
+    }
+
+    fun testOnProjectClosedExternallyFixesOpenButInClosedPathsInconsistency() {
+        // If a project somehow ends up open AND in closedProjectPaths (the bug),
+        // onProjectClosedExternally should repair it when the project actually closes.
+        val path = project.basePath ?: ""
+        service.enroll(project)
+        service.markClosed(path)  // Simulate the inconsistent state
+        assertTrue("test setup: in closedProjectPaths", service.wasClosedByUs(path))
+
+        // onProjectClosedExternally is called when the window closes
+        service.onProjectClosedExternally(path, project.name)
+
+        // State should now be consistent — closed and marked as such
+        assertTrue("after external close: must be in closedProjectPaths", service.wasClosedByUs(path))
+        assertFalse("after external close: must not be in pendingClose", service.isInPendingClose(path))
+    }
+
+    // ── onDormant cancels focus alarm (Bug: timer:focus raced timer:inactivity)
+
+    fun testDormantTransitionSetsModeCorrectly() {
+        // After going dormant, mode must remain DORMANT — the focus alarm (which
+        // would transition back to background) must not fire after dormant is entered.
+        // We can only assert the synchronous state; the alarm cancellation is async.
+        service.enroll(project)
+        service.transition(project, ProjectMode.ACTIVE)
+        service.transition(project, ProjectMode.BACKGROUND)
+        service.transition(project, ProjectMode.DORMANT)
+
+        assertEquals(
+            "mode must be DORMANT after dormant transition regardless of prior focus state",
+            ProjectMode.DORMANT,
+            service.getMode(project)
+        )
+    }
+
+    // ── pendingClose set (event-driven flush replaces alarm reschedule) ──────
+
+    fun testFloorBlockedProjectAddedToPendingClose() {
+        // When the floor blocks a close, the project must enter pendingClose so
+        // the next flush can close it without a repeated alarm.
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+        service.transition(project, ProjectMode.CLOSED)
+
+        val path = project.basePath ?: ""
+        assertTrue(
+            "floor-blocked project must be in pendingClose",
+            service.isInPendingClose(path)
+        )
+        // And NOT in closedProjectPaths — that would make wasClosedByUs true
+        assertFalse(service.wasClosedByUs(path))
+    }
+
+    fun testFlushPendingClosesDoesNothingAtFloor() {
+        // With exactly one managed open project (= floor), flush must not close it.
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+        service.transition(project, ProjectMode.CLOSED)  // blocked → pendingClose
+
+        service.flushPendingCloses()  // still at floor — must stay
+
+        assertEquals(
+            "flushPendingCloses must not close below the floor",
+            ProjectMode.DORMANT,
+            service.getMode(project)
+        )
+        assertFalse(service.wasClosedByUs(project.basePath ?: ""))
+    }
+
+    fun testOnProjectClosedExternallyRemovesFromPendingAndMarksClosed() {
+        // If a user manually closes a window that was in pendingClose, the service
+        // must mark it as closed (so future auto-open works) and clear the entry.
+        service.enroll(project)
+        val path = project.basePath ?: ""
+        service.transition(project, ProjectMode.DORMANT)
+        service.transition(project, ProjectMode.CLOSED)  // blocked → pendingClose
+        assertTrue("precondition: must be in pendingClose", service.isInPendingClose(path))
+
+        service.onProjectClosedExternally(path, project.name)
+
+        assertFalse("pendingClose must be cleared after external close", service.isInPendingClose(path))
+        assertTrue("project must be marked as closed by us", service.wasClosedByUs(path))
+    }
+
+    fun testHealthCheckRunsWithoutException() {
+        // healthCheck must not throw even with no managed projects.
+        service.healthCheck("test")
+    }
+
+    fun testHealthCheckWithEnrolledProjectProducesOkResult() {
+        service.enroll(project)
+        // Must complete cleanly with a managed project in background mode.
+        service.healthCheck("test_enrolled")
+    }
+
+    // ── State machine transitions ─────────────────────────────────────────────
+
+    fun testTransitionActiveChangesMode() {
+        service.enroll(project)
+        service.transition(project, ProjectMode.ACTIVE)
+        assertEquals(ProjectMode.ACTIVE, service.getMode(project))
+    }
+
+    fun testTransitionDormantChangesMode() {
+        service.enroll(project)
+        service.transition(project, ProjectMode.DORMANT)
+        assertEquals(ProjectMode.DORMANT, service.getMode(project))
+    }
+
+    fun testTransitionIsNoOpWhenModeUnchanged() {
+        service.enroll(project)
+        service.transition(project, ProjectMode.BACKGROUND)  // already BACKGROUND after enroll
+        assertEquals(ProjectMode.BACKGROUND, service.getMode(project))
+    }
+
+    fun testResetInactivityTimerIsNoOpInActiveMode() {
+        // In ACTIVE mode, MCP calls should not start the dormant countdown.
+        // We verify by checking no exception is thrown and mode is unchanged.
+        service.enroll(project)
+        service.transition(project, ProjectMode.ACTIVE)
+        service.resetInactivityTimer(project)  // must not throw or change state
+        assertEquals(ProjectMode.ACTIVE, service.getMode(project))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/KtorMcpServerWatchdogTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/KtorMcpServerWatchdogTest.kt
@@ -1,0 +1,174 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorMcpServer
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorSseSessionManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+/**
+ * Platform tests for KtorMcpServer watchdog behaviour.
+ *
+ * Tests that isRunning() correctly reflects actual engine state and that
+ * onUnexpectedStop fires only when the stop was not intentional.
+ *
+ * Uses a fixed test port offset from the production port to avoid conflicts
+ * when IntelliJ is running alongside the test suite.
+ */
+class KtorMcpServerWatchdogTest : BasePlatformTestCase() {
+
+    private lateinit var testScope: CoroutineScope
+    private var server: KtorMcpServer? = null
+
+    private val testPort = 29280 // offset from production 29170
+
+    override fun setUp() {
+        super.setUp()
+        testScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
+
+    override fun tearDown() {
+        try {
+            server?.stop()
+            server = null
+            testScope.cancel()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    // ── isRunning() reflects actual engine lifecycle ───────────────────────
+
+    fun testIsRunningFalseBeforeStart() {
+        server = makeServer()
+        assertFalse("isRunning must be false before start()", server!!.isRunning())
+    }
+
+    fun testIsRunningTrueAfterSuccessfulStart() {
+        server = makeServer()
+        val result = server!!.start()
+        assertEquals("start must succeed on free port", KtorMcpServer.StartResult.Success, result)
+        assertTrue("isRunning must be true after successful start()", server!!.isRunning())
+    }
+
+    fun testIsRunningFalseAfterStop() {
+        server = makeServer()
+        server!!.start()
+        assertTrue("sanity: isRunning must be true after start", server!!.isRunning())
+
+        server!!.stop()
+        assertFalse("isRunning must be false after stop()", server!!.isRunning())
+    }
+
+    fun testIsRunningFalseAfterDispose() {
+        server = makeServer()
+        server!!.start()
+        server!!.dispose()
+        assertFalse("isRunning must be false after dispose()", server!!.isRunning())
+        server = null // already disposed
+    }
+
+    // ── onUnexpectedStop callback ─────────────────────────────────────────
+
+    fun testOnUnexpectedStopNotFiredOnIntentionalStop() {
+        var callCount = 0
+        server = makeServer(onUnexpectedStop = { callCount++ })
+        server!!.start()
+        server!!.stop()
+
+        assertEquals(
+            "onUnexpectedStop must NOT fire when stop() is called intentionally",
+            0, callCount
+        )
+    }
+
+    fun testOnUnexpectedStopNotFiredOnDispose() {
+        var callCount = 0
+        server = makeServer(onUnexpectedStop = { callCount++ })
+        server!!.start()
+        server!!.dispose()
+        server = null
+
+        assertEquals(
+            "onUnexpectedStop must NOT fire on dispose()",
+            0, callCount
+        )
+    }
+
+    fun testStartResultSuccessOnFreePort() {
+        server = makeServer()
+        val result = server!!.start()
+        assertTrue(
+            "start on a free port must return Success, got $result",
+            result is KtorMcpServer.StartResult.Success
+        )
+    }
+
+    fun testStartResultPortInUseWhenPortTaken() {
+        // Start first server to occupy the port
+        val first = makeServer()
+        val firstResult = first.start()
+        assertEquals(KtorMcpServer.StartResult.Success, firstResult)
+
+        try {
+            // Second server on same port must fail — either PortInUse, Error wrapping BindException,
+            // or a thrown CancellationException (Ktor CIO can wrap BindException in a JobCancellation
+            // when the bind fails inside a coroutine). All three outcomes indicate the conflict was
+            // detected; none is StartResult.Success.
+            val second = makeServer()
+            val result = runCatching { second.start() }
+            val startResult = result.getOrNull()
+
+            if (result.isFailure) {
+                // Thrown CancellationException — conflict detected, server did not start
+                val cause = generateSequence(result.exceptionOrNull()) { it.cause }
+                    .any { it is java.net.BindException }
+                assertTrue("exception must be caused by BindException", cause)
+            } else {
+                assertFalse(
+                    "second start on occupied port must not return Success, got $startResult",
+                    startResult is KtorMcpServer.StartResult.Success
+                )
+            }
+            second.stop()
+        } finally {
+            first.stop()
+        }
+    }
+
+    // ── isRunning() uses engineRunning flag, not just server != null ───────
+
+    fun testIsRunningFalseWhenNeverStarted() {
+        // engineRunning starts as false; server reference is null → false
+        server = makeServer()
+        assertFalse(server!!.isRunning())
+    }
+
+    fun testMultipleStartStopCycles() {
+        server = makeServer()
+
+        repeat(3) { cycle ->
+            val result = server!!.start()
+            assertEquals("cycle $cycle: start must succeed", KtorMcpServer.StartResult.Success, result)
+            assertTrue("cycle $cycle: isRunning must be true", server!!.isRunning())
+            server!!.stop()
+            assertFalse("cycle $cycle: isRunning must be false after stop", server!!.isRunning())
+        }
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────
+
+    private fun makeServer(onUnexpectedStop: (() -> Unit)? = null): KtorMcpServer {
+        val handler = JsonRpcHandler(com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry())
+        return KtorMcpServer(
+            port = testPort,
+            host = "127.0.0.1",
+            jsonRpcHandler = handler,
+            sseSessionManager = KtorSseSessionManager(),
+            coroutineScope = testScope,
+            onUnexpectedStop = onUnexpectedStop
+        )
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
@@ -16,6 +16,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHiera
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ReformatCodeTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool.Companion.buildCompiledElementErrorMessage
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.SafeDeleteTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
@@ -547,6 +548,66 @@ class ToolsTest : BasePlatformTestCase() {
         })
 
         assertTrue("Should error with blank name", result.isError)
+    }
+
+    fun testRenameSymbolToolCompiledElementReturnsHelpfulError() = runBlocking {
+        // Regression test: renaming a compiled class (e.g. a JDK type) used to trigger
+        // an assertion in RenameProcessor constructor, logged as SEVERE "Plugin to blame".
+        // Fix: validateAndPrepare() detects PsiCompiledElement before reaching RenameProcessor
+        // and returns a clear error message containing "compiled".
+        //
+        // In the test fixture the JDK may not be fully indexed, so java.lang.String may not
+        // resolve to a PsiCompiledElement — we verify via unit-level logic below instead.
+        val psiFile = myFixture.addFileToProject(
+            "Usage.java",
+            """
+            public class Usage {
+                public void method() {
+                    String s = "hello";
+                }
+            }
+            """.trimIndent()
+        )
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+
+        val document = com.intellij.psi.PsiDocumentManager.getInstance(project)
+            .getDocument(psiFile) ?: error("no document")
+        val offset = document.text.indexOf("String s")
+        val line = document.getLineNumber(offset) + 1
+        val column = offset - document.getLineStartOffset(line - 1) + 1
+
+        val tool = RenameSymbolTool()
+        val result = tool.execute(project, buildJsonObject {
+            put("file", psiFile.virtualFile.path)
+            put("line", line)
+            put("column", column)
+            put("newName", "MyString")
+        })
+
+        // The rename must not succeed — either the compiled check fires (error mentions
+        // "compiled") or the element didn't resolve (some other error). Either way, no
+        // SEVERE "Plugin to blame" assertion must fire, which is the key regression property.
+        assertTrue("Renaming a JDK type reference must not succeed", result.isError)
+        val msg = (result.content.firstOrNull() as? ContentBlock.Text)?.text ?: ""
+        assertFalse(
+            "Success response must not be returned for a compiled/unresolved symbol",
+            msg.contains("Successfully renamed", ignoreCase = true)
+        )
+    }
+
+    fun testRenameCompiledElementCheckLogic() {
+        // Unit-level regression test for the compiled-element guard in validateAndPrepare().
+        // Verifies the check logic directly without needing a real PsiCompiledElement from the JDK.
+        // The guard is: if (namedElement is PsiCompiledElement) return error mentioning "compiled".
+        val errorForCompiled = buildCompiledElementErrorMessage("description", "/path/to/Something.class")
+        assertTrue(
+            "Error message for compiled element must mention 'compiled'",
+            errorForCompiled.contains("compiled", ignoreCase = true)
+        )
+        assertTrue(
+            "Error message must name the element",
+            errorForCompiled.contains("description")
+        )
     }
 
     fun testSafeDeleteToolMissingParams() = runBlocking {


### PR DESCRIPTION
## Context

When running many IntelliJ projects simultaneously as MCP servers for AI coding agents, idle projects consume memory indefinitely — eventually causing IDE freezes. This PR adds a lifecycle layer that automatically sleeps and wakes projects based on window focus and MCP activity, freeing memory when projects aren't in use.

## Depends on

\#187 (ide_set_power_save_mode, ide_close_project, ide_open_project) — this PR should be reviewed after that one.

## State machine

Four states per managed project, with all timing thresholds configurable in Settings → Index MCP Server:

| State | What runs | Trigger |
|-------|-----------|---------|
| `active` | Full IDE | Window focus gained |
| `background` | Power Save ON, MCP functional | 2 min after focus lost |
| `dormant` | Editors closed, PSI caches freed | 2 min with no MCP calls |
| `closed` | Project fully closed, all memory freed | 10 min with no MCP calls |

## How it works

**Automatic enrollment** — projects enroll on first semantic MCP tool use (find references, diagnostics, refactoring, etc.). Infrastructure tools (`ide_open_project`, `ide_close_project`) do not trigger enrollment. The user receives a balloon notification. No setup required.

**Auto-wake** — `AbstractMcpTool.execute()` wakes DORMANT projects to `background` before tool execution. `ProjectResolver.resolveOrOpen()` reopens CLOSED projects and waits for indexing to complete before returning — callers see normal results after a short delay with no code changes required.

**Null-path auto-recovery** — if all managed projects are closed and a tool call arrives without `project_path`, the lifecycle manager reopens one automatically so MCP routing is never completely lost.

**Floor/ceiling** — configurable minimum (default 4) and maximum (default 10) open projects. The manager never closes the last N projects below the floor, ensuring MCP always has a routing context. When above the ceiling, the least recently used dormant project is evicted.

**Server watchdog** — `McpServerService` now monitors the embedded Ktor server lifecycle. If the server stops unexpectedly (e.g., due to memory pressure), it automatically restarts with exponential backoff (5s/15s/30s). A 30s polling alarm acts as a safety net.

## New tools (all opt-in — disabled by default)

| Tool | Purpose |
|------|---------|
| `ide_project_status` | Combined snapshot: every open project and every managed project with mode per row — **enabled by default** (read-only, required for agent self-navigation) |
| `ide_set_project_mode` | Explicit mode override |
| `ide_get_project_modes` | List managed projects with current mode |
| `ide_set_all_project_modes` | Set all managed projects to the same mode at once |
| `ide_enroll_all_projects` | Enroll every currently open project in one call |
| `ide_release_project` | Remove a project from lifecycle management; accepts optional `path` to release a closed project without opening it |
| `ide_release_all_projects` | Release every managed project (including closed ones) at once |
| `ide_lifecycle_log` | Query recent lifecycle events from an in-memory ring buffer; each event has a `trigger` field explaining the cause |
| `ide_set_lifecycle_log_file` | Enable/disable writing lifecycle events to a persistent log file alongside idea.log |

## New IDE actions (Cmd+Shift+A)

- `MCP: Open Project` — searchable popup of managed projects by state
- `MCP: Show Project States` — opens the lifecycle settings panel directly

## Settings added

- Lifecycle enable/disable toggle
- Focus → background delay (default 2 min)
- Background → dormant delay (default 2 min)
- Dormant → closed delay (default 10 min)
- Minimum open projects floor (default 4)
- Maximum open projects ceiling (default 10)
- Event log buffer size (default 500, range 100–10,000)
- Write events to log file toggle

## Test plan

- `LifecycleUnitTest` — enum values, settings defaults/round-trip, tool schemas, ToolNames.ALL completeness
- `ProjectModeServiceTest` — closed-project registry persistence, mode queries, enrollment/release, wakeForMcp, floor enforcement, pendingClose set, health check invariants
- `LifecycleToolsTest` — tool parameter validation, auto-enroll via middleware, auto-wake from DORMANT, bulk enroll/release
- `KtorMcpServerWatchdogTest` — server isRunning() contract, start/stop lifecycle, onUnexpectedStop callback
- `McpServerWatchdogTest` — backoff sequence, shutdown guard, restart-after-success reset

## Design notes

See `docs/pr-lifecycle-management.md` for threading details, the `pendingClose` event-driven flush design, and the health check invariant taxonomy (`drift:` vs `bug:`).

The companion skill (`src/main/resources/skill/ide-index-mcp/`) has been updated with routing guidance — agents automatically know to use `mcp__intellij-index__*` tools with `project_path` for auto-open, rather than falling back to bash or asking the user to open projects manually.