### PR TITLE
feat: support filePattern and regex in ide_search_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [4.19.0] - 2026-05-26
+### Added
+- Added `regex` support to `ide_search_text`, including existing `context` filtering and pagination.
+
+### Fixed
+- Wired `ide_search_text`'s documented `filePattern` glob filter into the schema and search execution path. Fixes [#190](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/190).
+
 ## [4.18.0] - 2026-05-24
 ### Added
 - **PHP symbol reference handler** — PHP now supports `language`+`symbol` parameter mode for `ide_find_references`, `ide_find_definition`, `ide_call_hierarchy`, `ide_find_implementations`, and `ide_find_super_methods`. Accepts symbol formats with PHP namespaces (e.g., `\\App\\Service\\UserService`, `\\App\\Service\\UserService::find()`, `\\App\\Service\\UserService::$property`). Fixes [#179](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/179).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ## [4.19.0] - 2026-05-26
 ### Added
-- Added `regex` support to `ide_search_text`, including existing `context` filtering and pagination.
+- Added `regex` support to `ide_search_text` through IntelliJ's Find in Files path, including existing `context` filtering and pagination.
 
 ### Fixed
-- Wired `ide_search_text`'s documented `filePattern` glob filter into the schema and search execution path. Fixes [#190](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/190).
+- Wired `ide_search_text`'s documented `filePattern` filter into the schema and search execution path using IntelliJ file mask semantics. Fixes [#190](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/190).
 
 ## [4.18.0] - 2026-05-24
 ### Added

--- a/USAGE.md
+++ b/USAGE.md
@@ -429,7 +429,7 @@ Searches for text using the IDE's pre-built word index. Significantly faster tha
 | `regex` | boolean | No | Treat `query` as a regular expression (default: false) |
 | `context` | string | No | Where to search: `"code"`, `"comments"`, `"strings"`, or `"all"` (default) |
 | `caseSensitive` | boolean | No | Case sensitive search (default: true) |
-| `filePattern` | string | No | Glob pattern to filter files by name or project-relative path (e.g., `"*.kt"`, `"*.gradle.kts"`, `"src/**/*.java"`) |
+| `filePattern` | string | No | IntelliJ file mask to filter files by name (e.g., `"*.kt"`, `"*.gradle.kts"`, `"*.java,!*Test.java"`) |
 | `limit` | integer | No | Maximum results (default: 100, max: 500) |
 
 **Example Request:**

--- a/USAGE.md
+++ b/USAGE.md
@@ -425,10 +425,11 @@ Searches for text using the IDE's pre-built word index. Significantly faster tha
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | string | Yes | Exact word to search for (not a pattern/regex) |
+| `query` | string | Yes | Text to search for; treated as an exact word unless `regex` is `true` |
+| `regex` | boolean | No | Treat `query` as a regular expression (default: false) |
 | `context` | string | No | Where to search: `"code"`, `"comments"`, `"strings"`, or `"all"` (default) |
 | `caseSensitive` | boolean | No | Case sensitive search (default: true) |
-| `filePattern` | string | No | Glob pattern to filter files (e.g., `"*.kt"`, `"*.gradle.kts"`) |
+| `filePattern` | string | No | Glob pattern to filter files by name or project-relative path (e.g., `"*.kt"`, `"*.gradle.kts"`, `"src/**/*.java"`) |
 | `limit` | integer | No | Maximum results (default: 100, max: 500) |
 
 **Example Request:**
@@ -442,6 +443,23 @@ Searches for text using the IDE's pre-built word index. Significantly faster tha
       "query": "TODO",
       "context": "comments",
       "filePattern": "*.kt"
+    }
+  }
+}
+```
+
+Regex example:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_search_text",
+    "arguments": {
+      "query": "Runtime\\.getRuntime\\(\\)\\.exec\\(",
+      "regex": true,
+      "context": "code",
+      "filePattern": "*.java"
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.18.0
+pluginVersion = 4.19.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
@@ -48,6 +48,8 @@ object ParamNames {
     const val LIMIT = "limit"
     const val CONTEXT = "context"
     const val CASE_SENSITIVE = "caseSensitive"
+    const val FILE_PATTERN = "filePattern"
+    const val REGEX = "regex"
     const val CURSOR = "cursor"
 
     // Preview parameters

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
@@ -11,15 +11,24 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SearchTextRes
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TextMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.DelegatingGlobalSearchScope
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiSearchHelper
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.search.TextOccurenceProcessor
 import com.intellij.psi.search.UsageSearchContext
 import com.intellij.psi.util.PsiModificationTracker
+import java.util.regex.PatternSyntaxException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
@@ -29,10 +38,63 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
 
+internal class SearchTextFilePatternMatcher private constructor(
+    private val regex: Regex,
+    private val matchPath: Boolean
+) {
+    fun matches(relativePath: String, fileName: String): Boolean {
+        val normalizedPath = relativePath.replace('\\', '/')
+        val normalizedFileName = fileName.replace('\\', '/')
+        return if (matchPath) {
+            regex.matches(normalizedPath)
+        } else {
+            regex.matches(normalizedFileName)
+        }
+    }
+
+    companion object {
+        fun fromGlob(pattern: String?): SearchTextFilePatternMatcher? {
+            if (pattern == null) return null
+            val normalized = pattern.trim().replace('\\', '/')
+            if (normalized.isEmpty()) return null
+            return SearchTextFilePatternMatcher(
+                regex = globToRegex(normalized).toRegex(),
+                matchPath = normalized.contains('/')
+            )
+        }
+
+        private fun globToRegex(glob: String): String {
+            val builder = StringBuilder("^")
+            var index = 0
+            while (index < glob.length) {
+                val char = glob[index]
+                when (char) {
+                    '*' -> {
+                        if (index + 1 < glob.length && glob[index + 1] == '*') {
+                            builder.append(".*")
+                            index++
+                        } else {
+                            builder.append("[^/]*")
+                        }
+                    }
+                    '?' -> builder.append("[^/]")
+                    '.', '(', ')', '+', '|', '^', '$', '@', '%', '{', '}', '[', ']' -> {
+                        builder.append('\\').append(char)
+                    }
+                    else -> builder.append(char)
+                }
+                index++
+            }
+            builder.append('$')
+            return builder.toString()
+        }
+    }
+}
+
 /**
  * Text search using IDE's word index.
  *
- * Uses a pre-built word index for exact word matches.
+ * Uses a pre-built word index for exact word matches and scans project files for regex matches.
  *
  * Supports context filtering: search only in code, comments, or string literals.
  */
@@ -47,25 +109,28 @@ class SearchTextTool : AbstractMcpTool() {
     override val name = ToolNames.SEARCH_TEXT
 
     override val description = """
-        Search for text using IDE's word index. Significantly faster than file scanning for exact word matches.
+        Search for text using IDE's word index or regex scanning.
 
-        Uses a pre-built word index for O(1) lookups instead of scanning all files.
+        Exact searches use a pre-built word index for O(1) lookups instead of scanning all files. Regex searches scan project files.
 
         Context filtering: search only in code, comments, or string literals.
+        File filtering: pass filePattern with a glob such as "*.kt" or "src/**/*.java".
 
         Returns: matching locations with file, line, column, context snippet, and context type.
 
         Supports pagination: first call returns results + nextCursor. Pass cursor to get the next page.
-        Parameters: query (required for fresh search), context (optional: "code", "comments", "strings", "all"), caseSensitive (optional, default: true), pageSize (optional, default: 100, max: 500), cursor (for pagination, replaces search params; project_path may still be required).
+        Parameters: query (required for fresh search), regex (optional, default: false), context (optional: "code", "comments", "strings", "all"), filePattern (optional glob), caseSensitive (optional, default: true), pageSize (optional, default: 100, max: 500), cursor (for pagination, replaces search params; project_path may still be required).
 
-        Example: {"query": "ConfigManager"} or {"query": "TODO", "context": "comments"}
+        Example: {"query": "ConfigManager"} or {"query": "TODO", "context": "comments", "filePattern": "*.kt"} or {"query": "Runtime\\.getRuntime\\(\\)\\.exec\\(", "regex": true, "filePattern": "*.java"}
     """.trimIndent()
 
     override val inputSchema: JsonObject = SchemaBuilder.tool()
         .projectPath()
-        .stringProperty(ParamNames.QUERY, "Exact word to search for (not a pattern/regex). Required for fresh search, ignored when cursor is provided.")
+        .stringProperty(ParamNames.QUERY, "Text to search for. Treated as an exact word unless regex is true. Required for fresh search, ignored when cursor is provided.")
+        .booleanProperty(ParamNames.REGEX, "Treat query as a regular expression. Default: false.")
         .enumProperty(ParamNames.CONTEXT, "Where to search: \"code\", \"comments\", \"strings\", \"all\". Default: \"all\".", listOf("code", "comments", "strings", "all"))
         .booleanProperty(ParamNames.CASE_SENSITIVE, "Case sensitive search. Default: true.")
+        .stringProperty(ParamNames.FILE_PATTERN, "Glob pattern to filter files by name or project-relative path, e.g. \"*.kt\", \"*.gradle.kts\", \"src/**/*.java\".")
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
@@ -94,6 +159,8 @@ class SearchTextTool : AbstractMcpTool() {
             ?: return createErrorResult("Missing required parameter: ${ParamNames.QUERY}")
         val contextStr = arguments[ParamNames.CONTEXT]?.jsonPrimitive?.content ?: "all"
         val caseSensitive = arguments[ParamNames.CASE_SENSITIVE]?.jsonPrimitive?.boolean ?: true
+        val regex = arguments[ParamNames.REGEX]?.jsonPrimitive?.boolean ?: false
+        val filePattern = optionalStringArg(arguments, ParamNames.FILE_PATTERN)
         val pageSize = resolvePageSize(arguments, DEFAULT_PAGE_SIZE, aliases = arrayOf("limit"))
         val collectLimit = maxOf(PaginationService.DEFAULT_OVERCOLLECT, pageSize)
 
@@ -102,16 +169,36 @@ class SearchTextTool : AbstractMcpTool() {
         }
 
         val searchContext = parseSearchContext(contextStr)
+        val filePatternMatcher = try {
+            SearchTextFilePatternMatcher.fromGlob(filePattern)
+        } catch (e: PatternSyntaxException) {
+            return createErrorResult("Invalid filePattern glob: ${e.message}")
+        }
+        val regexPattern = if (regex) {
+            try {
+                query.toRegex(if (caseSensitive) emptySet() else setOf(RegexOption.IGNORE_CASE))
+            } catch (e: PatternSyntaxException) {
+                return createErrorResult("Invalid regex query: ${e.message}")
+            } catch (e: IllegalArgumentException) {
+                return createErrorResult("Invalid regex query: ${e.message}")
+            }
+        } else {
+            null
+        }
 
         requireSmartMode(project)
 
         val cursorToken = suspendingReadAction {
-            val scope = createFilteredScope(project)
-            val matches = searchText(project, query, scope, searchContext, caseSensitive, collectLimit)
+            val scope = createSearchScope(project, filePatternMatcher)
+            val matches = if (regexPattern != null) {
+                searchRegex(project, regexPattern, scope, searchContext, collectLimit)
+            } else {
+                searchText(project, query, scope, searchContext, caseSensitive, collectLimit)
+            }
 
             val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = extender@{ seenKeys, limit ->
                 suspendingReadAction {
-                    extendSearchText(project, query, searchContext, caseSensitive, seenKeys, limit)
+                    extendSearchText(project, query, regexPattern, searchContext, caseSensitive, filePatternMatcher, seenKeys, limit)
                 }
             }
 
@@ -130,7 +217,11 @@ class SearchTextTool : AbstractMcpTool() {
                 searchExtender = searchExtender,
                 psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
                 projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
-                metadata = mapOf("query" to query)
+                metadata = buildMap {
+                    put("query", query)
+                    put("regex", regex.toString())
+                    if (filePattern != null) put("filePattern", filePattern)
+                }
             )
         }
 
@@ -162,7 +253,7 @@ class SearchTextTool : AbstractMcpTool() {
     private fun searchText(
         project: Project,
         word: String,
-        scope: com.intellij.psi.search.GlobalSearchScope,
+        scope: GlobalSearchScope,
         searchContext: Short,
         caseSensitive: Boolean,
         limit: Int
@@ -223,12 +314,26 @@ class SearchTextTool : AbstractMcpTool() {
     private fun extendSearchText(
         project: Project,
         word: String,
+        regex: Regex?,
         searchContext: Short,
         caseSensitive: Boolean,
+        filePatternMatcher: SearchTextFilePatternMatcher?,
         seenKeys: Set<String>,
         limit: Int
     ): List<PaginationService.SerializedResult> {
-        val scope = createFilteredScope(project)
+        val scope = createSearchScope(project, filePatternMatcher)
+        if (regex != null) {
+            return searchRegex(project, regex, scope, searchContext, limit, seenKeys)
+                .asSequence()
+                .map { match ->
+                    PaginationService.SerializedResult(
+                        key = "${match.file}:${match.line}",
+                        data = json.encodeToJsonElement(match)
+                    )
+                }
+                .toList()
+        }
+
         val newResults = ConcurrentLinkedQueue<PaginationService.SerializedResult>()
         val seenLines = ConcurrentHashMap.newKeySet<String>()
         seenLines.addAll(seenKeys)
@@ -280,6 +385,55 @@ class SearchTextTool : AbstractMcpTool() {
         return newResults.toList()
     }
 
+    private fun searchRegex(
+        project: Project,
+        regex: Regex,
+        scope: GlobalSearchScope,
+        searchContext: Short,
+        limit: Int,
+        seenKeys: Set<String> = emptySet()
+    ): List<TextMatch> {
+        val results = mutableListOf<TextMatch>()
+        val seenLines = HashSet<String>()
+        seenLines.addAll(seenKeys)
+        val fileIndex = ProjectFileIndex.getInstance(project)
+        val psiManager = PsiManager.getInstance(project)
+        val fileDocumentManager = FileDocumentManager.getInstance()
+
+        fileIndex.iterateContent { virtualFile ->
+            if (results.size >= limit) {
+                return@iterateContent false
+            }
+            if (virtualFile.isDirectory || !scope.contains(virtualFile)) {
+                return@iterateContent true
+            }
+
+            val document = fileDocumentManager.getDocument(virtualFile) ?: return@iterateContent true
+            val psiFile = psiManager.findFile(virtualFile) ?: return@iterateContent true
+            val text = document.text
+
+            for (matchResult in regex.findAll(text)) {
+                if (results.size >= limit) {
+                    return@iterateContent false
+                }
+                if (matchResult.value.isEmpty()) {
+                    continue
+                }
+
+                val match = convertToTextMatch(project, psiFile, document, matchResult.range.first, searchContext)
+                    ?: continue
+                val lineKey = "${match.file}:${match.line}"
+                if (seenLines.add(lineKey)) {
+                    results.add(match)
+                }
+            }
+
+            true
+        }
+
+        return results
+    }
+
     private fun convertToTextMatch(
         project: Project,
         element: PsiElement,
@@ -290,15 +444,41 @@ class SearchTextTool : AbstractMcpTool() {
         val relativePath = getRelativePath(project, virtualFile)
 
         val document = PsiDocumentManager.getInstance(project).getDocument(containingFile) ?: return null
-        val offset = element.textOffset
-        val lineNumber = document.getLineNumber(offset)
+        return convertToTextMatch(project, containingFile, document, element.textOffset, searchContext, element, relativePath)
+    }
+
+    private fun convertToTextMatch(
+        project: Project,
+        psiFile: PsiFile,
+        document: com.intellij.openapi.editor.Document,
+        offset: Int,
+        searchContext: Short
+    ): TextMatch? {
+        val virtualFile = psiFile.virtualFile ?: return null
+        val relativePath = getRelativePath(project, virtualFile)
+        val element = findElementAtOffset(psiFile, offset)
+        return convertToTextMatch(project, psiFile, document, offset, searchContext, element, relativePath)
+    }
+
+    private fun convertToTextMatch(
+        project: Project,
+        psiFile: PsiFile,
+        document: com.intellij.openapi.editor.Document,
+        offset: Int,
+        searchContext: Short,
+        element: PsiElement?,
+        relativePath: String
+    ): TextMatch? {
+        if (document.textLength == 0) return null
+        val safeOffset = offset.coerceIn(0, document.textLength - 1)
+        val lineNumber = document.getLineNumber(safeOffset)
         val lineStartOffset = document.getLineStartOffset(lineNumber)
-        val columnNumber = offset - lineStartOffset
+        val columnNumber = safeOffset - lineStartOffset
 
         val lineEndOffset = document.getLineEndOffset(lineNumber)
-        val lineText = document.getText(com.intellij.openapi.util.TextRange(lineStartOffset, lineEndOffset))
+        val lineText = document.getText(TextRange(lineStartOffset, lineEndOffset))
 
-        val contextType = resolveActualContextType(element)
+        val contextType = element?.let { resolveActualContextType(it) } ?: "CODE"
 
         // When a specific context filter is active, skip elements that don't match.
         // processElementsWithWord may return false positives (e.g., code occurrences
@@ -314,6 +494,30 @@ class SearchTextTool : AbstractMcpTool() {
             context = lineText.trim(),
             contextType = contextType
         )
+    }
+
+    private fun findElementAtOffset(psiFile: PsiFile, offset: Int): PsiElement? {
+        val textLength = psiFile.textLength
+        if (textLength <= 0) return null
+        return psiFile.findElementAt(offset.coerceIn(0, textLength - 1))
+    }
+
+    private fun createSearchScope(
+        project: Project,
+        filePatternMatcher: SearchTextFilePatternMatcher?
+    ): GlobalSearchScope {
+        val baseScope = createFilteredScope(project)
+        if (filePatternMatcher == null) {
+            return baseScope
+        }
+
+        return object : DelegatingGlobalSearchScope(baseScope) {
+            override fun contains(file: VirtualFile): Boolean {
+                if (!super.contains(file)) return false
+                val relativePath = getRelativePath(project, file)
+                return filePatternMatcher.matches(relativePath, file.name)
+            }
+        }
     }
 
     private fun resolveActualContextType(element: PsiElement): String {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
@@ -10,17 +10,17 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SearchTextResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TextMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.find.FindModel
+import com.intellij.find.impl.FindInProjectUtil
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.Condition
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
 import com.intellij.psi.search.DelegatingGlobalSearchScope
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiSearchHelper
@@ -28,73 +28,21 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.search.TextOccurenceProcessor
 import com.intellij.psi.search.UsageSearchContext
 import com.intellij.psi.util.PsiModificationTracker
-import java.util.regex.PatternSyntaxException
+import com.intellij.usageView.UsageInfo
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.regex.PatternSyntaxException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
 
-internal class SearchTextFilePatternMatcher private constructor(
-    private val regex: Regex,
-    private val matchPath: Boolean
-) {
-    fun matches(relativePath: String, fileName: String): Boolean {
-        val normalizedPath = relativePath.replace('\\', '/')
-        val normalizedFileName = fileName.replace('\\', '/')
-        return if (matchPath) {
-            regex.matches(normalizedPath)
-        } else {
-            regex.matches(normalizedFileName)
-        }
-    }
-
-    companion object {
-        fun fromGlob(pattern: String?): SearchTextFilePatternMatcher? {
-            if (pattern == null) return null
-            val normalized = pattern.trim().replace('\\', '/')
-            if (normalized.isEmpty()) return null
-            return SearchTextFilePatternMatcher(
-                regex = globToRegex(normalized).toRegex(),
-                matchPath = normalized.contains('/')
-            )
-        }
-
-        private fun globToRegex(glob: String): String {
-            val builder = StringBuilder("^")
-            var index = 0
-            while (index < glob.length) {
-                val char = glob[index]
-                when (char) {
-                    '*' -> {
-                        if (index + 1 < glob.length && glob[index + 1] == '*') {
-                            builder.append(".*")
-                            index++
-                        } else {
-                            builder.append("[^/]*")
-                        }
-                    }
-                    '?' -> builder.append("[^/]")
-                    '.', '(', ')', '+', '|', '^', '$', '@', '%', '{', '}', '[', ']' -> {
-                        builder.append('\\').append(char)
-                    }
-                    else -> builder.append(char)
-                }
-                index++
-            }
-            builder.append('$')
-            return builder.toString()
-        }
-    }
-}
-
 /**
  * Text search using IDE's word index.
  *
- * Uses a pre-built word index for exact word matches and scans project files for regex matches.
+ * Uses a pre-built word index for exact word matches and IntelliJ Find in Files for regex matches.
  *
  * Supports context filtering: search only in code, comments, or string literals.
  */
@@ -109,17 +57,17 @@ class SearchTextTool : AbstractMcpTool() {
     override val name = ToolNames.SEARCH_TEXT
 
     override val description = """
-        Search for text using IDE's word index or regex scanning.
+        Search for text using IDE's word index or IntelliJ Find in Files.
 
-        Exact searches use a pre-built word index for O(1) lookups instead of scanning all files. Regex searches scan project files.
+        Exact searches use a pre-built word index for O(1) lookups instead of scanning all files. Regex searches use IntelliJ's Find in Files path.
 
         Context filtering: search only in code, comments, or string literals.
-        File filtering: pass filePattern with a glob such as "*.kt" or "src/**/*.java".
+        File filtering: pass filePattern with an IntelliJ file mask such as "*.kt" or "*.java,!*Test.java".
 
         Returns: matching locations with file, line, column, context snippet, and context type.
 
         Supports pagination: first call returns results + nextCursor. Pass cursor to get the next page.
-        Parameters: query (required for fresh search), regex (optional, default: false), context (optional: "code", "comments", "strings", "all"), filePattern (optional glob), caseSensitive (optional, default: true), pageSize (optional, default: 100, max: 500), cursor (for pagination, replaces search params; project_path may still be required).
+        Parameters: query (required for fresh search), regex (optional, default: false), context (optional: "code", "comments", "strings", "all"), filePattern (optional IntelliJ file mask), caseSensitive (optional, default: true), pageSize (optional, default: 100, max: 500), cursor (for pagination, replaces search params; project_path may still be required).
 
         Example: {"query": "ConfigManager"} or {"query": "TODO", "context": "comments", "filePattern": "*.kt"} or {"query": "Runtime\\.getRuntime\\(\\)\\.exec\\(", "regex": true, "filePattern": "*.java"}
     """.trimIndent()
@@ -130,7 +78,7 @@ class SearchTextTool : AbstractMcpTool() {
         .booleanProperty(ParamNames.REGEX, "Treat query as a regular expression. Default: false.")
         .enumProperty(ParamNames.CONTEXT, "Where to search: \"code\", \"comments\", \"strings\", \"all\". Default: \"all\".", listOf("code", "comments", "strings", "all"))
         .booleanProperty(ParamNames.CASE_SENSITIVE, "Case sensitive search. Default: true.")
-        .stringProperty(ParamNames.FILE_PATTERN, "Glob pattern to filter files by name or project-relative path, e.g. \"*.kt\", \"*.gradle.kts\", \"src/**/*.java\".")
+        .stringProperty(ParamNames.FILE_PATTERN, "IntelliJ file mask to filter files by name, e.g. \"*.kt\", \"*.gradle.kts\", \"*.java,!*Test.java\".")
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
@@ -168,15 +116,16 @@ class SearchTextTool : AbstractMcpTool() {
             return createErrorResult("Query cannot be empty")
         }
 
-        val searchContext = parseSearchContext(contextStr)
-        val filePatternMatcher = try {
-            SearchTextFilePatternMatcher.fromGlob(filePattern)
+        val usageSearchContext = parseUsageSearchContext(contextStr)
+        val findSearchContext = parseFindSearchContext(contextStr)
+        val fileMaskCondition = try {
+            createFileMaskCondition(filePattern)
         } catch (e: PatternSyntaxException) {
-            return createErrorResult("Invalid filePattern glob: ${e.message}")
+            return createErrorResult("Invalid filePattern mask: ${e.message}")
         }
-        val regexPattern = if (regex) {
+        val findModel = if (regex) {
             try {
-                query.toRegex(if (caseSensitive) emptySet() else setOf(RegexOption.IGNORE_CASE))
+                createFindModel(project, query, caseSensitive, filePattern, findSearchContext)
             } catch (e: PatternSyntaxException) {
                 return createErrorResult("Invalid regex query: ${e.message}")
             } catch (e: IllegalArgumentException) {
@@ -188,41 +137,35 @@ class SearchTextTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
-        val cursorToken = suspendingReadAction {
-            val scope = createSearchScope(project, filePatternMatcher)
-            val matches = if (regexPattern != null) {
-                searchRegex(project, regexPattern, scope, searchContext, collectLimit)
-            } else {
-                searchText(project, query, scope, searchContext, caseSensitive, collectLimit)
-            }
-
-            val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = extender@{ seenKeys, limit ->
-                suspendingReadAction {
-                    extendSearchText(project, query, regexPattern, searchContext, caseSensitive, filePatternMatcher, seenKeys, limit)
-                }
-            }
-
-            val serializedResults = matches.map { match ->
-                PaginationService.SerializedResult(
-                    key = "${match.file}:${match.line}",
-                    data = json.encodeToJsonElement(match)
-                )
-            }
-
-            val paginationService = ApplicationManager.getApplication().getService(PaginationService::class.java)
-            paginationService.createCursor(
-                toolName = name,
-                results = serializedResults,
-                seenKeys = serializedResults.map { it.key }.toSet(),
-                searchExtender = searchExtender,
-                psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-                projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
-                metadata = buildMap {
-                    put("query", query)
-                    put("regex", regex.toString())
-                    if (filePattern != null) put("filePattern", filePattern)
+        val cursorToken = if (findModel != null) {
+            val matches = searchRegex(project, findModel, usageSearchContext, collectLimit)
+            createCursor(
+                project = project,
+                query = query,
+                regex = regex,
+                filePattern = filePattern,
+                matches = matches,
+                searchExtender = { seenKeys, limit ->
+                    extendSearchText(project, query, findModel, usageSearchContext, caseSensitive, fileMaskCondition, seenKeys, limit)
                 }
             )
+        } else {
+            suspendingReadAction {
+                val scope = createSearchScope(project, fileMaskCondition)
+                val matches = searchText(project, query, scope, usageSearchContext, caseSensitive, collectLimit)
+                createCursor(
+                    project = project,
+                    query = query,
+                    regex = regex,
+                    filePattern = filePattern,
+                    matches = matches,
+                    searchExtender = { seenKeys, limit ->
+                        suspendingReadAction {
+                            extendSearchText(project, query, null, usageSearchContext, caseSensitive, fileMaskCondition, seenKeys, limit)
+                        }
+                    }
+                )
+            }
         }
 
         return buildPaginatedResult<TextMatch, SearchTextResult>(getPageFromCache(cursorToken, pageSize, project)) { items, page ->
@@ -240,13 +183,82 @@ class SearchTextTool : AbstractMcpTool() {
         }
     }
 
-    private fun parseSearchContext(contextStr: String): Short {
+    private fun createCursor(
+        project: Project,
+        query: String,
+        regex: Boolean,
+        filePattern: String?,
+        matches: List<TextMatch>,
+        searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult>
+    ): String {
+        val serializedResults = matches.map { match ->
+            PaginationService.SerializedResult(
+                key = "${match.file}:${match.line}",
+                data = json.encodeToJsonElement(match)
+            )
+        }
+
+        val paginationService = ApplicationManager.getApplication().getService(PaginationService::class.java)
+        return paginationService.createCursor(
+            toolName = name,
+            results = serializedResults,
+            seenKeys = serializedResults.map { it.key }.toSet(),
+            searchExtender = searchExtender,
+            psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
+            projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+            metadata = buildMap {
+                put("query", query)
+                put("regex", regex.toString())
+                if (filePattern != null) put("filePattern", filePattern)
+            }
+        )
+    }
+
+    private fun parseUsageSearchContext(contextStr: String): Short {
         return when (contextStr.lowercase()) {
             "code" -> UsageSearchContext.IN_CODE
             "comments" -> UsageSearchContext.IN_COMMENTS
             "strings" -> UsageSearchContext.IN_STRINGS
             "all" -> UsageSearchContext.ANY
             else -> UsageSearchContext.ANY
+        }
+    }
+
+    private fun parseFindSearchContext(contextStr: String): FindModel.SearchContext {
+        return when (contextStr.lowercase()) {
+            "code" -> FindModel.SearchContext.EXCEPT_COMMENTS_AND_STRING_LITERALS
+            "comments" -> FindModel.SearchContext.IN_COMMENTS
+            "strings" -> FindModel.SearchContext.IN_STRING_LITERALS
+            else -> FindModel.SearchContext.ANY
+        }
+    }
+
+    private fun createFileMaskCondition(filePattern: String?): Condition<CharSequence>? {
+        val normalized = filePattern?.trim()
+        if (normalized.isNullOrEmpty()) return null
+        return FindInProjectUtil.createFileMaskCondition(normalized)
+    }
+
+    private fun createFindModel(
+        project: Project,
+        query: String,
+        caseSensitive: Boolean,
+        filePattern: String?,
+        searchContext: FindModel.SearchContext
+    ): FindModel {
+        return FindModel().apply {
+            stringToFind = query
+            isRegularExpressions = true
+            isCaseSensitive = caseSensitive
+            isMultipleFiles = true
+            isProjectScope = true
+            isFindAll = true
+            isMultiline = true
+            this.searchContext = searchContext
+            customScope = createFilteredScope(project)
+            isCustomScope = true
+            fileFilter = filePattern?.trim().orEmpty()
+            compileRegExp()
         }
     }
 
@@ -314,16 +326,16 @@ class SearchTextTool : AbstractMcpTool() {
     private fun extendSearchText(
         project: Project,
         word: String,
-        regex: Regex?,
+        findModel: FindModel?,
         searchContext: Short,
         caseSensitive: Boolean,
-        filePatternMatcher: SearchTextFilePatternMatcher?,
+        fileMaskCondition: Condition<CharSequence>?,
         seenKeys: Set<String>,
         limit: Int
     ): List<PaginationService.SerializedResult> {
-        val scope = createSearchScope(project, filePatternMatcher)
-        if (regex != null) {
-            return searchRegex(project, regex, scope, searchContext, limit, seenKeys)
+        val scope = createSearchScope(project, fileMaskCondition)
+        if (findModel != null) {
+            return searchRegex(project, findModel, searchContext, limit, seenKeys)
                 .asSequence()
                 .map { match ->
                     PaginationService.SerializedResult(
@@ -387,8 +399,7 @@ class SearchTextTool : AbstractMcpTool() {
 
     private fun searchRegex(
         project: Project,
-        regex: Regex,
-        scope: GlobalSearchScope,
+        findModel: FindModel,
         searchContext: Short,
         limit: Int,
         seenKeys: Set<String> = emptySet()
@@ -396,42 +407,34 @@ class SearchTextTool : AbstractMcpTool() {
         val results = mutableListOf<TextMatch>()
         val seenLines = HashSet<String>()
         seenLines.addAll(seenKeys)
-        val fileIndex = ProjectFileIndex.getInstance(project)
-        val psiManager = PsiManager.getInstance(project)
-        val fileDocumentManager = FileDocumentManager.getInstance()
+        val presentation = FindInProjectUtil.setupProcessPresentation(FindInProjectUtil.setupViewPresentation(findModel))
 
-        fileIndex.iterateContent { virtualFile ->
+        FindInProjectUtil.findUsages(findModel, project, presentation, emptySet<VirtualFile>()) { usageInfo: UsageInfo ->
             if (results.size >= limit) {
-                return@iterateContent false
-            }
-            if (virtualFile.isDirectory || !scope.contains(virtualFile)) {
-                return@iterateContent true
+                return@findUsages false
             }
 
-            val document = fileDocumentManager.getDocument(virtualFile) ?: return@iterateContent true
-            val psiFile = psiManager.findFile(virtualFile) ?: return@iterateContent true
-            val text = document.text
-
-            for (matchResult in regex.findAll(text)) {
-                if (results.size >= limit) {
-                    return@iterateContent false
-                }
-                if (matchResult.value.isEmpty()) {
-                    continue
-                }
-
-                val match = convertToTextMatch(project, psiFile, document, matchResult.range.first, searchContext)
-                    ?: continue
-                val lineKey = "${match.file}:${match.line}"
-                if (seenLines.add(lineKey)) {
-                    results.add(match)
-                }
+            val match = convertToTextMatch(project, usageInfo, searchContext) ?: return@findUsages true
+            val lineKey = "${match.file}:${match.line}"
+            if (seenLines.add(lineKey)) {
+                results.add(match)
             }
 
-            true
+            results.size < limit
         }
 
         return results
+    }
+
+    private fun convertToTextMatch(
+        project: Project,
+        usageInfo: UsageInfo,
+        searchContext: Short
+    ): TextMatch? {
+        val psiFile = usageInfo.file ?: return null
+        val document = PsiDocumentManager.getInstance(project).getDocument(psiFile) ?: return null
+        val offset = usageInfo.segment?.startOffset ?: usageInfo.navigationOffset
+        return convertToTextMatch(project, psiFile, document, offset, searchContext)
     }
 
     private fun convertToTextMatch(
@@ -504,18 +507,17 @@ class SearchTextTool : AbstractMcpTool() {
 
     private fun createSearchScope(
         project: Project,
-        filePatternMatcher: SearchTextFilePatternMatcher?
+        fileMaskCondition: Condition<CharSequence>?
     ): GlobalSearchScope {
         val baseScope = createFilteredScope(project)
-        if (filePatternMatcher == null) {
+        if (fileMaskCondition == null) {
             return baseScope
         }
 
         return object : DelegatingGlobalSearchScope(baseScope) {
             override fun contains(file: VirtualFile): Boolean {
                 if (!super.contains(file)) return false
-                val relativePath = getRelativePath(project, file)
-                return filePatternMatcher.matches(relativePath, file.name)
+                return fileMaskCondition.value(file.nameSequence)
             }
         }
     }

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -31,7 +31,7 @@ The IDE Index MCP server exposes JetBrains IDE indexing and refactoring capabili
 | Go to a symbol's definition | `ide_find_definition` | Never - grep can't resolve through imports/generics |
 | Find a class by name | `ide_find_class` | Only if IDE unavailable |
 | Find a file by name | `ide_find_file` | `Glob` is fine for simple patterns |
-| Search for a word in code | `ide_search_text` | `Grep` is fine for regex patterns (IDE tool is exact-word only) |
+| Search for text in code | `ide_search_text` | `Grep` is fine when IDE context filtering is unnecessary |
 | Rename a symbol across project | `ide_refactor_rename` | Never - sed/replace breaks code |
 | Move a file to another directory | `ide_move_file` | Never - mv/git mv bypasses IDE move semantics |
 | Check for errors in a file | `ide_diagnostics` | Never - no equivalent |
@@ -41,7 +41,7 @@ The IDE Index MCP server exposes JetBrains IDE indexing and refactoring capabili
 | Delete a symbol safely | `ide_refactor_safe_delete` | Never - manual deletion misses usages |
 | Find what a method overrides | `ide_find_super_methods` | Never - no equivalent |
 | Read file content | Built-in Read tool | `ide_read_file` only for library/jar sources |
-| Find text with regex | `Grep` | IDE search_text doesn't support regex |
+| Find text with regex | `ide_search_text` | Use `Grep` when you do not need IDE context filtering |
 
 ## Pre-Flight Check
 
@@ -121,7 +121,7 @@ Omit `paths` to sync the entire project.
 
 8. **Not syncing after external file changes**: After creating files via Write tool, call `ide_sync_files` before searching.
 
-9. **Using `ide_search_text` for regex**: This tool is exact-word only (uses word index). Use `Grep` for regex.
+9. **Assuming regex is the default in `ide_search_text`**: Regex requires `"regex": true`; otherwise the tool uses the faster exact-word index.
 
 10. **Using `ide_find_class` for methods/functions**: It searches classes only. Use `ide_search_text` for a quick word lookup.
 

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -100,7 +100,7 @@ Search for files by name using IDE's file index. Equivalent to Ctrl+Shift+N / Cm
 **Path note**: Project results use relative paths. Dependency/library results may use absolute paths or `jar://` URLs.
 
 ### ide_search_text
