### PR TITLE
v4.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [4.19.1] - 2026-05-26
+### Fixed
+- Fixed `ide_search_text` regex search and `filePattern` filtering for [#190](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/190).
+
 ## [4.19.0] - 2026-05-26
 ### Added
 - Added `regex` support to `ide_search_text` through IntelliJ's Find in Files path, including existing `context` filtering and pagination.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.19.0
+pluginVersion = 4.19.1
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary
- Bump the plugin patch version to `4.19.1`.
- Add a changelog entry for the `ide_search_text` regex and `filePattern` fix in [#190](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/190).

## Testing
- Not run; release metadata only.
