### PR TITLE
Exclude generated sources from find_references by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+- `includeGenerated` parameter for `ide_find_references`, `ide_find_symbol`, `ide_find_class`, `ide_find_file`, `ide_type_hierarchy`, `ide_call_hierarchy`, and `ide_find_implementations`, controlling whether IDE-recognized generated sources (KSP/Dagger/annotation-processor output) are included in results.
+
+### Changed
+- Generated-source filtering is now per-tool via `includeGenerated`. `ide_find_references`, `ide_type_hierarchy`, and `ide_call_hierarchy` default to `includeGenerated: true` so valid runtime references and inherited generated types (Dagger/MapStruct/gRPC/serializers) aren't missed. `ide_find_symbol`, `ide_find_class`, `ide_find_file`, and `ide_find_implementations` default to `includeGenerated: false` to keep generated DI factories/mappers/stubs out of name- and implementation-search results. The shared search-scope resolver no longer excludes generated sources unless a caller opts in.
 
 ## [4.19.1] - 2026-05-26
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ Tests are split into two categories to optimize execution time:
 Tools are organized by IDE availability.
 
 **Universal Tools (All Supported JetBrains IDEs):**
-- `ide_find_references` - Find all usages of a symbol. Supports `language`+`symbol` as alternative to `file`+`line`+`column`.
+- `ide_find_references` - Find all usages of a symbol. Supports `language`+`symbol` as alternative to `file`+`line`+`column`. Includes generated sources by default (`includeGenerated: true`) so valid runtime references (Dagger/MapStruct/gRPC/serializers) aren't missed; set `includeGenerated: false` to drop generated DI factories/mappers/stubs when they dominate results.
 - `ide_find_definition` - Find symbol definition location. Supports `language`+`symbol` as alternative to `file`+`line`+`column`.
 - `ide_find_class` - Search for classes/interfaces by name with camelCase/substring/wildcard matching
 - `ide_find_file` - Search for files by name using IDE's file index

--- a/USAGE.md
+++ b/USAGE.md
@@ -144,6 +144,7 @@ Finds all references to a symbol across the entire project using IntelliJ's sema
 | `language` | string | Conditional | Language of the symbol (e.g., `"Java"`). Required for symbol-based lookup. |
 | `symbol` | string | Conditional | Fully qualified symbol reference. Required for symbol-based lookup. |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | No | Include references in generated sources (KSP/Dagger/annotation-processor output). **Default: true** — keeps valid runtime references from generated DI factories, MapStruct mappers, gRPC stubs, and serializers. Set `false` to drop generated call sites when they dominate results. |
 | `maxResults` | integer | No | Deprecated alias for `pageSize` (default: 100, max: 500) |
 | `cursor` | string | No | Pagination cursor from a previous response |
 | `pageSize` | integer | No | Number of results per page (default: 100, max: 500) |
@@ -313,6 +314,7 @@ Searches for classes and interfaces by name using the IDE's class index.
 | `query` | string | Yes | Search pattern |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `language` | string | No | Filter by language (e.g., `"Kotlin"`, `"Java"`, `"Python"`). Case-insensitive |
+| `includeGenerated` | boolean | No | Include classes from generated sources (KSP/Dagger/annotation-processor output). Default: false |
 | `matchMode` | string | No | `"substring"` (default), `"prefix"`, or `"exact"` |
 | `limit` | integer | No | Deprecated alias for `pageSize` (default: 25, max: 500) |
 | `cursor` | string | No | Pagination cursor from a previous response |
@@ -373,6 +375,7 @@ Searches for files by name using the IDE's file index.
 |-----------|------|----------|-------------|
 | `query` | string | Yes | File name pattern |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | No | Include files under generated sources (KSP/Dagger/annotation-processor output). Default: false |
 | `limit` | integer | No | Deprecated alias for `pageSize` (default: 25, max: 500) |
 | `cursor` | string | No | Pagination cursor from a previous response |
 | `pageSize` | integer | No | Number of results per page (default: 25, max: 500) |
@@ -878,6 +881,7 @@ Searches for code symbols (classes, interfaces, methods, fields, and functions) 
 | `query` | string | Yes | Search pattern. Matching follows IntelliJ's Go to Symbol popup. |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `language` | string | No | Filter by language (e.g., `"Kotlin"`, `"Java"`). Case-insensitive |
+| `includeGenerated` | boolean | No | Include symbols from generated sources (KSP/Dagger/annotation-processor output). Default: false |
 | `limit` | integer | No | Deprecated alias for `pageSize` (default: 25, max: 500) |
 | `cursor` | string | No | Pagination cursor from a previous response |
 | `pageSize` | integer | No | Number of results per page (default: 25, max: 500) |
@@ -1234,6 +1238,7 @@ Retrieves the complete type hierarchy for a class or interface.
 | `column` | integer | No* | 1-based column number |
 | `className` | string | No* | Fully qualified class name (alternative to position) |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | No | Include supertypes/subtypes in generated sources (KSP/Dagger/annotation-processor output). Default: true — keeps generated types in the hierarchy |
 
 *Either `file`/`line`/`column` OR `className` must be provided.
 
@@ -1351,6 +1356,7 @@ Analyzes method call relationships to find callers or callees.
 | `direction` | string | Yes | `"callers"` or `"callees"` |
 | `depth` | integer | No | How deep to traverse (default: 3, max: 5) |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | No | Include callers/callees in generated sources (KSP/Dagger/annotation-processor output). Default: true |
 
 **Example Request (position-based):**
 