-Search for text using IDE's pre-built word index for exact searches or file scanning for regex searches.
+Search for text using IDE's pre-built word index for exact searches or IntelliJ Find in Files for regex searches.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -108,7 +108,7 @@ Search for text using IDE's pre-built word index for exact searches or file scan
 | `regex` | boolean | no | Treat `query` as a regular expression. Default false |
 | `context` | enum | no | `all` (default), `code`, `comments`, `strings` |
 | `caseSensitive` | boolean | no | Default true |
-| `filePattern` | string | no | Glob file filter, e.g. `*.kt`, `src/**/*.java` |
+| `filePattern` | string | no | IntelliJ file mask, e.g. `*.kt`, `*.java,!*Test.java` |
 | `limit` | integer | no | Default 100, max 500 |
 | `project_path` | string | no | Project root path |
 

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -100,13 +100,15 @@ Search for files by name using IDE's file index. Equivalent to Ctrl+Shift+N / Cm
 **Path note**: Project results use relative paths. Dependency/library results may use absolute paths or `jar://` URLs.
 
 ### ide_search_text
-Search for exact words using IDE's pre-built word index. O(1) lookups, not file scanning.
+Search for text using IDE's pre-built word index for exact searches or file scanning for regex searches.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | string | yes | Exact word (NOT regex/pattern) |
+| `query` | string | yes | Text to search for; exact word unless `regex` is true |
+| `regex` | boolean | no | Treat `query` as a regular expression. Default false |
 | `context` | enum | no | `all` (default), `code`, `comments`, `strings` |
 | `caseSensitive` | boolean | no | Default true |
