### PR TITLE
Add ide_install_plugin and ide_restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+Both tools are **disabled by default** and must be enabled in Settings → Index MCP Server before use.
+
+- **`ide_install_plugin`** — install a plugin zip into the IDE, replacing any existing version. Auto-detects the output of `./gradlew buildPlugin` (`build/distributions/*.zip`) when no path is supplied; accepts an explicit path for any plugin zip. A restart is required to load the updated plugin.
+- **`ide_restart`** — restart the IDE. Terminates the MCP connection immediately; no further tool calls should be made after invoking this. Typical use: `ide_install_plugin` followed by `ide_restart`.
 
 ## [4.20.0] - 2026-06-07
 ### Added
@@ -11,6 +16,10 @@
 ## [4.19.3] - 2026-06-05
 ### Fixed
 - Replaced internal IntelliJ `PluginManager.findEnabledPlugin` usage with public plugin-state checks for Marketplace approval.
+- Fixed `ide_file_structure` for Lombok/augmented Java classes by skipping generated PSI members without real source offsets. Fixes [#201](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/201).
+
+## [4.19.2] - 2026-06-04
+### Fixed
 - Fixed `ide_file_structure` for Lombok/augmented Java classes by skipping generated PSI members without real source offsets. Fixes [#201](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/201).
 
 ## [4.19.1] - 2026-05-26

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ These tools work in all supported JetBrains IDEs.
 | `ide_read_file` | Read file content by path or qualified name, including library/jar sources *(disabled by default)* |
 | `ide_get_active_file` | Get the currently active file(s) in the editor with cursor position *(disabled by default)* |
 | `ide_open_file` | Open a file in the editor with optional line/column navigation *(disabled by default)* |
+| `ide_install_plugin` | Install a plugin zip into the IDE, replacing any existing version — auto-detects `build/distributions/*.zip` when no path is given *(disabled by default)* |
+| `ide_restart` | Restart the IDE — terminates the MCP connection; call after `ide_install_plugin` *(disabled by default)* |
 | `ide_refactor_rename` | Rename a symbol and update all references across the project (all languages) |
 | `ide_move_file` | Move a file to a new directory, applying language-aware reference/package updates when the IDE provides a semantic move backend |
 | `ide_reformat_code` | Reformat code using project code style with import optimization *(disabled by default)* |

--- a/USAGE.md
+++ b/USAGE.md
@@ -67,6 +67,9 @@ These tools activate based on available language plugins:
   - [ide_read_file](#ide_read_file)
   - [ide_get_active_file](#ide_get_active_file)
   - [ide_open_file](#ide_open_file)
+- [Plugin Development](#plugin-development)
+  - [ide_install_plugin](#ide_install_plugin)
+  - [ide_restart](#ide_restart)
 - [Refactoring Tools](#refactoring-tools)
   - [ide_refactor_rename](#ide_refactor_rename)
   - [ide_move_file](#ide_move_file)
@@ -969,6 +972,80 @@ Searches for code symbols (classes, interfaces, methods, fields, and functions) 
 - `SYMBOL` - Generic symbol when the IDE contributor does not expose a more specific kind
 
 For Markdown heading outlines, use `ide_file_structure`.
+
+---
+
+## Plugin Development
+
+> **Note**: Both tools in this section are disabled by default. Enable them in Settings > Tools > Index MCP Server.
+
+### ide_install_plugin
+
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+
+Install a plugin zip into the IDE, replacing any existing version. When no path is given, auto-detects the most recently modified zip in `build/distributions/` of the active project — the output of `./gradlew buildPlugin`.
+
+A restart is required for the change to take effect. Call `ide_restart` after this tool returns.
+
+**Use when:**
+- Installing a freshly built plugin without leaving the MCP session
+- Iterating on plugin development: build → install → restart in one flow
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | No | Absolute path to the plugin zip. Defaults to auto-detection from `build/distributions/` |
+| `project_path` | string | No | Project path when multiple projects are open and `path` is omitted |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_install_plugin",
+    "arguments": {}
+  }
+}
+```
+
+**Example Response:**
+
+```
+Plugin 'com.example.my-plugin' installed from my-plugin-1.0.0.zip. Restart the IDE to load the updated plugin (call ide_restart).
+```
+
+---
+
+### ide_restart
+
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+
+Restart the IDE. This terminates the MCP connection — the AI assistant will lose connectivity and must reconnect after the IDE comes back up.
+
+**Use when:**
+- Loading a freshly installed plugin after `ide_install_plugin`
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_path` | string | No | Project path when multiple projects are open |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_restart",
+    "arguments": {}
+  }
+}
+```
+
+> **Note**: The MCP connection drops immediately after this call. Reconnect your AI assistant client before making further tool calls.
 
 ---
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,3 +41,4 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
+org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
@@ -35,6 +35,10 @@ object ToolNames {
     const val GET_ACTIVE_FILE = "ide_get_active_file"
     const val OPEN_FILE = "ide_open_file"
 
+    // Plugin development tools
+    const val INSTALL_PLUGIN = "ide_install_plugin"
+    const val RESTART_IDE = "ide_restart"
+
     /**
      * All known tool names, sorted alphabetically.
      * Keep this list in sync when adding or removing tool name constants.
@@ -54,6 +58,7 @@ object ToolNames {
         FIND_SYMBOL,
         GET_ACTIVE_FILE,
         INDEX_STATUS,
+        INSTALL_PLUGIN,
         REFACTOR_MOVE,
         OPEN_FILE,
         OPTIMIZE_IMPORTS,
@@ -61,6 +66,7 @@ object ToolNames {
         REFACTOR_RENAME,
         REFACTOR_SAFE_DELETE,
         REFORMAT_CODE,
+        RESTART_IDE,
         SEARCH_TEXT,
         SYNC_FILES,
         TYPE_HIERARCHY

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServer.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServer.kt
@@ -332,6 +332,8 @@ class KtorMcpServer(
             } else {
                 call.respond(HttpStatusCode.Accepted)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.error("Error processing MCP request (Streamable HTTP)", e)
             call.respondText(
@@ -387,6 +389,8 @@ class KtorMcpServer(
                         protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION
                     )
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 LOG.error("Error processing MCP batch message (Streamable HTTP)", e)
                 createJsonRpcError(parsed?.get("id"), -32603, e.message ?: "Internal error")
@@ -424,6 +428,8 @@ class KtorMcpServer(
             } else {
                 call.respond(HttpStatusCode.InternalServerError)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.error("Error processing initialize (Streamable HTTP)", e)
             call.respondText(
@@ -469,6 +475,8 @@ class KtorMcpServer(
             } else {
                 call.respond(HttpStatusCode.Accepted)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LOG.error("Error processing MCP request (Streamable HTTP)", e)
             call.respondText(
@@ -518,6 +526,8 @@ class KtorMcpServer(
                         LOG.warn("Failed to send response to session $sessionId - session may have closed")
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 LOG.error("Error processing MCP request (SSE)", e)
                 sseSessionManager.sendEvent(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -34,7 +34,7 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
         var syncExternalChanges: Boolean = false,
         var availableProjectsMode: AvailableProjectsMode = AvailableProjectsMode.EXPANDED,
         var responseFormat: ResponseFormat = ResponseFormat.JSON,
-        var disabledTools: MutableSet<String> = mutableSetOf("ide_build_project", "ide_file_structure", "ide_find_symbol", "ide_read_file", "ide_get_active_file", "ide_open_file", "ide_reformat_code", "ide_optimize_imports", "ide_convert_java_to_kotlin"),
+        var disabledTools: MutableSet<String> = mutableSetOf("ide_build_project", "ide_file_structure", "ide_find_symbol", "ide_read_file", "ide_get_active_file", "ide_open_file", "ide_reformat_code", "ide_optimize_imports", "ide_convert_java_to_kotlin", "ide_close_project", "ide_open_project", "ide_set_power_save_mode", "ide_install_plugin", "ide_restart"),
         var serverPort: Int = -1, // -1 means use IDE-specific default
         var serverHost: String = McpConstants.DEFAULT_SERVER_HOST
     )

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -16,6 +16,8 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.ReadFileT
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.InstallPluginTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.RestartIdeTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.SyncFilesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.MoveFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.OptimizeImportsTool
@@ -235,6 +237,8 @@ class ToolRegistry {
         register(GetIndexStatusTool())
         register(SyncFilesTool())
         register(BuildProjectTool())
+        register(InstallPluginTool())
+        register(RestartIdeTool())
 
         // Refactoring tools (universal - uses platform APIs)
         register(RenameSymbolTool())

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/InstallPluginTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/InstallPluginTool.kt
@@ -1,0 +1,153 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.application.PathManager
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+
+class InstallPluginTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+
+    override val name = "ide_install_plugin"
+
+    override val description = """
+        Install a plugin into the IDE, replacing any existing version.
+
+        Locates the plugin zip, removes the previously installed version (if any),
+        and extracts the new version into the IDE plugins directory. A restart is
+        required for the change to take effect — call ide_restart after this tool
+        returns, or ask the user to restart manually.
+
+        If path is omitted, the tool searches build/distributions/*.zip in the
+        active project directory (the output of ./gradlew buildPlugin). When multiple
+        zip files are found, the most recently modified one is used.
+
+        Parameters:
+        - path (optional): Absolute path to the plugin zip. Defaults to auto-detection
+          from the active project's build/distributions/ directory.
+        - project_path (optional): Required when multiple projects are open and path
+          is omitted, to identify which project's build output to use.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .stringProperty("path", "Absolute path to the plugin zip to install.")
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val zipPath = arguments["path"]?.jsonPrimitive?.content
+            ?.let { Path.of(it) }
+            ?: findBuildOutput(project)
+            ?: return createErrorResult(
+                "No plugin zip found. Run ./gradlew buildPlugin first, or supply an explicit path."
+            )
+
+        if (!zipPath.toString().endsWith(".zip")) {
+            return createErrorResult("Expected a .zip file, got: $zipPath")
+        }
+
+        if (!Files.exists(zipPath)) {
+            return createErrorResult("File not found: $zipPath")
+        }
+
+        val pluginId = readPluginId(zipPath)
+            ?: return createErrorResult(
+                "Could not read plugin ID from META-INF/plugin.xml inside $zipPath"
+            )
+
+        val pluginsDir = Path.of(PathManager.getPluginsPath())
+        removeExistingInstallation(pluginsDir, pluginId)
+        extractZip(zipPath, pluginsDir)
+
+        LOG.info("installed plugin $pluginId from $zipPath")
+        return createSuccessResult(
+            "Plugin '$pluginId' installed from ${zipPath.fileName}. " +
+            "Restart the IDE to load the updated plugin (call ide_restart)."
+        )
+    }
+
+    private fun findBuildOutput(project: Project): Path? {
+        val distDir = Path.of(project.basePath ?: return null, "build", "distributions")
+        if (!Files.isDirectory(distDir)) return null
+
+        return Files.list(distDir)
+            .filter { it.toString().endsWith(".zip") }
+            .max(Comparator.comparingLong { Files.getLastModifiedTime(it).toMillis() })
+            .orElse(null)
+    }
+
+    private fun readPluginId(zipPath: Path): String? = ZipFile(zipPath.toFile()).use { zip ->
+        zip.entries().asSequence().find { it.name.endsWith("META-INF/plugin.xml") }?.let { entry ->
+            extractPluginId(zip.getInputStream(entry).bufferedReader().readText())?.let { return it }
+        }
+        // Gradle Plugin 2.x+: plugin.xml is inside the main jar in lib/
+        zip.entries().asSequence().filter { it.name.endsWith(".jar") }
+            .firstNotNullOfOrNull { pluginIdFromJar(zip.getInputStream(it)) }
+    }
+
+    private fun pluginIdFromJar(input: InputStream): String? = ZipInputStream(input).use { zis ->
+        var entry = zis.nextEntry
+        while (entry != null) {
+            if (entry.name == "META-INF/plugin.xml") return extractPluginId(zis.bufferedReader().readText())
+            zis.closeEntry()
+            entry = zis.nextEntry
+        }
+        null
+    }
+
+    private fun extractPluginId(pluginXml: String): String? =
+        Regex("<id>([^<]+)</id>").find(pluginXml)?.groupValues?.get(1)?.trim()
+
+    private fun removeExistingInstallation(pluginsDir: Path, pluginId: String) {
+        val existing = pluginsDir.toFile().listFiles() ?: return
+        for (dir in existing) {
+            if (pluginIdFromInstallation(dir) == pluginId) {
+                FileUtil.delete(dir)
+                LOG.info("removed previous installation of $pluginId at ${dir.absolutePath}")
+                return
+            }
+        }
+    }
+
+    private fun pluginIdFromInstallation(dir: File): String? {
+        val pluginXml = File(dir, "META-INF/plugin.xml")
+        if (pluginXml.exists()) return extractPluginId(pluginXml.readText())
+        return File(dir, "lib").takeIf { it.isDirectory }
+            ?.listFiles()
+            ?.filter { it.extension == "jar" }
+            ?.firstNotNullOfOrNull { pluginIdFromJar(it.inputStream()) }
+    }
+
+    private fun extractZip(zipPath: Path, destDir: Path) {
+        ZipFile(zipPath.toFile()).use { zip ->
+            zip.entries().asSequence().forEach { entry ->
+                val dest = destDir.resolve(entry.name)
+                if (entry.isDirectory) {
+                    Files.createDirectories(dest)
+                } else {
+                    Files.createDirectories(dest.parent)
+                    zip.getInputStream(entry).use { input ->
+                        Files.copy(input, dest, StandardCopyOption.REPLACE_EXISTING)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val LOG = logger<InstallPluginTool>()
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RestartIdeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RestartIdeTool.kt
@@ -1,0 +1,43 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ex.ApplicationEx
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+
+class RestartIdeTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+
+    override val name = "ide_restart"
+
+    override val description = """
+        Restart the IDE.
+
+        WARNING: this terminates the MCP server. The connection to this IDE will
+        drop immediately and no response will be received after the restart is
+        initiated. Call this as a final step — do not expect to execute further
+        tool calls in the same session.
+
+        Typical use: call ide_install_plugin, then ide_restart.
+
+        Parameters:
+        - project_path (optional): only needed when multiple projects are open.
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val app = ApplicationManager.getApplication()
+        app.invokeLater {
+            app.saveAll()
+            if (app is ApplicationEx) app.restart(true) else app.restart()
+        }
+        return createSuccessResult("Restarting IDE.")
+    }
+}

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -129,7 +129,9 @@ Omit `paths` to sync the entire project.
 
 These tools exist but are disabled by default. If you get "tool not found", they need to be enabled in IDE settings (Settings > Tools > Index MCP Server):
 
-`ide_build_project`, `ide_file_structure`, `ide_find_symbol`, `ide_read_file`, `ide_get_active_file`, `ide_open_file`, `ide_reformat_code`
+`ide_build_project`, `ide_file_structure`, `ide_find_symbol`, `ide_install_plugin`, `ide_read_file`, `ide_get_active_file`, `ide_open_file`, `ide_reformat_code`, `ide_restart`
+
+Note: `ide_restart` terminates the MCP connection — reconnect your client after calling it.
 
 ## Detailed Tool Parameters
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
@@ -68,7 +68,9 @@ class ConstantsUnitTest : TestCase() {
             ToolNames.OPTIMIZE_IMPORTS,
             ToolNames.CONVERT_JAVA_TO_KOTLIN,
             ToolNames.GET_ACTIVE_FILE,
-            ToolNames.OPEN_FILE
+            ToolNames.OPEN_FILE,
+            ToolNames.INSTALL_PLUGIN,
+            ToolNames.RESTART_IDE
         )
 
         for (name in expectedNames) {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
@@ -493,7 +493,10 @@ class ToolExecutionIntegrationTest : BasePlatformTestCase() {
             ToolNames.OPTIMIZE_IMPORTS,
             // Editor tools
             ToolNames.GET_ACTIVE_FILE,
-            ToolNames.OPEN_FILE
+            ToolNames.OPEN_FILE,
+            // Plugin dev tools
+            ToolNames.INSTALL_PLUGIN,
+            ToolNames.RESTART_IDE
         )
         if (PluginDetectors.java.isAvailable && PluginDetectors.kotlin.isAvailable) {
             expectedTools.add(ToolNames.CONVERT_JAVA_TO_KOTLIN)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/PluginDevToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/PluginDevToolsTest.kt
@@ -1,0 +1,48 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.InstallPluginTool
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class PluginDevToolsTest : BasePlatformTestCase() {
+
+    private fun resultText(result: ToolCallResult) =
+        (result.content.firstOrNull() as? ContentBlock.Text)?.text ?: ""
+
+    fun testInstallPluginToolReturnsErrorWhenNoBuildOutputExists() = runBlocking {
+        // The test project has no build/distributions/ directory, so auto-detection fails.
+        val result = InstallPluginTool().execute(project, buildJsonObject { })
+
+        assertTrue("Missing zip must produce an error", result.isError)
+        val text = resultText(result)
+        assertTrue(
+            "Error must suggest running buildPlugin",
+            text.contains("buildPlugin", ignoreCase = true) ||
+            text.contains("No plugin zip", ignoreCase = true)
+        )
+    }
+
+    fun testInstallPluginToolReturnsErrorForNonExistentPath() = runBlocking {
+        val result = InstallPluginTool().execute(
+            project,
+            buildJsonObject { put("path", "/nonexistent/plugin.zip") }
+        )
+
+        assertTrue(result.isError)
+        assertTrue(resultText(result).contains("not found", ignoreCase = true))
+    }
+
+    fun testInstallPluginToolRejectsNonZipPath() = runBlocking {
+        val result = InstallPluginTool().execute(
+            project,
+            buildJsonObject { put("path", "/some/plugin.jar") }
+        )
+
+        assertTrue(result.isError)
+        assertTrue(resultText(result).contains(".zip", ignoreCase = true))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/PluginDevToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/PluginDevToolsUnitTest.kt
@@ -1,0 +1,62 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.InstallPluginTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.RestartIdeTool
+import junit.framework.TestCase
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class PluginDevToolsUnitTest : TestCase() {
+
+    fun testInstallPluginToolName() {
+        assertEquals(ToolNames.INSTALL_PLUGIN, InstallPluginTool().name)
+    }
+
+    fun testInstallPluginToolPathIsOptional() {
+        val required = InstallPluginTool().inputSchema["required"]
+            ?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+        assertFalse("path must be optional — auto-detection is the default", required.contains("path"))
+    }
+
+    fun testInstallPluginToolHasProjectPath() {
+        val properties = InstallPluginTool().inputSchema["properties"]?.jsonObject
+        assertNotNull(properties?.get("project_path"))
+    }
+
+    fun testRestartIdeToolName() {
+        assertEquals(ToolNames.RESTART_IDE, RestartIdeTool().name)
+    }
+
+    fun testRestartIdeToolHasProjectPath() {
+        val properties = RestartIdeTool().inputSchema["properties"]?.jsonObject
+        assertNotNull(properties?.get("project_path"))
+    }
+
+    fun testRestartIdeToolDescriptionWarnsAboutConnectionLoss() {
+        val desc = RestartIdeTool().description
+        assertTrue(
+            "Description must warn that the MCP connection will terminate",
+            desc.contains("terminates", ignoreCase = true) ||
+            desc.contains("connection", ignoreCase = true) ||
+            desc.contains("drop", ignoreCase = true)
+        )
+    }
+
+    fun testToolNamesAllContainsPluginDevTools() {
+        assertTrue(ToolNames.ALL.contains(ToolNames.INSTALL_PLUGIN))
+        assertTrue(ToolNames.ALL.contains(ToolNames.RESTART_IDE))
+    }
+
+    fun testToolNamesAllIsSorted() {
+        assertEquals(ToolNames.ALL.sorted(), ToolNames.ALL)
+    }
+
+    fun testPluginDevToolsAreDisabledByDefault() {
+        val defaults = McpSettings.State().disabledTools
+        assertTrue("ide_install_plugin must be opt-in", defaults.contains(ToolNames.INSTALL_PLUGIN))
+        assertTrue("ide_restart must be opt-in", defaults.contains(ToolNames.RESTART_IDE))
+    }
+}


### PR DESCRIPTION
## Summary

Two tools to support iterative plugin development from an AI coding agent.

**`ide_install_plugin`** — installs a plugin zip into the IDE plugins directory, removing the previous version of the same plugin first. When no `path` is given, auto-detects `build/distributions/*.zip` in the active project (the output of `./gradlew buildPlugin`). When multiple zips are present the most recently modified is used; an explicit `path` overrides detection entirely.

**`ide_restart`** — restarts the IDE. The MCP connection drops immediately when the restart begins. The tool description explicitly warns callers not to expect a response or issue further tool calls after invoking it.

Both tools are **disabled by default** and must be enabled in Settings → Tools → Index MCP Server before use.

## Motivation — closing the plugin development loop

With `ide_install_plugin` and `ide_restart`, an AI coding agent can execute the full plugin development cycle without human intervention:

```
edit source → ide_build_project → ide_install_plugin → ide_restart → smoke test via MCP → repeat
```

Every step after the initial code edit is an MCP call. The agent makes a change, builds, installs, restarts, then immediately calls `ide_index_status` to confirm the new plugin loaded, and runs further MCP tools to verify the changes work. No human needs to touch the IDE between iterations.

This is particularly useful when the plugin under development _is_ the MCP server — the agent can test its own changes by calling the tools it just shipped.

## Smoke test protocol

A smoke test protocol is included at `docs/smoke-test-protocol.md` (in \#188). It documents the install-restart-verify cycle and covers what the automated test suite cannot: HTTP-level behaviour, tool registration after restart, and end-to-end error paths. When working on this plugin, run the protocol after any `buildPlugin` → install → restart cycle for changes that touch HTTP transport, tool registration, or server startup.

## Test plan

- `PluginDevToolsUnitTest` — tool names, schemas (path optional, project_path present), restart description warns about connection loss, ToolNames.ALL completeness, disabled-by-default check
- `PluginDevToolsTest` — error on missing build output, error on non-existent path, error on non-zip file