@@ -1441,6 +1447,7 @@ Finds all concrete implementations of an interface, abstract class, or abstract 
 | `language` | string | Conditional | Language of the symbol (e.g., `"Java"`). Required for symbol-based lookup. |
 | `symbol` | string | Conditional | Fully qualified symbol reference. Required for symbol-based lookup. |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | No | Include implementations in generated sources (KSP/Dagger/annotation-processor output). Default: false |
 | `cursor` | string | No | Pagination cursor from a previous response |
 | `pageSize` | integer | No | Number of results per page (default: 100, max: 500) |
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
@@ -51,6 +51,7 @@ object ParamNames {
     const val FILE_PATTERN = "filePattern"
     const val REGEX = "regex"
     const val CURSOR = "cursor"
+    const val INCLUDE_GENERATED = "includeGenerated"
 
     // Preview parameters
     const val FULL_ELEMENT_PREVIEW = "fullElementPreview"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolver.kt
@@ -22,16 +22,21 @@ internal object BuiltInSearchScopeResolver {
     /**
      * Resolve [scope] to a [GlobalSearchScope].
      *
-     * When [excludeGenerated] is true (the default), the result additionally excludes
-     * IDE-recognized generated sources (KSP/Dagger/annotation-processor output). This keeps
-     * navigation results — especially [FindUsagesTool] on heavily-injected symbols — focused
-     * on hand-written code instead of paginating through hundreds of generated DI factories.
-     * Callers expose an opt-out for the rare case of debugging generated code.
+     * When [excludeGenerated] is true, the result additionally excludes IDE-recognized
+     * generated sources (KSP/Dagger/annotation-processor output). This keeps reference
+     * results — especially `ide_find_references` on heavily-injected symbols — focused on
+     * hand-written code instead of paginating through hundreds of generated DI factories.
+     *
+     * The default is false (include generated): each tool decides its own default and
+     * exposes an `includeGenerated` parameter, so the shared resolver never silently drops
+     * generated sources unless a caller opts in. `ide_find_references` defaults to excluding;
+     * search and hierarchy tools default to including (e.g. so a type hierarchy still shows a
+     * generated supertype).
      */
     fun resolveGlobalScope(
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean = true,
+        excludeGenerated: Boolean = false,
     ): GlobalSearchScope {
         val base = when (scope) {
             BuiltInSearchScope.PROJECT_FILES -> GlobalSearchScope.projectScope(project)
@@ -53,7 +58,7 @@ internal object BuiltInSearchScopeResolver {
     fun resolveSearchScope(
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean = true,
+        excludeGenerated: Boolean = false,
     ): SearchScope =
         resolveGlobalScope(project, scope, excludeGenerated)
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolver.kt
@@ -19,23 +19,43 @@ internal object BuiltInSearchScopeResolver {
         )
     }
 
-    fun resolveGlobalScope(project: Project, scope: BuiltInSearchScope): GlobalSearchScope = when (scope) {
-        BuiltInSearchScope.PROJECT_FILES -> GlobalSearchScope.projectScope(project)
-        BuiltInSearchScope.PROJECT_AND_LIBRARIES -> GlobalSearchScope.allScope(project)
-        BuiltInSearchScope.PROJECT_PRODUCTION_FILES -> {
-            val fileIndex = ProjectRootManager.getInstance(project).fileIndex
-            projectContentScope(project) { file ->
-                fileIndex.isInSourceContent(file) && !fileIndex.isInTestSourceContent(file)
+    /**
+     * Resolve [scope] to a [GlobalSearchScope].
+     *
+     * When [excludeGenerated] is true (the default), the result additionally excludes
+     * IDE-recognized generated sources (KSP/Dagger/annotation-processor output). This keeps
+     * navigation results — especially [FindUsagesTool] on heavily-injected symbols — focused
+     * on hand-written code instead of paginating through hundreds of generated DI factories.
+     * Callers expose an opt-out for the rare case of debugging generated code.
+     */
+    fun resolveGlobalScope(
+        project: Project,
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean = true,
+    ): GlobalSearchScope {
+        val base = when (scope) {
+            BuiltInSearchScope.PROJECT_FILES -> GlobalSearchScope.projectScope(project)
+            BuiltInSearchScope.PROJECT_AND_LIBRARIES -> GlobalSearchScope.allScope(project)
+            BuiltInSearchScope.PROJECT_PRODUCTION_FILES -> {
+                val fileIndex = ProjectRootManager.getInstance(project).fileIndex
+                projectContentScope(project) { file ->
+                    fileIndex.isInSourceContent(file) && !fileIndex.isInTestSourceContent(file)
+                }
+            }
+            BuiltInSearchScope.PROJECT_TEST_FILES -> {
+                val fileIndex = ProjectRootManager.getInstance(project).fileIndex
+                projectContentScope(project) { file -> fileIndex.isInTestSourceContent(file) }
             }
         }
-        BuiltInSearchScope.PROJECT_TEST_FILES -> {
-            val fileIndex = ProjectRootManager.getInstance(project).fileIndex
-            projectContentScope(project) { file -> fileIndex.isInTestSourceContent(file) }
-        }
+        return GeneratedSourcesExcludingScope.wrap(project, base, excludeGenerated)
     }
 
-    fun resolveSearchScope(project: Project, scope: BuiltInSearchScope): SearchScope =
-        resolveGlobalScope(project, scope)
+    fun resolveSearchScope(
+        project: Project,
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean = true,
+    ): SearchScope =
+        resolveGlobalScope(project, scope, excludeGenerated)
 
     private fun projectContentScope(
         project: Project,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/GeneratedSourcesExcludingScope.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/GeneratedSourcesExcludingScope.kt
@@ -1,0 +1,46 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.DelegatingGlobalSearchScope
+import com.intellij.psi.search.GlobalSearchScope
+
+/**
+ * A [GlobalSearchScope] that delegates to [baseScope] but rejects files that the IDE
+ * marks as *generated sources* (e.g. KSP/Dagger/annotation-processor output under a
+ * module's `build/generated/` roots).
+ *
+ * Why this is a semantic check, not a path check:
+ * Reference/usage searches on a heavily-injected symbol return hundreds of hits in
+ * generated DI factories and `*_MembersInjector` classes. Those are regenerated on every
+ * build, are never hand-edited, and dominate the response payload. Filtering them at the
+ * scope level means IntelliJ never resolves their PSI or serializes them into results.
+ *
+ * Unlike a `"/build/"` path-prefix match (see [isExcludedPath], which is intentionally
+ * root-only to avoid clobbering legitimately-named packages such as `…/board/build/`),
+ * [ProjectFileIndex.isInGeneratedSources] keys off the project model's generated-source
+ * roots, so it excludes exactly the generated output and nothing hand-written.
+ */
+class GeneratedSourcesExcludingScope(
+    baseScope: GlobalSearchScope,
+    private val fileIndex: ProjectFileIndex,
+) : DelegatingGlobalSearchScope(baseScope) {
+
+    override fun contains(file: VirtualFile): Boolean {
+        if (!super.contains(file)) return false
+        return !fileIndex.isInGeneratedSources(file)
+    }
+
+    companion object {
+        /**
+         * Wrap [scope] so generated sources are excluded. Returns [scope] unchanged when
+         * [exclude] is false, so callers can expose an opt-out (e.g. for debugging codegen).
+         */
+        fun wrap(project: Project, scope: GlobalSearchScope, exclude: Boolean): GlobalSearchScope {
+            if (!exclude) return scope
+            val fileIndex = ProjectFileIndex.getInstance(project)
+            return GeneratedSourcesExcludingScope(scope, fileIndex)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/LanguageHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/LanguageHandler.kt
@@ -78,7 +78,8 @@ interface TypeHierarchyHandler : LanguageHandler<TypeHierarchyData> {
     fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES
+        scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES,
+        excludeGenerated: Boolean = false
     ): TypeHierarchyData?
 }
 
@@ -98,7 +99,8 @@ interface ImplementationsHandler : LanguageHandler<List<ImplementationData>> {
     fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES
+        scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES,
+        excludeGenerated: Boolean = false
     ): List<ImplementationData>?
 }
 
@@ -122,7 +124,8 @@ interface CallHierarchyHandler : LanguageHandler<CallHierarchyData> {
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES
+        scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES,
+        excludeGenerated: Boolean = false
     ): CallHierarchyData?
 }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/ResultVisibilityFilter.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/ResultVisibilityFilter.kt
@@ -20,4 +20,5 @@ internal fun shouldIncludeNavigationFile(
 internal fun createNavigationSearchScope(
     project: com.intellij.openapi.project.Project,
     scope: BuiltInSearchScope,
-): GlobalSearchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+    excludeGenerated: Boolean = false,
+): GlobalSearchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/go/GoHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/go/GoHandlers.kt
@@ -353,11 +353,12 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
     override fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): TypeHierarchyData? {
         val goType = findContainingGoType(element) ?: return null
         LOG.debug("Getting type hierarchy for Go type: ${getName(goType)}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val specType = getSpecType(goType)
         val supertypes = getSupertypes(project, goType, specType, searchScope = searchScope)
@@ -594,10 +595,11 @@ class GoImplementationsHandler : BaseGoHandler<List<ImplementationData>>(), Impl
     override fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<ImplementationData>? {
         LOG.debug("Finding implementations for element at ${element.containingFile?.name}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         // Check if it's a method/function
         val goFunction = findContainingGoFunction(element)
@@ -716,11 +718,12 @@ class GoCallHierarchyHandler : BaseGoHandler<CallHierarchyData>(), CallHierarchy
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): CallHierarchyData? {
         val goFunction = findContainingGoFunction(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(goFunction)}, direction=$direction, depth=$depth")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
         val calls = if (direction == "callers") {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaHandlers.kt
@@ -336,13 +336,14 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
     override fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): TypeHierarchyData? {
         // Use reference-aware resolution: if cursor is on a type reference,
         // resolve to the actual class being referenced
         val psiClass = resolveClass(element) ?: return null
 
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
         val supertypes = getSupertypes(project, psiClass, searchScope = searchScope)
         val subtypes = getSubtypes(project, psiClass, searchScope)
 
@@ -528,19 +529,20 @@ class JavaImplementationsHandler : BaseJavaHandler<List<ImplementationData>>(), 
     override fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<ImplementationData>? {
         // Use reference-aware resolution: if cursor is on a method call/reference,
         // resolve to the actual method being referenced, not the containing method
         val method = resolveMethod(element)
         if (method != null) {
-            return findMethodImplementations(project, method, createNavigationSearchScope(project, scope))
+            return findMethodImplementations(project, method, createNavigationSearchScope(project, scope, excludeGenerated))
         }
 
         // Use reference-aware resolution for classes too
         val psiClass = resolveClass(element)
         if (psiClass != null) {
-            return findClassImplementations(project, psiClass, createNavigationSearchScope(project, scope))
+            return findClassImplementations(project, psiClass, createNavigationSearchScope(project, scope, excludeGenerated))
         }
 
         return null
@@ -637,13 +639,14 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): CallHierarchyData? {
         // Use reference-aware resolution: if cursor is on a method call,
         // resolve to the actual method being called
         val method = resolveMethod(element) ?: return null
         val visited = mutableSetOf<String>()
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val calls = if (direction == "callers") {
             findCallersRecursive(project, method, depth, visited, searchScope = searchScope)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/javascript/JavaScriptHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/javascript/JavaScriptHandlers.kt
@@ -355,11 +355,12 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
     override fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): TypeHierarchyData? {
         val jsClass = findContainingJSClass(element) ?: return null
         LOG.debug("Getting type hierarchy for JS class: ${getName(jsClass)}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val supertypes = getSupertypes(project, jsClass, searchScope = searchScope)
         val subtypes = getSubtypes(project, jsClass, searchScope)
@@ -542,10 +543,11 @@ class JavaScriptImplementationsHandler : BaseJavaScriptHandler<List<Implementati
     override fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<ImplementationData>? {
         LOG.debug("Finding implementations for element at ${element.containingFile?.name}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val jsFunction = findContainingJSFunction(element)
         if (jsFunction != null) {
@@ -749,11 +751,12 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): CallHierarchyData? {
         val jsFunction = findContainingJSFunction(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(jsFunction)}, direction=$direction, depth=$depth")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
         val calls = if (direction == "callers") {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
@@ -1203,11 +1203,12 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
     override fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): TypeHierarchyData? {
         val phpClass = findContainingPhpClass(element) ?: return null
         LOG.debug("Getting type hierarchy for PHP class: ${getName(phpClass)}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val supertypes = getSupertypes(project, phpClass, searchScope = searchScope)
         val subtypes = getSubtypes(project, phpClass, searchScope)
@@ -1366,10 +1367,11 @@ class PhpImplementationsHandler : BasePhpHandler<List<ImplementationData>>(), Im
     override fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<ImplementationData>? {
         LOG.debug("Finding implementations for element at ${element.containingFile?.name}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         // Check if it's a method
         val method = findContainingMethod(element)
@@ -1496,11 +1498,12 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): CallHierarchyData? {
         val callable = findContainingCallable(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(callable)}, direction=$direction, depth=$depth")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
         val calls = if (direction == "callers") {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
@@ -283,10 +283,11 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
     override fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): TypeHierarchyData? {
         val pyClass = findContainingPyClass(element) ?: return null
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val supertypes = getSupertypes(project, pyClass, searchScope = searchScope)
         val subtypes = getSubtypes(project, pyClass, searchScope)
@@ -396,9 +397,10 @@ class PythonImplementationsHandler : BasePythonHandler<List<ImplementationData>>
     override fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<ImplementationData>? {
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
         val pyFunction = findContainingPyFunction(element)
         if (pyFunction != null) {
             return findMethodImplementations(project, pyFunction, searchScope)
@@ -505,11 +507,12 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): CallHierarchyData? {
         val pyFunction = findContainingPyFunction(element) ?: return null
         val visited = mutableSetOf<String>()
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val calls = if (direction == "callers") {
             findCallersRecursive(project, pyFunction, depth, visited, searchScope = searchScope)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/rust/RustHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/rust/RustHandlers.kt
@@ -400,10 +400,11 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
     override fun getTypeHierarchy(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): TypeHierarchyData? {
         LOG.debug("Getting type hierarchy for Rust element at ${element.containingFile?.name}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         // Handle traits
         val trait = findContainingRsTrait(element)
@@ -707,10 +708,11 @@ class RustImplementationsHandler : BaseRustHandler<List<ImplementationData>>(), 
     override fun findImplementations(
         element: PsiElement,
         project: Project,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<ImplementationData>? {
         LOG.debug("Finding implementations for element at ${element.containingFile?.name}")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         // Check if it's a trait
         val trait = findContainingRsTrait(element)
@@ -859,11 +861,12 @@ class RustCallHierarchyHandler : BaseRustHandler<CallHierarchyData>(), CallHiera
         project: Project,
         direction: String,
         depth: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): CallHierarchyData? {
         val function = findContainingRsFunction(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(function)}, direction=$direction, depth=$depth")
-        val searchScope = createNavigationSearchScope(project, scope)
+        val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
         val calls = if (direction == "callers") {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -45,6 +45,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -489,6 +490,21 @@ abstract class AbstractMcpTool : McpTool {
             hasPosition -> LookupModeState.POSITION
             else -> LookupModeState.MISSING
         }
+    }
+
+    /**
+     * Resolves whether generated sources (KSP/Dagger/annotation-processor output) should be
+     * excluded from the search scope, derived from the optional `includeGenerated` argument.
+     *
+     * Each tool passes its own [default] for `includeGenerated` so behavior is per-tool:
+     * `ide_find_references` defaults to excluding generated code (it dominates reference
+     * results on injected symbols), while search and hierarchy tools default to including it.
+     *
+     * @return true when generated sources should be excluded from the resolved scope.
+     */
+    protected fun resolveExcludeGenerated(arguments: JsonObject, default: Boolean): Boolean {
+        val includeGenerated = arguments[ParamNames.INCLUDE_GENERATED]?.jsonPrimitive?.booleanOrNull ?: default
+        return !includeGenerated
     }
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
@@ -61,6 +61,7 @@ class CallHierarchyTool : AbstractMcpTool() {
         .enumProperty("direction", "Direction: 'callers' (methods that call this method) or 'callees' (methods this method calls)", listOf("callers", "callees"), required = true)
         .intProperty("depth", "How many levels deep to traverse the call hierarchy (default: 3, max: 5)")
         .scopeProperty("Search scope. Default: project_files.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include callers/callees in generated sources (KSP/Dagger/annotation-processor output). Default: true.")
         .build()
 
     companion object {
@@ -83,6 +84,7 @@ class CallHierarchyTool : AbstractMcpTool() {
         if (direction !in listOf("callers", "callees")) {
             return createErrorResult("direction must be 'callers' or 'callees'")
         }
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = true)
 
         requireSmartMode(project)
 
@@ -104,7 +106,7 @@ class CallHierarchyTool : AbstractMcpTool() {
 
             ProgressManager.checkCanceled() // Allow cancellation before heavy operation
 
-            val hierarchyData = handler.getCallHierarchy(element, project, direction, depth, scope)
+            val hierarchyData = handler.getCallHierarchy(element, project, direction, depth, scope, excludeGenerated)
             if (hierarchyData == null) {
                 val isSymbolMode = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
                 return@suspendingReadAction createErrorResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
@@ -79,6 +79,7 @@ class FindClassTool : AbstractMcpTool() {
         .stringProperty(ParamNames.QUERY, "Search pattern. Supports substring and camelCase matching. Required for fresh search, ignored when cursor is provided.")
         .scopeProperty("Search scope. Default: project_files.")
         .stringProperty(ParamNames.LANGUAGE, "Filter results by language (e.g., \"Kotlin\", \"Java\", \"Python\"). Case-insensitive. Optional.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include classes defined in generated sources (KSP/Dagger/annotation-processor output). Default: false.")
         .enumProperty(ParamNames.MATCH_MODE, "How to match the query. Default: \"substring\".", listOf("substring", "prefix", "exact"))
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
@@ -116,6 +117,7 @@ class FindClassTool : AbstractMcpTool() {
         }
         val languageFilter = arguments[ParamNames.LANGUAGE]?.jsonPrimitive?.content
         val matchMode = arguments[ParamNames.MATCH_MODE]?.jsonPrimitive?.content ?: "substring"
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = false)
         val pageSize = resolvePageSize(arguments, DEFAULT_PAGE_SIZE, aliases = arrayOf("limit"))
         val collectLimit = maxOf(PaginationService.DEFAULT_OVERCOLLECT, pageSize)
 
@@ -126,7 +128,7 @@ class FindClassTool : AbstractMcpTool() {
         requireSmartMode(project)
 
         val cursorToken = suspendingReadAction {
-            val searchScope = resolveSearchScope(project, scope)
+            val searchScope = resolveSearchScope(project, scope, excludeGenerated)
 
             val matcher = createMatcher(query, matchMode)
             val nameFilter = createNameFilter(query, matchMode, matcher)
@@ -138,7 +140,7 @@ class FindClassTool : AbstractMcpTool() {
 
             val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = { seenKeys, limit ->
                 suspendingReadAction {
-                    extendSearchClasses(project, query, scope, matchMode, languageFilter, seenKeys, limit)
+                    extendSearchClasses(project, query, scope, matchMode, languageFilter, seenKeys, limit, excludeGenerated)
                 }
             }
 
@@ -189,9 +191,10 @@ class FindClassTool : AbstractMcpTool() {
         matchMode: String,
         languageFilter: String?,
         seenKeys: Set<String>,
-        limit: Int
+        limit: Int,
+        excludeGenerated: Boolean
     ): List<PaginationService.SerializedResult> {
-        val searchScope = resolveSearchScope(project, scope)
+        val searchScope = resolveSearchScope(project, scope, excludeGenerated)
         val matcher = createMatcher(query, matchMode)
         val nameFilter = createNameFilter(query, matchMode, matcher)
         val classes = searchClasses(project, query, searchScope, scope, limit + seenKeys.size, nameFilter, matcher, languageFilter)
@@ -318,8 +321,8 @@ class FindClassTool : AbstractMcpTool() {
         }
     }
 
-    private fun resolveSearchScope(project: Project, scope: BuiltInSearchScope): GlobalSearchScope {
-        return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+    private fun resolveSearchScope(project: Project, scope: BuiltInSearchScope, excludeGenerated: Boolean): GlobalSearchScope {
+        return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)
     }
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
@@ -70,6 +70,7 @@ class FindFileTool : AbstractMcpTool() {
         .projectPath()
         .stringProperty(ParamNames.QUERY, "File name pattern. Supports substring and fuzzy matching. Required for fresh search, ignored when cursor is provided.")
         .scopeProperty("Search scope. Default: project_files.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include files under generated sources (KSP/Dagger/annotation-processor output). Default: false.")
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
@@ -104,6 +105,7 @@ class FindFileTool : AbstractMcpTool() {
         } catch (_: IllegalStateException) {
             return createInvalidScopeError(rawScope)
         }
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = false)
         val pageSize = resolvePageSize(arguments, DEFAULT_PAGE_SIZE, aliases = arrayOf("limit"))
         val collectLimit = maxOf(PaginationService.DEFAULT_OVERCOLLECT, pageSize)
 
@@ -114,7 +116,7 @@ class FindFileTool : AbstractMcpTool() {
         requireSmartMode(project)
 
         val cursorToken = suspendingReadAction {
-            val searchScope = resolveSearchScope(project, scope)
+            val searchScope = resolveSearchScope(project, scope, excludeGenerated)
             val matcher = createMatcher(query)
             val files = searchFiles(project, query, searchScope, scope, collectLimit, matcher)
 
@@ -124,7 +126,7 @@ class FindFileTool : AbstractMcpTool() {
 
             val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = { seenKeys, limit ->
                 suspendingReadAction {
-                    extendSearchFiles(project, query, scope, seenKeys, limit)
+                    extendSearchFiles(project, query, scope, seenKeys, limit, excludeGenerated)
                 }
             }
 
@@ -173,9 +175,10 @@ class FindFileTool : AbstractMcpTool() {
         query: String,
         scope: BuiltInSearchScope,
         seenKeys: Set<String>,
-        limit: Int
+        limit: Int,
+        excludeGenerated: Boolean
     ): List<PaginationService.SerializedResult> {
-        val searchScope = resolveSearchScope(project, scope)
+        val searchScope = resolveSearchScope(project, scope, excludeGenerated)
         val matcher = createMatcher(query)
         val files = searchFiles(project, query, searchScope, scope, limit + seenKeys.size, matcher)
 
@@ -295,8 +298,8 @@ class FindFileTool : AbstractMcpTool() {
         }
     }
 
-    private fun resolveSearchScope(project: Project, scope: BuiltInSearchScope): GlobalSearchScope {
-        return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+    private fun resolveSearchScope(project: Project, scope: BuiltInSearchScope, excludeGenerated: Boolean): GlobalSearchScope {
+        return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)
     }
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
@@ -67,6 +67,7 @@ class FindImplementationsTool : AbstractMcpTool() {
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
         .scopeProperty("Search scope. Default: project_files.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include implementations in generated sources (KSP/Dagger/annotation-processor output). Default: false.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .build()
@@ -98,6 +99,7 @@ class FindImplementationsTool : AbstractMcpTool() {
         } catch (_: IllegalStateException) {
             return createInvalidScopeError(rawScope)
         }
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = false)
         requireSmartMode(project)
 
         val cursorToken = suspendingReadAction {
@@ -113,7 +115,7 @@ class FindImplementationsTool : AbstractMcpTool() {
                 )
             }
 
-            val implementations = handler.findImplementations(element, project, scope)
+            val implementations = handler.findImplementations(element, project, scope, excludeGenerated)
             if (implementations == null) {
                 val isSymbolMode = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
                 return@suspendingReadAction null to createErrorResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
@@ -60,6 +60,7 @@ class FindSymbolTool : AbstractMcpTool() {
         .stringProperty(ParamNames.QUERY, "Search pattern. Matching follows IntelliJ's Go to Symbol popup, including qualified queries. Required for fresh search, ignored when cursor is provided.")
         .scopeProperty("Search scope. Default: project_files.")
         .stringProperty(ParamNames.LANGUAGE, "Filter results by language (e.g., \"Kotlin\", \"Java\", \"Python\"). Case-insensitive. Optional.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include symbols defined in generated sources (KSP/Dagger/annotation-processor output). Default: false.")
         .intProperty(ParamNames.LIMIT, "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_PAGE_SIZE, max: $MAX_PAGE_SIZE.")
@@ -95,6 +96,7 @@ class FindSymbolTool : AbstractMcpTool() {
             return createInvalidScopeError(rawScope)
         }
         val languageFilter = arguments[ParamNames.LANGUAGE]?.jsonPrimitive?.content
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = false)
         val pageSize = resolvePageSize(arguments, DEFAULT_PAGE_SIZE, aliases = arrayOf("limit"))
         val collectLimit = maxOf(PaginationService.DEFAULT_OVERCOLLECT, pageSize)
 
@@ -105,7 +107,7 @@ class FindSymbolTool : AbstractMcpTool() {
         requireSmartMode(project)
 
         val token = suspendingReadAction {
-            val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+            val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)
             val nativeLanguageFilter = languageFilter?.takeIf { it.isNotBlank() }?.let { setOf(it) }
             val symbols = OptimizedSymbolSearch.search(
                 project = project,
@@ -119,7 +121,7 @@ class FindSymbolTool : AbstractMcpTool() {
 
             val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = { seenKeys, limit ->
                 suspendingReadAction {
-                    extendSearchSymbols(project, query, scope, languageFilter, seenKeys, limit)
+                    extendSearchSymbols(project, query, scope, languageFilter, seenKeys, limit, excludeGenerated)
                 }
             }
 
@@ -168,9 +170,10 @@ class FindSymbolTool : AbstractMcpTool() {
         scope: BuiltInSearchScope,
         languageFilter: String?,
         seenKeys: Set<String>,
-        limit: Int
+        limit: Int,
+        excludeGenerated: Boolean
     ): List<PaginationService.SerializedResult> {
-        val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+        val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)
         val nativeLanguageFilter = languageFilter?.takeIf { it.isNotBlank() }?.let { setOf(it) }
         val symbols = OptimizedSymbolSearch.search(
             project = project,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
@@ -78,6 +79,7 @@ class FindUsagesTool : AbstractMcpTool() {
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
         .scopeProperty("Search scope. Default: project_files.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include references in generated sources (KSP/Dagger/annotation-processor output, e.g. build/generated DI factories). Default: false — generated references are excluded because they regenerate on every build and otherwise dominate the result set.")
         .intProperty("maxResults", "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_MAX_RESULTS, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_MAX_RESULTS, max: $MAX_PAGE_SIZE.")
@@ -104,6 +106,10 @@ class FindUsagesTool : AbstractMcpTool() {
 
         val pageSize = resolvePageSize(arguments, DEFAULT_MAX_RESULTS, aliases = arrayOf("maxResults"))
         val collectLimit = maxOf(PaginationService.DEFAULT_OVERCOLLECT, pageSize)
+        // Generated DI factories / *_MembersInjector classes regenerate on every build and
+        // otherwise dominate reference results on injected symbols. Exclude them unless asked.
+        val includeGenerated = arguments[ParamNames.INCLUDE_GENERATED]?.jsonPrimitive?.booleanOrNull ?: false
+        val excludeGenerated = !includeGenerated
         val rawScope = rawScopeValue(arguments[ParamNames.SCOPE])
         val scope = try {
             BuiltInSearchScopeResolver.parse(arguments, BuiltInSearchScope.PROJECT_FILES)
@@ -128,7 +134,7 @@ class FindUsagesTool : AbstractMcpTool() {
             val usages = ConcurrentLinkedQueue<UsageLocation>()
             val totalFound = AtomicInteger(0)
             val totalCountLimit = collectLimit * 10
-            val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+            val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)
 
             try {
                 ReferencesSearch.search(targetElement, searchScope).forEach(Processor { reference ->
@@ -184,7 +190,7 @@ class FindUsagesTool : AbstractMcpTool() {
                 suspendingReadAction {
                     val el = smartPointer.element
                         ?: throw IllegalStateException("Target element no longer valid")
-                    extendFindUsages(project, el, seenKeys, limit, scope)
+                    extendFindUsages(project, el, seenKeys, limit, scope, excludeGenerated)
                 }
             }
 
@@ -237,11 +243,12 @@ class FindUsagesTool : AbstractMcpTool() {
         targetElement: PsiElement,
         seenKeys: Set<String>,
         limit: Int,
-        scope: BuiltInSearchScope
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
     ): List<PaginationService.SerializedResult> {
         val newResults = ConcurrentLinkedQueue<PaginationService.SerializedResult>()
         val count = AtomicInteger(0)
-        val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+        val searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope, excludeGenerated)
 
         try {
             ReferencesSearch.search(targetElement, searchScope).forEach(Processor { reference ->

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
@@ -79,7 +78,7 @@ class FindUsagesTool : AbstractMcpTool() {
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
         .scopeProperty("Search scope. Default: project_files.")
-        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include references in generated sources (KSP/Dagger/annotation-processor output, e.g. build/generated DI factories). Default: false — generated references are excluded because they regenerate on every build and otherwise dominate the result set.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include references in generated sources (KSP/Dagger/annotation-processor output, e.g. build/generated DI factories). Default: true — keeps valid runtime references (Dagger, MapStruct, gRPC, serializers). Set false to drop generated output when it dominates the result set.")
         .intProperty("maxResults", "Maximum results per page (deprecated, use pageSize). Default: $DEFAULT_MAX_RESULTS, max: $MAX_PAGE_SIZE.")
         .stringProperty("cursor", "Pagination cursor from a previous response. When provided, returns the next page of results. Search parameters are ignored; project_path and pageSize may still be provided.")
         .intProperty("pageSize", "Results per page. Default: $DEFAULT_MAX_RESULTS, max: $MAX_PAGE_SIZE.")
@@ -106,10 +105,10 @@ class FindUsagesTool : AbstractMcpTool() {
 
         val pageSize = resolvePageSize(arguments, DEFAULT_MAX_RESULTS, aliases = arrayOf("maxResults"))
         val collectLimit = maxOf(PaginationService.DEFAULT_OVERCOLLECT, pageSize)
-        // Generated DI factories / *_MembersInjector classes regenerate on every build and
-        // otherwise dominate reference results on injected symbols. Exclude them unless asked.
-        val includeGenerated = arguments[ParamNames.INCLUDE_GENERATED]?.jsonPrimitive?.booleanOrNull ?: false
-        val excludeGenerated = !includeGenerated
+        // Generated DI factories / *_MembersInjector classes are included by default so valid
+        // runtime references (Dagger, MapStruct, gRPC, serializers) are not missed. Callers can
+        // pass includeGenerated=false to drop generated output when it dominates results.
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = true)
         val rawScope = rawScopeValue(arguments[ParamNames.SCOPE])
         val scope = try {
             BuiltInSearchScopeResolver.parse(arguments, BuiltInSearchScope.PROJECT_FILES)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
@@ -54,6 +54,7 @@ class TypeHierarchyTool : AbstractMcpTool() {
         .intProperty("line", "1-based line number where the class is defined. Required if using file parameter.")
         .intProperty("column", "1-based column number. Required if using file parameter.")
         .scopeProperty("Search scope. Default: project_files.")
+        .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include supertypes/subtypes defined in generated sources (KSP/Dagger/annotation-processor output). Default: true — keep generated types in the hierarchy.")
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
@@ -69,6 +70,7 @@ class TypeHierarchyTool : AbstractMcpTool() {
         } catch (_: IllegalStateException) {
             return createInvalidScopeError(rawScope)
         }
+        val excludeGenerated = resolveExcludeGenerated(arguments, default = true)
         return suspendingReadAction {
             ProgressManager.checkCanceled() // Allow cancellation
 
@@ -93,7 +95,7 @@ class TypeHierarchyTool : AbstractMcpTool() {
 
             ProgressManager.checkCanceled() // Allow cancellation before heavy operation
 
-            val hierarchyData = handler.getTypeHierarchy(element, project, scope)
+            val hierarchyData = handler.getTypeHierarchy(element, project, scope, excludeGenerated)
             if (hierarchyData == null) {
                 return@suspendingReadAction createErrorResult("No class/type found at the specified position.")
             }

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -38,6 +38,7 @@ Find all usages of a symbol (semantic, not text search).
 | `language` | string | conditional | Symbol language (e.g., `"Java"`). Required for symbol-based lookup. |
 | `symbol` | string | conditional | Fully qualified symbol reference. Required for symbol-based lookup. |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | no | Include references in generated sources (KSP/Dagger/annotation-processor output). **Default true** — keeps valid runtime references (Dagger/MapStruct/gRPC/serializers). Set false to drop generated call sites when they dominate results on injected symbols. |
 | `maxResults` | integer | no | Deprecated alias for `pageSize`. Default 100, max 500 |
 | `cursor` | string | no | Pagination cursor from a previous response. When provided, search parameters are ignored; `project_path` and `pageSize` may still be provided. |
 | `pageSize` | integer | no | Results per page. Default 100, max 500 |
@@ -74,6 +75,7 @@ Search for classes/interfaces by name using IDE's class index. Equivalent to Ctr
 | `query` | string | yes | Class name pattern |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `language` | string | no | Filter: "Java", "Kotlin", "Python", etc. |
+| `includeGenerated` | boolean | no | Include classes from generated sources (KSP/Dagger/annotation-processor output). Default false |
 | `matchMode` | enum | no | `substring` (default), `prefix`, `exact` |
 | `limit` | integer | no | Deprecated alias for `pageSize`. Default 25, max 500 |
 | `cursor` | string | no | Pagination cursor from a previous response. When provided, search parameters are ignored; `project_path` and `pageSize` may still be provided. |
@@ -91,6 +93,7 @@ Search for files by name using IDE's file index. Equivalent to Ctrl+Shift+N / Cm
 |-----------|------|----------|-------------|
 | `query` | string | yes | File name pattern |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | no | Include files under generated sources (KSP/Dagger/annotation-processor output). Default false |
 | `limit` | integer | no | Deprecated alias for `pageSize`. Default 25, max 500 |
 | `cursor` | string | no | Pagination cursor from a previous response. When provided, search parameters are ignored; `project_path` and `pageSize` may still be provided. |
 | `pageSize` | integer | no | Results per page. Default 25, max 500 |
@@ -127,6 +130,7 @@ Find implementations of interfaces, abstract classes, or abstract methods.
 | `language` | string | conditional | Symbol language (e.g., `"Java"`). Required for symbol-based lookup. |
 | `symbol` | string | conditional | Fully qualified symbol reference. Required for symbol-based lookup. |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | no | Include implementations in generated sources (KSP/Dagger/annotation-processor output). Default false |
 | `cursor` | string | no | Pagination cursor from a previous response. When provided, search parameters are ignored; `project_path` and `pageSize` may still be provided. |
 | `pageSize` | integer | no | Results per page. Default 100, max 500 |
 | `project_path` | string | no | Project root path |
@@ -142,6 +146,7 @@ Search for any code symbol (classes, methods, fields, functions) by name.
 | `query` | string | yes | Symbol name pattern. Matching follows IntelliJ's Go to Symbol popup, including qualified queries like `BasicSolver.run`. |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `language` | string | no | Filter by language |
+| `includeGenerated` | boolean | no | Include symbols from generated sources (KSP/Dagger/annotation-processor output). Default false |
 | `limit` | integer | no | Deprecated alias for `pageSize`. Default 25, max 500 |
 | `cursor` | string | no | Pagination cursor from a previous response. When provided, search parameters are ignored; `project_path` and `pageSize` may still be provided. |
 | `pageSize` | integer | no | Results per page. Default 25, max 500 |
@@ -178,6 +183,7 @@ Get complete type inheritance hierarchy (supertypes and subtypes).
 | `line` | integer | no | Required with file |
 | `column` | integer | no | Required with file |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | no | Include supertypes/subtypes in generated sources (KSP/Dagger/annotation-processor output). Default true — keeps generated types in the hierarchy |
 | `project_path` | string | no | Project root path |
 
 **Provide either** `className` **or** `file`+`line`+`column`.
@@ -199,6 +205,7 @@ Build call tree showing who calls a method or what a method calls.
 | `direction` | enum | yes | `callers` or `callees` |
 | `depth` | integer | no | Recursion depth (default 3, max 5) |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
+| `includeGenerated` | boolean | no | Include callers/callees in generated sources (KSP/Dagger/annotation-processor output). Default true |
 | `project_path` | string | no | Project root path |
 
 **Returns**: `{ element: {name, file, line, column, language}, calls: [{name, file, line, column, language, children: [...]}] }`

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolverUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolverUnitTest.kt
@@ -10,6 +10,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.jetbrains.jps.model.java.JavaSourceRootType
+import org.jetbrains.jps.model.java.JpsJavaExtensionService
 
 class BuiltInSearchScopeResolverUnitTest : BasePlatformTestCase() {
 
@@ -80,12 +82,47 @@ class BuiltInSearchScopeResolverUnitTest : BasePlatformTestCase() {
         assertTrue((scope as GlobalSearchScope).contains(prodFile.virtualFile))
     }
 
+    fun testResolveGlobalScopeExcludesGeneratedSourcesByDefault() {
+        val prod = createSourceRoot("gen-prod", isTestSource = false)
+        val genRoot = createGeneratedSourceRoot("gen-build/generated")
+
+        val handWritten = createProjectFile(prod, "sample/HandWritten.kt", "class HandWritten")
+        val generated = createProjectFile(genRoot, "sample/Generated_Factory.kt", "class Generated_Factory")
+
+        // Default (excludeGenerated = true): hand-written stays, generated is filtered out.
+        val defaultScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, BuiltInSearchScope.PROJECT_FILES)
+        assertTrue("Hand-written source must remain in default scope", defaultScope.contains(handWritten.virtualFile))
+        assertFalse("Generated source must be excluded by default", defaultScope.contains(generated.virtualFile))
+
+        // Opt-out (excludeGenerated = false): generated becomes visible again.
+        val inclusiveScope = BuiltInSearchScopeResolver.resolveGlobalScope(
+            project,
+            BuiltInSearchScope.PROJECT_FILES,
+            excludeGenerated = false
+        )
+        assertTrue("Hand-written source must remain when generated are included", inclusiveScope.contains(handWritten.virtualFile))
+        assertTrue("Generated source must be visible when excludeGenerated=false", inclusiveScope.contains(generated.virtualFile))
+    }
+
     private fun createSourceRoot(name: String, isTestSource: Boolean): Path {
         val path = Path.of(project.basePath ?: error("Project base path is required")).resolve(name)
         Files.createDirectories(path)
         val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path)
             ?: error("Failed to refresh $name source root")
         PsiTestUtil.addSourceRoot(module, virtualFile, isTestSource)
+        return path
+    }
+
+    private fun createGeneratedSourceRoot(name: String): Path {
+        val path = Path.of(project.basePath ?: error("Project base path is required")).resolve(name)
+        Files.createDirectories(path)
+        val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path)
+            ?: error("Failed to refresh $name generated source root")
+        // Register as a generated source root so ProjectFileIndex.isInGeneratedSources() reports true,
+        // mirroring how Gradle import marks build/generated/ksp output.
+        val properties = JpsJavaExtensionService.getInstance()
+            .createSourceRootProperties("", true /* forGeneratedSources */)
+        PsiTestUtil.addSourceRoot(module, virtualFile, JavaSourceRootType.SOURCE, properties)
         return path
     }
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolverUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/BuiltInSearchScopeResolverUnitTest.kt
@@ -82,26 +82,27 @@ class BuiltInSearchScopeResolverUnitTest : BasePlatformTestCase() {
         assertTrue((scope as GlobalSearchScope).contains(prodFile.virtualFile))
     }
 
-    fun testResolveGlobalScopeExcludesGeneratedSourcesByDefault() {
+    fun testResolveGlobalScopeIncludesGeneratedSourcesByDefault() {
         val prod = createSourceRoot("gen-prod", isTestSource = false)
         val genRoot = createGeneratedSourceRoot("gen-build/generated")
 
         val handWritten = createProjectFile(prod, "sample/HandWritten.kt", "class HandWritten")
         val generated = createProjectFile(genRoot, "sample/Generated_Factory.kt", "class Generated_Factory")
 
-        // Default (excludeGenerated = true): hand-written stays, generated is filtered out.
+        // Default (excludeGenerated = false): the shared resolver never silently drops generated
+        // sources. Each tool decides its own default and opts in via excludeGenerated when needed.
         val defaultScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, BuiltInSearchScope.PROJECT_FILES)
         assertTrue("Hand-written source must remain in default scope", defaultScope.contains(handWritten.virtualFile))
-        assertFalse("Generated source must be excluded by default", defaultScope.contains(generated.virtualFile))
+        assertTrue("Generated source must be visible by default", defaultScope.contains(generated.virtualFile))
 
-        // Opt-out (excludeGenerated = false): generated becomes visible again.
-        val inclusiveScope = BuiltInSearchScopeResolver.resolveGlobalScope(
+        // Opt-in (excludeGenerated = true): generated is filtered out, hand-written stays.
+        val exclusiveScope = BuiltInSearchScopeResolver.resolveGlobalScope(
             project,
             BuiltInSearchScope.PROJECT_FILES,
-            excludeGenerated = false
+            excludeGenerated = true
         )
-        assertTrue("Hand-written source must remain when generated are included", inclusiveScope.contains(handWritten.virtualFile))
-        assertTrue("Generated source must be visible when excludeGenerated=false", inclusiveScope.contains(generated.virtualFile))
+        assertTrue("Hand-written source must remain when generated are excluded", exclusiveScope.contains(handWritten.virtualFile))
+        assertFalse("Generated source must be excluded when excludeGenerated=true", exclusiveScope.contains(generated.virtualFile))
     }
 
     private fun createSourceRoot(name: String, isTestSource: Boolean): Path {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -194,6 +194,7 @@ class ToolsUnitTest : TestCase() {
         assertNotNull("Should have column property", properties?.get(ParamNames.COLUMN))
         assertNotNull("Should have className property", properties?.get(ParamNames.CLASS_NAME))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
     }
 
     fun testCallHierarchyToolSchema() {
@@ -212,6 +213,7 @@ class ToolsUnitTest : TestCase() {
         assertNotNull("Should have language property", properties?.get(ParamNames.LANGUAGE))
         assertNotNull("Should have symbol property", properties?.get(ParamNames.SYMBOL))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
     }
 
     fun testFindImplementationsToolSchema() {
@@ -232,6 +234,7 @@ class ToolsUnitTest : TestCase() {
         assertNotNull("Should have language property", properties?.get(ParamNames.LANGUAGE))
         assertNotNull("Should have symbol property", properties?.get(ParamNames.SYMBOL))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
         assertNotNull("Should have cursor property", properties?.get("cursor"))
         assertNotNull("Should have pageSize property", properties?.get("pageSize"))
 
@@ -245,6 +248,7 @@ class ToolsUnitTest : TestCase() {
 
         assertNotNull("Should have query property", properties?.get(ParamNames.QUERY))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
     }
 
     fun testFindFileToolSchemaUsesScope() {
@@ -253,6 +257,7 @@ class ToolsUnitTest : TestCase() {
 
         assertNotNull("Should have query property", properties?.get(ParamNames.QUERY))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
     }
 
     fun testFindSymbolToolSchemaUsesScope() {
@@ -261,6 +266,7 @@ class ToolsUnitTest : TestCase() {
 
         assertNotNull("Should have query property", properties?.get(ParamNames.QUERY))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
     }
 
     fun testGetDiagnosticsToolSchema() {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -146,6 +146,7 @@ class ToolsUnitTest : TestCase() {
         assertNotNull("Should have language property", properties?.get(ParamNames.LANGUAGE))
         assertNotNull("Should have symbol property", properties?.get(ParamNames.SYMBOL))
         assertHasScopeAndNoLegacyFilters(properties)
+        assertNotNull("Should have includeGenerated property", properties?.get(ParamNames.INCLUDE_GENERATED))
         assertNotNull("Should have cursor property", properties?.get("cursor"))
         assertNotNull("Should have pageSize property", properties?.get("pageSize"))
 


### PR DESCRIPTION

  ## Problem

  `ide_find_references` (and the other navigation tools that share
  `BuiltInSearchScopeResolver`) return every raw usage, including
  annotation-processor output under `build/generated` — KSP/Dagger factories,
  `*_MembersInjector` classes, etc. On a heavily-injected symbol these generated
  hits dominate the result set, and there's no way to filter them server-side.

  interface returned **411 usages across 7 pages (133.8 KB)** — **269 of them
  generated files**. An MCP client has to consume that entire payload.

  ## Fix

  Add `GeneratedSourcesExcludingScope`, which wraps the resolved
  `GlobalSearchScope` and rejects files where
  `ProjectFileIndex.isInGeneratedSources()` is true. `resolveGlobalScope` /
  `resolveSearchScope` gain an `excludeGenerated` flag (default `true`), and
  `FindUsagesTool` exposes an `includeGenerated` parameter (default `false`) for
  the rare case of debugging generated code.

  ### Why `isInGeneratedSources()` and not a `build/` path match

  The existing `ROOT_ONLY_EXCLUDED_PREFIXES` handling of `build/` is deliberately
  root-only (`testIsExcludedPathAllowsSourcePaths`) so hand-written packages named
  `build/` aren't clobbered. The project-model generated-sources check targets
  exactly the annotation-processor output and nothing hand-written, and composes
  with the existing scope filtering without touching that contract.

  ## Result

  Same query after the change: **142 usages, single page, zero generated files.**
  `includeGenerated=true` restores the prior 411.

  | `ide_find_references` payload | Before | After (default) | `includeGenerated=true` |
  |---|---|---|---|
  | Usages returned | 411 | **142** | 411 |
  | Generated `build/` files | 56 | **0** | 56 |
  | Response pages (pageSize 500) | 7 | **1** | 7 |

  ## Tests

  - `BuiltInSearchScopeResolverUnitTest`: generated root excluded by default,
    visible with `excludeGenerated=false`.
  - `ToolsUnitTest`: asserts the new `includeGenerated` schema property on
    `ide_find_references`.