+| `filePattern` | string | no | Glob file filter, e.g. `*.kt`, `src/**/*.java` |
 | `limit` | integer | no | Default 100, max 500 |
 | `project_path` | string | no | Project root path |
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
@@ -11,6 +11,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindImple
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSuperMethodsTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindDefinitionTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ReformatCodeTool
@@ -436,6 +437,55 @@ class ToolsTest : BasePlatformTestCase() {
         )
 
         assertEquals(listOf("ProjectScopeSymbol"), results.map { it.name })
+    }
+
+    fun testSearchTextToolFilePatternFiltersExactSearchResults() = runBlocking {
+        myFixture.addFileToProject("mappers/UserMapper.xml", "<mapper><select id=\"a\">select needle from sys_user</select></mapper>")
+        myFixture.addFileToProject("web/pagination.js", "const q = 'needle';")
+        myFixture.addFileToProject("tmp/opac_phase2_sql-mybatis.json", "{\"query\":\"needle\"}")
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+
+        val tool = SearchTextTool()
+        val result = tool.execute(project, buildJsonObject {
+            put("query", "needle")
+            put("filePattern", "*.xml")
+            put("pageSize", 10)
+        })
+
+        assertFalse("Search should succeed", result.isError)
+        val resultJson = json.parseToJsonElement((result.content.first() as ContentBlock.Text).text).jsonObject
+        val files = resultJson["matches"]!!.jsonArray.map { it.jsonObject["file"]!!.jsonPrimitive.content }
+
+        assertEquals(listOf("mappers/UserMapper.xml"), files)
+    }
+
+    fun testSearchTextToolRegexUsesFindInFilesOutsideReadAction() = runBlocking {
+        myFixture.addFileToProject(
+            "src/CommandRunner.java",
+            """
+            class CommandRunner {
+                void run() throws Exception {
+                    Runtime.getRuntime().exec("calc");
+                }
+            }
+            """.trimIndent()
+        )
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
+
+        val tool = SearchTextTool()
+        val result = tool.execute(project, buildJsonObject {
+            put("query", "Runtime\\.getRuntime\\(\\)\\.exec\\(")
+            put("regex", true)
+            put("context", "code")
+            put("filePattern", "*.java")
+            put("pageSize", 10)
+        })
+
+        assertFalse("Regex search should succeed", result.isError)
+        val resultJson = json.parseToJsonElement((result.content.first() as ContentBlock.Text).text).jsonObject
+        val files = resultJson["matches"]!!.jsonArray.map { it.jsonObject["file"]!!.jsonPrimitive.content }
+
+        assertEquals(listOf("src/CommandRunner.java"), files)
     }
 
     // Intelligence Tools Tests

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -16,7 +16,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindImple
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSuperMethodsTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSymbolTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextFilePatternMatcher
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
@@ -746,24 +745,6 @@ class ToolsUnitTest : TestCase() {
 
         assertNull("Should not have anyOf (incompatible with Anthropic API)", schema["anyOf"])
         assertNull("Should not have required array (all params optional for pagination)", schema[SchemaConstants.REQUIRED])
-    }
-
-    fun testSearchTextFilePatternMatcherMatchesBasenameGlob() {
-        val matcher = SearchTextFilePatternMatcher.fromGlob("*.xml")
-
-        assertNotNull(matcher)
-        assertTrue(matcher!!.matches("media/layout/main.xml", "main.xml"))
-        assertFalse(matcher.matches("media/js/pagination.js", "pagination.js"))
-        assertFalse(matcher.matches("tmp/opac_phase2_sql-mybatis.json", "opac_phase2_sql-mybatis.json"))
-    }
-
-    fun testSearchTextFilePatternMatcherMatchesRelativePathGlob() {
-        val matcher = SearchTextFilePatternMatcher.fromGlob("src/**/*.java")
-
-        assertNotNull(matcher)
-        assertTrue(matcher!!.matches("src/main/java/App.java", "App.java"))
-        assertFalse(matcher.matches("test/main/java/App.java", "App.java"))
-        assertFalse(matcher.matches("src/main/kotlin/App.kt", "App.kt"))
     }
 
     fun testGetActiveFileToolSchema() {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -16,6 +16,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindImple
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSuperMethodsTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSymbolTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextFilePatternMatcher
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
@@ -735,14 +736,34 @@ class ToolsUnitTest : TestCase() {
 
         assertNotNull("Should have project_path property", properties?.get(ParamNames.PROJECT_PATH))
         assertNotNull("Should have query property", properties?.get(ParamNames.QUERY))
+        assertNotNull("Should have regex property", properties?.get(ParamNames.REGEX))
         assertNotNull("Should have context property", properties?.get(ParamNames.CONTEXT))
         assertNotNull("Should have caseSensitive property", properties?.get(ParamNames.CASE_SENSITIVE))
+        assertNotNull("Should have filePattern property", properties?.get(ParamNames.FILE_PATTERN))
         assertNotNull("Should have limit property", properties?.get(ParamNames.LIMIT))
         assertNotNull("Should have cursor property", properties?.get("cursor"))
         assertNotNull("Should have pageSize property", properties?.get("pageSize"))
 
         assertNull("Should not have anyOf (incompatible with Anthropic API)", schema["anyOf"])
         assertNull("Should not have required array (all params optional for pagination)", schema[SchemaConstants.REQUIRED])
+    }
+
+    fun testSearchTextFilePatternMatcherMatchesBasenameGlob() {
+        val matcher = SearchTextFilePatternMatcher.fromGlob("*.xml")
+
+        assertNotNull(matcher)
+        assertTrue(matcher!!.matches("media/layout/main.xml", "main.xml"))
+        assertFalse(matcher.matches("media/js/pagination.js", "pagination.js"))
+        assertFalse(matcher.matches("tmp/opac_phase2_sql-mybatis.json", "opac_phase2_sql-mybatis.json"))
+    }
+
+    fun testSearchTextFilePatternMatcherMatchesRelativePathGlob() {
+        val matcher = SearchTextFilePatternMatcher.fromGlob("src/**/*.java")
+
+        assertNotNull(matcher)
+        assertTrue(matcher!!.matches("src/main/java/App.java", "App.java"))
+        assertFalse(matcher.matches("test/main/java/App.java", "App.java"))
+        assertFalse(matcher.matches("src/main/kotlin/App.kt", "App.kt"))
     }
 
     fun testGetActiveFileToolSchema() {


### PR DESCRIPTION
## Summary
- Fix `ide_search_text` so documented `filePattern` is actually wired into schema and search execution.
- - Add `regex` parameter support to `ide_search_text` while keeping `context` filtering and pagination behavior.
- - Update usage/skill docs and changelog for the new behavior.
## What changed
- Added `filePattern` and `regex` parameters to tool schema.
- - Implemented glob matcher + filtered search scope for `filePattern`.
- - Added regex search path (file scan) with context-type filtering and cursor-based pagination compatibility.
- - Added unit tests for schema and glob matching behavior.
## Validation
- `./gradlew test --tests "ToolsUnitTest"` (pass)
- - `./gradlew test --tests "*UnitTest*"` still reports one pre-existing unrelated failure in `McpSettingsUnitTest.testHostValidationLogic`.
Closes #190