### PR TITLE
Add repo-scoped workspace lifecycle routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,47 @@ codex mcp add webstorm-index --url http://127.0.0.1:29173/index-mcp/streamable-h
 
 To remove: `codex mcp remove <server-name>` (e.g., `codex mcp remove intellij-index`)
 
+### Repo-Scoped Workspace Servers
+
+For a workspace-style IDE window that contains multiple attached repository roots, use the normal broad server first, then attach each repository root that should have its own MCP endpoint:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_attach_repo_to_workspace",
+    "arguments": {
+      "repo_path": "/Users/dev/workspace/services/billing-api"
+    }
+  }
+}
+```
+
+The response includes a deterministic `repoId` and normalized `repoPath`. The repo id is the repository folder name when unique; if two attached roots share the same folder name, the id is suffixed with an 8-character path hash.
+
+Call `ide_get_repo_scoped_client_config` to export the broad server plus every attached repo-scoped server:
+
+```json
+{
+  "broadServerName": "intellij-index",
+  "broadStreamableHttpUrl": "http://127.0.0.1:29170/index-mcp/streamable-http",
+  "scopedServers": [
+    {
+      "repoId": "billing-api",
+      "repoPath": "/Users/dev/workspace/services/billing-api",
+      "serverName": "intellij-index-billing-api",
+      "streamableHttpUrl": "http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http",
+      "codexCommand": "codex mcp remove intellij-index-billing-api 2>/dev/null; codex mcp add intellij-index-billing-api --url http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http"
+    }
+  ],
+  "codexCommands": [
+    "codex mcp remove intellij-index-billing-api 2>/dev/null; codex mcp add intellij-index-billing-api --url http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http"
+  ]
+}
+```
+
+Register the scoped server URL when an agent should operate inside one repository while the IDE keeps the wider workspace open. Calls through `/index-mcp/repos/{repoId}/streamable-http` inject that repo root as `project_path`; conflicting `project_path` arguments are rejected. To remove the content root and route, call `ide_detach_repo_from_workspace` with the published `repo_id`.
+
 ### Cursor
 
 Add to `.cursor/mcp.json` in your project root or `~/.cursor/mcp.json` globally (adjust name and port for your IDE):
@@ -225,7 +266,7 @@ Each JetBrains IDE has a unique default port and server name to allow running mu
 
 ## Available Tools
 
-The plugin provides **21 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
+The plugin provides **24 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
 
 ### Universal Tools
 
@@ -242,6 +283,9 @@ These tools work in all supported JetBrains IDEs.
 | `ide_diagnostics` | Analyze file problems with fresh editor diagnostics for open files or public batch diagnostics for closed files, plus optional build/test results; intentions are best-effort |
 | `ide_index_status` | Check if the IDE is in dumb mode or smart mode |
 | `ide_sync_files` | Force sync IDE's virtual file system and PSI cache with external file changes |
+| `ide_attach_repo_to_workspace` | Attach a repository root to the active workspace and publish its repo-scoped MCP route |
+| `ide_detach_repo_from_workspace` | Detach a previously attached repository root and remove its repo-scoped MCP route |
+| `ide_get_repo_scoped_client_config` | Export broad and repo-scoped server metadata plus Codex registration commands |
 | `ide_build_project` | Build project using IDE's build system (JPS, Gradle, Maven) with structured errors *(disabled by default)* |
 | `ide_read_file` | Read file content by path or qualified name, including library/jar sources *(disabled by default)* |
 | `ide_get_active_file` | Get the currently active file(s) in the editor with cursor position *(disabled by default)* |
@@ -279,21 +323,21 @@ PHP file structure support requires the PHP plugin and is available in PhpStorm 
 
 | IDE | Universal | Navigation | Refactoring |
 |-----|-----------|------------|-------------|
-| IntelliJ IDEA | ✓ 14 tools | ✓ 6 tools | ✓ rename + reformat + safe delete + Java→Kotlin |
-| Android Studio | ✓ 14 tools | ✓ 6 tools | ✓ rename + reformat + safe delete + Java→Kotlin |
-| PyCharm | ✓ 14 tools | ✓ 6 tools | ✓ rename + reformat |
-| WebStorm | ✓ 14 tools | ✓ 6 tools | ✓ rename + reformat |
-| GoLand | ✓ 14 tools | ✓ 4 tools | ✓ rename + reformat |
-| RustRover | ✓ 14 tools | ✓ 5 tools | ✓ rename + reformat |
-| PhpStorm | ✓ 14 tools | ✓ 6 tools | ✓ rename + reformat |
+| IntelliJ IDEA | ✓ 17 tools | ✓ 6 tools | ✓ rename + reformat + safe delete + Java→Kotlin |
+| Android Studio | ✓ 17 tools | ✓ 6 tools | ✓ rename + reformat + safe delete + Java→Kotlin |
+| PyCharm | ✓ 17 tools | ✓ 6 tools | ✓ rename + reformat |
+| WebStorm | ✓ 17 tools | ✓ 6 tools | ✓ rename + reformat |
+| GoLand | ✓ 17 tools | ✓ 4 tools | ✓ rename + reformat |
+| RustRover | ✓ 17 tools | ✓ 5 tools | ✓ rename + reformat |
+| PhpStorm | ✓ 17 tools | ✓ 6 tools | ✓ rename + reformat |
 
 **May Work (Untested):**
 
 | IDE | Universal | Navigation | Refactoring |
 |-----|-----------|------------|-------------|
-| RubyMine | ✓ 14 tools | ✓ 2 Markdown tools | ✓ rename + reformat |
-| CLion | ✓ 14 tools | ✓ 2 Markdown tools | ✓ rename + reformat |
-| DataGrip | ✓ 14 tools | ✓ 2 Markdown tools | ✓ rename + reformat |
+| RubyMine | ✓ 17 tools | ✓ 2 Markdown tools | ✓ rename + reformat |
+| CLion | ✓ 17 tools | ✓ 2 Markdown tools | ✓ rename + reformat |
+| DataGrip | ✓ 17 tools | ✓ 2 Markdown tools | ✓ rename + reformat |
 
 > **Note**: Navigation tools activate when language plugins are present. Markdown adds heading search and file-structure support when the bundled Markdown plugin is enabled. Go and Rust do not expose `ide_find_super_methods` due to language semantics, and Go does not expose `ide_find_implementations`. The rename and reformat tools work across all languages. `ide_convert_java_to_kotlin` is available only in IntelliJ IDEA and Android Studio, requires both Java and Kotlin plugins, and is disabled by default.
 
@@ -328,6 +372,16 @@ The plugin supports **workspace projects** where a single IDE window contains mu
 - A **subdirectory** of any open project
 
 When an error occurs, the response returns `available_projects`. By default this includes workspace sub-projects so AI agents can discover valid module content roots. If you want smaller error payloads, switch **Project list in error responses** to **Compact** in plugin settings to return only top-level project roots.
+
+### Repo-Scoped Routes
+
+Attached repository roots are also exposed as repo-scoped Streamable HTTP routes:
+
+```text
+POST /index-mcp/repos/{repoId}/streamable-http
+```
+
+Use these routes when one IDE window hosts a master workspace but a coding agent should resolve relative paths, file searches, reads, opens, and structure requests inside one attached repo. Detaching a repo removes both the workspace content root and the scoped route.
 
 ## Tool Window
 
@@ -422,6 +476,8 @@ AI Assistant ──────► POST /index-mcp/streamable-http (initialize o
              ──────► POST /index-mcp/streamable-http (follow-up requests/notifications)
                      ◄── JSON-RPC response or HTTP 202 Accepted
 ```
+
+Repo-scoped workspace routes use the same Streamable HTTP behavior at `/index-mcp/repos/{repoId}/streamable-http`, with the scoped repository root injected for tool resolution.
 
 The plugin uses stateless Streamable HTTP for the primary MCP transport. It does not
 issue `Mcp-Session-Id` headers, does not require session resumption, and does not

--- a/USAGE.md
+++ b/USAGE.md
@@ -21,6 +21,9 @@ These tools work in every supported JetBrains IDE:
 | `ide_diagnostics` | Analyze file problems with fresh IDE diagnostics, plus optional build/test results | Enabled |
 | `ide_index_status` | Check indexing status | Enabled |
 | `ide_sync_files` | Force sync VFS/PSI cache | Enabled |
+| `ide_attach_repo_to_workspace` | Attach a repo root and publish a repo-scoped route | Enabled |
+| `ide_detach_repo_from_workspace` | Detach a repo root and remove its scoped route | Enabled |
+| `ide_get_repo_scoped_client_config` | Export broad and repo-scoped client registration metadata | Enabled |
 | `ide_build_project` | Build project with structured errors | Disabled |
 | `ide_read_file` | Read file content by path or qualified name | Disabled |
 | `ide_get_active_file` | Get currently active editor file(s) | Disabled |
@@ -63,6 +66,9 @@ These tools activate based on available language plugins:
   - [ide_diagnostics](#ide_diagnostics)
   - [ide_index_status](#ide_index_status)
   - [ide_sync_files](#ide_sync_files)
+  - [ide_attach_repo_to_workspace](#ide_attach_repo_to_workspace)
+  - [ide_detach_repo_from_workspace](#ide_detach_repo_from_workspace)
+  - [ide_get_repo_scoped_client_config](#ide_get_repo_scoped_client_config)
   - [ide_build_project](#ide_build_project)
   - [ide_read_file](#ide_read_file)
   - [ide_get_active_file](#ide_get_active_file)
@@ -91,6 +97,18 @@ All tools accept an optional `project_path` parameter:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `project_path` | string | No | Absolute path to the project root. Required when multiple projects are open in the IDE. For workspace projects, use the sub-project path. |
+
+Repo-scoped Streamable HTTP routes inject `project_path` automatically from the route repo id. If a scoped request also supplies a different `project_path`, the request is rejected.
+
+### Repo-Scoped Workspace Routes
+
+When one IDE window contains a master workspace plus multiple attached repositories, attach each repository root with `ide_attach_repo_to_workspace`. The tool returns a deterministic `repoId`; use that id in:
+
+```text
+POST /index-mcp/repos/{repoId}/streamable-http
+```
+
+Repo ids use the repository folder name when unique. If two attached roots share the same folder name, the id is suffixed with an 8-character path hash. Use `ide_get_repo_scoped_client_config` to export the broad endpoint plus each scoped endpoint and Codex registration command.
 
 ### Position Parameters
 
@@ -650,6 +668,133 @@ Force the IDE to synchronize its virtual file system and PSI cache with external
   "message": "Synced 1 path(s)"
 }
 ```
+
+---
+
+### ide_attach_repo_to_workspace
+
+Attaches an existing repository root to the active IDE workspace and publishes a repo-scoped MCP route for it.
+
+**Use when:**
+- A coding agent needs a dedicated MCP server for one repository inside a larger IDE workspace
+- Relative paths should resolve from an attached repo root instead of the workspace root
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `repo_path` | string | Yes | Absolute path to the repository root to attach |
+| `project_path` | string | No | Workspace project path when multiple projects are open |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_attach_repo_to_workspace",
+    "arguments": {
+      "repo_path": "/Users/dev/workspace/services/billing-api"
+    }
+  }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "repoId": "billing-api",
+  "repoPath": "/Users/dev/workspace/services/billing-api"
+}
+```
+
+---
+
+### ide_detach_repo_from_workspace
+
+Detaches a repository from the active workspace and removes its repo-scoped MCP route.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `repo_id` | string | Yes | Repo id returned by `ide_attach_repo_to_workspace` or `ide_get_repo_scoped_client_config` |
+| `project_path` | string | No | Workspace project path when multiple projects are open |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_detach_repo_from_workspace",
+    "arguments": {
+      "repo_id": "billing-api"
+    }
+  }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "repoId": "billing-api",
+  "detached": true
+}
+```
+
+---
+
+### ide_get_repo_scoped_client_config
+
+Exports the broad Streamable HTTP endpoint plus every currently attached repo-scoped endpoint.
+
+**Use when:**
+- Registering separate Codex MCP servers for each repository in a workspace
+- Refreshing client configuration after attaching or detaching repositories
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_path` | string | No | Workspace project path when multiple projects are open |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_get_repo_scoped_client_config",
+    "arguments": {}
+  }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "broadServerName": "intellij-index",
+  "broadStreamableHttpUrl": "http://127.0.0.1:29170/index-mcp/streamable-http",
+  "scopedServers": [
+    {
+      "repoId": "billing-api",
+      "repoPath": "/Users/dev/workspace/services/billing-api",
+      "serverName": "intellij-index-billing-api",
+      "streamableHttpUrl": "http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http",
+      "codexCommand": "codex mcp remove intellij-index-billing-api 2>/dev/null; codex mcp add intellij-index-billing-api --url http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http"
+    }
+  ],
+  "codexCommands": [
+    "codex mcp remove intellij-index-billing-api 2>/dev/null; codex mcp add intellij-index-billing-api --url http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http"
+  ]
+}
+```
+
+`scopedServers[*].streamableHttpUrl` uses `/index-mcp/repos/{repoId}/streamable-http`. Calls through that route resolve repo-relative file paths and repo-scoped file searches inside the attached root.
 
 ---
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
@@ -3,6 +3,8 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.constants
 object ParamNames {
     // Common parameters
     const val PROJECT_PATH = "project_path"
+    const val REPO_PATH = "repo_path"
+    const val REPO_ID = "repo_id"
     const val FILE = "file"
     const val LINE = "line"
     const val COLUMN = "column"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
@@ -22,6 +22,9 @@ object ToolNames {
     const val INDEX_STATUS = "ide_index_status"
     const val SYNC_FILES = "ide_sync_files"
     const val BUILD_PROJECT = "ide_build_project"
+    const val ATTACH_REPO_TO_WORKSPACE = "ide_attach_repo_to_workspace"
+    const val DETACH_REPO_FROM_WORKSPACE = "ide_detach_repo_from_workspace"
+    const val GET_REPO_SCOPED_CLIENT_CONFIG = "ide_get_repo_scoped_client_config"
 
     // Refactoring tools
     const val REFACTOR_RENAME = "ide_refactor_rename"
@@ -40,9 +43,11 @@ object ToolNames {
      * Keep this list in sync when adding or removing tool name constants.
      */
     val ALL: List<String> = listOf(
+        ATTACH_REPO_TO_WORKSPACE,
         BUILD_PROJECT,
         CALL_HIERARCHY,
         CONVERT_JAVA_TO_KOTLIN,
+        DETACH_REPO_FROM_WORKSPACE,
         DIAGNOSTICS,
         FILE_STRUCTURE,
         FIND_CLASS,
@@ -53,6 +58,7 @@ object ToolNames {
         FIND_SUPER_METHODS,
         FIND_SYMBOL,
         GET_ACTIVE_FILE,
+        GET_REPO_SCOPED_CLIENT_CONFIG,
         INDEX_STATUS,
         REFACTOR_MOVE,
         OPEN_FILE,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
@@ -40,6 +40,12 @@ class JsonRpcHandler @JvmOverloads constructor(
     suspend fun handleRequest(
         jsonString: String,
         protocolVersion: String
+    ): String? = handleRequest(jsonString, protocolVersion, repoScope = null)
+
+    suspend fun handleRequest(
+        jsonString: String,
+        protocolVersion: String,
+        repoScope: RepoScopeEntry?
     ): String? {
         val request = try {
             json.decodeFromString<JsonRpcRequest>(jsonString)
@@ -57,7 +63,7 @@ class JsonRpcHandler @JvmOverloads constructor(
         }
 
         val response = try {
-            routeRequest(request, protocolVersion)
+            routeRequest(request, protocolVersion, repoScope)
         } catch (e: Exception) {
             LOG.error("Error processing request: ${request.method}", e)
             createErrorResponse(request.id, JsonRpcErrorCodes.INTERNAL_ERROR, e.message ?: "Unknown error")
@@ -66,12 +72,16 @@ class JsonRpcHandler @JvmOverloads constructor(
         return response?.let { json.encodeToString(response) }
     }
 
-    private suspend fun routeRequest(request: JsonRpcRequest, protocolVersion: String): JsonRpcResponse? {
+    private suspend fun routeRequest(
+        request: JsonRpcRequest,
+        protocolVersion: String,
+        repoScope: RepoScopeEntry?
+    ): JsonRpcResponse? {
         return when (request.method) {
             JsonRpcMethods.INITIALIZE -> processInitialize(request, protocolVersion)
             JsonRpcMethods.NOTIFICATIONS_INITIALIZED -> null
             JsonRpcMethods.TOOLS_LIST -> processToolsList(request)
-            JsonRpcMethods.TOOLS_CALL -> processToolCall(request)
+            JsonRpcMethods.TOOLS_CALL -> processToolCall(request, repoScope)
             JsonRpcMethods.PING -> processPing(request)
             else -> createErrorResponse(request.id, JsonRpcErrorCodes.METHOD_NOT_FOUND, ErrorMessages.methodNotFound(request.method))
         }
@@ -106,7 +116,7 @@ class JsonRpcHandler @JvmOverloads constructor(
         )
     }
 
-    private suspend fun processToolCall(request: JsonRpcRequest): JsonRpcResponse {
+    private suspend fun processToolCall(request: JsonRpcRequest, repoScope: RepoScopeEntry?): JsonRpcResponse {
         val params = request.params
             ?: return createErrorResponse(request.id, JsonRpcErrorCodes.INVALID_PARAMS, ErrorMessages.MISSING_PARAMS)
 
@@ -118,8 +128,11 @@ class JsonRpcHandler @JvmOverloads constructor(
         val tool = toolRegistry.getTool(toolName)
             ?: return createErrorResponse(request.id, JsonRpcErrorCodes.METHOD_NOT_FOUND, ErrorMessages.toolNotFound(toolName))
 
+        val scopedArguments = applyRepoScope(request, arguments, repoScope)
+            ?: return createRepoScopeConflictResponse(request.id, arguments, repoScope!!)
+
         // Extract optional project_path from arguments
-        val projectPath = arguments[ParamNames.PROJECT_PATH]?.jsonPrimitive?.contentOrNull
+        val projectPath = scopedArguments[ParamNames.PROJECT_PATH]?.jsonPrimitive?.contentOrNull
 
         val projectResult = projectResolver.resolve(projectPath)
         if (projectResult.isError) {
@@ -134,7 +147,7 @@ class JsonRpcHandler @JvmOverloads constructor(
         // Record command in history
         val commandEntry = CommandEntry(
             toolName = toolName,
-            parameters = arguments
+            parameters = scopedArguments
         )
 
         recordHistorySafely(project, commandEntry)
@@ -142,7 +155,7 @@ class JsonRpcHandler @JvmOverloads constructor(
         val startTime = System.currentTimeMillis()
 
         return try {
-            val result = tool.execute(project, arguments)
+            val result = tool.execute(project, scopedArguments)
             val duration = System.currentTimeMillis() - startTime
 
             // Update history
@@ -185,6 +198,45 @@ class JsonRpcHandler @JvmOverloads constructor(
                 )
             )
         }
+    }
+
+    private fun applyRepoScope(
+        request: JsonRpcRequest,
+        arguments: JsonObject,
+        repoScope: RepoScopeEntry?
+    ): JsonObject? {
+        if (repoScope == null || request.method != JsonRpcMethods.TOOLS_CALL) return arguments
+
+        val explicitProjectPath = arguments[ParamNames.PROJECT_PATH]?.jsonPrimitive?.contentOrNull
+        if (explicitProjectPath != null &&
+            ProjectResolver.normalizePath(explicitProjectPath) != ProjectResolver.normalizePath(repoScope.rootPath)
+        ) {
+            return null
+        }
+
+        return JsonObject(arguments + (ParamNames.PROJECT_PATH to JsonPrimitive(repoScope.rootPath)))
+    }
+
+    private fun createRepoScopeConflictResponse(
+        id: JsonElement?,
+        arguments: JsonObject,
+        repoScope: RepoScopeEntry
+    ): JsonRpcResponse {
+        val payload = buildJsonObject {
+            put("error", "repo_scope_conflict")
+            put("repo_id", repoScope.repoId)
+            put("repo_path", repoScope.rootPath)
+            put("project_path", arguments[ParamNames.PROJECT_PATH]?.jsonPrimitive?.contentOrNull ?: "")
+        }
+        return JsonRpcResponse(
+            id = id,
+            result = json.encodeToJsonElement(
+                ToolCallResult(
+                    content = listOf(ContentBlock.Text(text = json.encodeToString(JsonObject.serializer(), payload))),
+                    isError = true
+                )
+            )
+        )
     }
 
     private fun recordHistorySafely(project: Project, commandEntry: CommandEntry) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/RepoScopeRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/RepoScopeRegistry.kt
@@ -1,0 +1,78 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import java.io.File
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+
+data class RepoScopeEntry(
+    val repoId: String,
+    val rootPath: String
+)
+
+class RepoScopeRegistry {
+    private val currentEntries = AtomicReference<List<RepoScopeEntry>>(emptyList())
+
+    fun entries(): List<RepoScopeEntry> = currentEntries.get()
+
+    fun replaceOpenRoots(rootPaths: List<String>): List<RepoScopeEntry> {
+        val entries = buildEntries(rootPaths)
+        currentEntries.set(entries)
+        return entries
+    }
+
+    fun attach(rootPath: String): RepoScopeEntry {
+        val normalized = normalizeRootPath(rootPath)
+        val roots = (entries().map { it.rootPath } + normalized).distinct()
+        val updated = replaceOpenRoots(roots)
+        return updated.first { it.rootPath == normalized }
+    }
+
+    fun detach(repoId: String): Boolean {
+        val before = entries()
+        val after = before.filterNot { it.repoId == repoId }
+        if (after.size == before.size) return false
+        currentEntries.set(after)
+        return true
+    }
+
+    fun find(repoId: String): RepoScopeEntry? = entries().firstOrNull { it.repoId == repoId }
+
+    companion object {
+        private val shared = RepoScopeRegistry()
+
+        fun getInstance(): RepoScopeRegistry = shared
+
+        fun buildEntries(rootPaths: List<String>): List<RepoScopeEntry> {
+            val normalizedRoots = rootPaths
+                .map(::normalizeRootPath)
+                .filter { it.isNotBlank() }
+                .distinct()
+
+            val leafCounts = normalizedRoots
+                .groupingBy(::leafName)
+                .eachCount()
+
+            return normalizedRoots
+                .map { root ->
+                    val leaf = leafName(root)
+                    val repoId = if ((leafCounts[leaf] ?: 0) == 1) leaf else "$leaf-${pathHash8(root)}"
+                    RepoScopeEntry(repoId = repoId, rootPath = root)
+                }
+                .sortedBy { it.repoId }
+        }
+
+        fun normalizeRootPath(path: String): String {
+            val canonical = runCatching { File(path).canonicalPath }.getOrElse { path }
+            return canonical.replace('\\', '/').trimEnd('/')
+        }
+
+        fun pathHash8(rootPath: String): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(normalizeRootPath(rootPath).toByteArray(Charsets.UTF_8))
+            return digest.joinToString("") { "%02x".format(it) }.take(8)
+        }
+
+        private fun leafName(rootPath: String): String =
+            normalizeRootPath(rootPath).substringAfterLast('/').ifBlank { "repo" }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/WorkspaceRepoManager.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/WorkspaceRepoManager.kt
@@ -1,0 +1,82 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.LocalFileSystem
+
+object WorkspaceRepoManager {
+
+    fun attachContentRoot(project: Project, repoPath: String): String {
+        val normalized = RepoScopeRegistry.normalizeRootPath(repoPath)
+        val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(normalized)
+            ?: error("Repository path does not exist: $repoPath")
+
+        val modules = ModuleManager.getInstance(project).modules
+        val targetModule = modules.firstOrNull() ?: error("Project has no modules to attach repository root.")
+
+        runWriteCommand(project, "Attach Repository To Workspace") {
+            val alreadyAttached = modules.any { module ->
+                ModuleRootManager.getInstance(module).contentRoots.any { root ->
+                    RepoScopeRegistry.normalizeRootPath(root.path) == normalized
+                }
+            }
+            if (!alreadyAttached) {
+                val model = ModuleRootManager.getInstance(targetModule).modifiableModel
+                try {
+                    model.addContentEntry(virtualFile)
+                    model.commit()
+                } catch (e: Exception) {
+                    model.dispose()
+                    throw e
+                }
+            }
+        }
+
+        return normalized
+    }
+
+    fun detachContentRoot(project: Project, repoPath: String): Boolean {
+        val normalized = RepoScopeRegistry.normalizeRootPath(repoPath)
+        var removed = false
+
+        runWriteCommand(project, "Detach Repository From Workspace") {
+            for (module in ModuleManager.getInstance(project).modules) {
+                val model = ModuleRootManager.getInstance(module).modifiableModel
+                try {
+                    val entriesToRemove = model.contentEntries.filter { entry ->
+                        entry.file?.path?.let { RepoScopeRegistry.normalizeRootPath(it) } == normalized
+                    }
+                    for (entry in entriesToRemove) {
+                        model.removeContentEntry(entry)
+                        removed = true
+                    }
+                    if (entriesToRemove.isNotEmpty()) {
+                        model.commit()
+                    } else {
+                        model.dispose()
+                    }
+                } catch (e: Exception) {
+                    model.dispose()
+                    throw e
+                }
+            }
+        }
+
+        return removed
+    }
+
+    private fun runWriteCommand(project: Project, name: String, action: () -> Unit) {
+        val app = ApplicationManager.getApplication()
+        val command = {
+            WriteCommandAction.runWriteCommandAction(project, name, null, { action() })
+        }
+        if (app.isDispatchThread) {
+            command()
+        } else {
+            app.invokeAndWait { command() }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServer.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServer.kt
@@ -2,6 +2,8 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.JsonRpcHandler
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeEntry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcError
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcResponse
 import com.intellij.openapi.Disposable
@@ -135,6 +137,10 @@ class KtorMcpServer(
                 handleCorsPreflight(call)
             }
 
+            options("${McpConstants.MCP_ENDPOINT_PATH}/repos/{repoId}/streamable-http") {
+                handleCorsPreflight(call)
+            }
+
             options(McpConstants.MCP_ENDPOINT_PATH) {
                 handleCorsPreflight(call)
             }
@@ -149,6 +155,10 @@ class KtorMcpServer(
                 handleStreamableHttpPostRequest(call)
             }
 
+            post("${McpConstants.MCP_ENDPOINT_PATH}/repos/{repoId}/streamable-http") {
+                handleRepoScopedStreamableHttpPostRequest(call)
+            }
+
             get(McpConstants.STREAMABLE_HTTP_ENDPOINT_PATH) {
                 if (!validateOrigin(call)) return@get
                 call.response.header(HttpHeaders.Allow, "POST")
@@ -156,6 +166,10 @@ class KtorMcpServer(
             }
 
             delete(McpConstants.STREAMABLE_HTTP_ENDPOINT_PATH) {
+                handleStreamableHttpDeleteRequest(call)
+            }
+
+            delete("${McpConstants.MCP_ENDPOINT_PATH}/repos/{repoId}/streamable-http") {
                 handleStreamableHttpDeleteRequest(call)
             }
 
@@ -250,7 +264,32 @@ class KtorMcpServer(
         if (!validateOrigin(call)) return
 
         val body = call.receiveText()
+        handleStreamableHttpBody(call, body, repoScope = null)
+    }
 
+    private suspend fun handleRepoScopedStreamableHttpPostRequest(call: ApplicationCall) {
+        if (!validateOrigin(call)) return
+
+        val repoId = call.parameters["repoId"].orEmpty()
+        val repoScope = RepoScopeRegistry.getInstance().find(repoId)
+        if (repoScope == null) {
+            call.respondText(
+                createJsonRpcError(null as JsonElement?, -32602, "Unknown repo id: $repoId"),
+                ContentType.Application.Json,
+                HttpStatusCode.NotFound
+            )
+            return
+        }
+
+        val body = call.receiveText()
+        handleStreamableHttpBody(call, body, repoScope)
+    }
+
+    private suspend fun handleStreamableHttpBody(
+        call: ApplicationCall,
+        body: String,
+        repoScope: RepoScopeEntry?
+    ) {
         if (body.isBlank()) {
             call.respondText(
                 createJsonRpcError(null as JsonElement?, -32700, "Empty request body"),
@@ -273,7 +312,7 @@ class KtorMcpServer(
         }
 
         if (element is JsonArray) {
-            handleStreamableHttpBatchRequest(call, element)
+            handleStreamableHttpBatchRequest(call, element, repoScope)
             return
         }
 
@@ -309,7 +348,8 @@ class KtorMcpServer(
                 runWithIdeModality {
                     jsonRpcHandler.handleRequest(
                         body,
-                        protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION
+                        protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION,
+                        repoScope = repoScope
                     )
                 }
             } catch (e: Exception) {
@@ -322,11 +362,12 @@ class KtorMcpServer(
         // Regular request: process and return JSON response
         try {
             val response = runWithIdeModality {
-                jsonRpcHandler.handleRequest(
-                    body,
-                    protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION
-                )
-            }
+                    jsonRpcHandler.handleRequest(
+                        body,
+                        protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION,
+                        repoScope = repoScope
+                    )
+                }
             if (response != null) {
                 call.respondText(response, ContentType.Application.Json)
             } else {
@@ -341,7 +382,11 @@ class KtorMcpServer(
         }
     }
 
-    private suspend fun handleStreamableHttpBatchRequest(call: ApplicationCall, batch: JsonArray) {
+    private suspend fun handleStreamableHttpBatchRequest(
+        call: ApplicationCall,
+        batch: JsonArray,
+        repoScope: RepoScopeEntry?
+    ) {
         if (batch.isEmpty()) {
             call.respondText(
                 createJsonRpcError(null as JsonElement?, -32600, "JSON-RPC batch requests must not be empty"),
@@ -384,7 +429,8 @@ class KtorMcpServer(
                 runWithIdeModality {
                     jsonRpcHandler.handleRequest(
                         message.toString(),
-                        protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION
+                        protocolVersion = McpConstants.STREAMABLE_HTTP_MCP_PROTOCOL_VERSION,
+                        repoScope = repoScope
                     )
                 }
             } catch (e: Exception) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -343,16 +343,26 @@ abstract class AbstractMcpTool : McpTool {
      * @param relativePath Path relative to project root, or absolute path
      * @return The VirtualFile, or null if not found
      */
-    protected fun resolveFile(project: Project, relativePath: String): VirtualFile? {
+    protected fun resolveFile(project: Project, relativePath: String, preferredRoot: String? = null): VirtualFile? {
         // Absolute paths are validated against project roots before resolving
-        if (relativePath.startsWith("/") || relativePath.startsWith("\\")) {
-            val canonical = File(relativePath).canonicalPath
+        val requestedFile = File(relativePath)
+        if (requestedFile.isAbsolute) {
+            val canonical = requestedFile.canonicalPath
             val projectRoots = listOfNotNull(project.basePath) + ProjectUtils.getModuleContentRoots(project)
             val withinProject = projectRoots.any { root ->
                 canonical.startsWith(File(root).canonicalPath + File.separator)
             }
             if (!withinProject) return null
             return LocalFileSystem.getInstance().refreshAndFindFileByPath(canonical)
+        }
+
+        if (!preferredRoot.isNullOrBlank()) {
+            val canonicalRoot = File(preferredRoot).canonicalPath
+            val canonical = File(canonicalRoot, relativePath).canonicalPath
+            if (canonical == canonicalRoot || canonical.startsWith(canonicalRoot + File.separator)) {
+                val file = LocalFileSystem.getInstance().refreshAndFindFileByPath(canonical)
+                if (file != null) return file
+            }
         }
 
         // Try project basePath first
@@ -386,8 +396,8 @@ abstract class AbstractMcpTool : McpTool {
      * @param relativePath Path relative to project root
      * @return The PsiFile, or null if not found
      */
-    protected fun getPsiFile(project: Project, relativePath: String): PsiFile? {
-        val virtualFile = resolveFile(project, relativePath) ?: return null
+    protected fun getPsiFile(project: Project, relativePath: String, preferredRoot: String? = null): PsiFile? {
+        val virtualFile = resolveFile(project, relativePath, preferredRoot) ?: return null
         return PsiManager.getInstance(project).findFile(virtualFile)
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -14,7 +14,10 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSymbo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.ReadFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTextTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.AttachRepoToWorkspaceTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.DetachRepoFromWorkspaceTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetRepoScopedClientConfigTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.SyncFilesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.MoveFileTool
@@ -235,6 +238,9 @@ class ToolRegistry {
         register(GetIndexStatusTool())
         register(SyncFilesTool())
         register(BuildProjectTool())
+        register(AttachRepoToWorkspaceTool())
+        register(DetachRepoFromWorkspaceTool())
+        register(GetRepoScopedClientConfigTool())
 
         // Refactoring tools (universal - uses platform APIs)
         register(RenameSymbolTool())

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/OpenFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/editor/OpenFileTool.kt
@@ -1,6 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.editor
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.OpenFileResult
@@ -53,7 +54,7 @@ class OpenFileTool : AbstractMcpTool() {
             return createErrorResult("Parameter 'column' must be >= 1, got $column.")
         }
 
-        val virtualFile = resolveFile(project, filePath)
+        val virtualFile = resolveFile(project, filePath, optionalStringArg(arguments, ParamNames.PROJECT_PATH))
             ?: return createErrorResult("File not found: $filePath")
 
         val relativePath = getRelativePath(project, virtualFile)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
@@ -200,6 +200,25 @@ data class SyncFilesResult(
     val message: String
 )
 
+@Serializable
+data class AttachRepoToWorkspaceResult(
+    val repoId: String,
+    val repoPath: String
+)
+
+@Serializable
+data class DetachRepoFromWorkspaceResult(
+    val repoId: String,
+    val detached: Boolean
+)
+
+@Serializable
+data class GetRepoScopedClientConfigResult(
+    val broadServerName: String,
+    val broadStreamableHttpUrl: String,
+    val codexCommands: List<String>
+)
+
 // ide_build_project output
 @Serializable
 data class BuildMessage(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
@@ -216,7 +216,17 @@ data class DetachRepoFromWorkspaceResult(
 data class GetRepoScopedClientConfigResult(
     val broadServerName: String,
     val broadStreamableHttpUrl: String,
+    val scopedServers: List<RepoScopedClientConfig>,
     val codexCommands: List<String>
+)
+
+@Serializable
+data class RepoScopedClientConfig(
+    val repoId: String,
+    val repoPath: String,
+    val serverName: String,
+    val streamableHttpUrl: String,
+    val codexCommand: String
 )
 
 // ide_build_project output

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
@@ -1,6 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileStructureResult
@@ -47,7 +48,7 @@ class FileStructureTool : AbstractMcpTool() {
         }
 
         return suspendingReadAction {
-            val psiFile = getPsiFile(project, file)
+            val psiFile = getPsiFile(project, file, optionalStringArg(arguments, ParamNames.PROJECT_PATH))
                 ?: return@suspendingReadAction createErrorResult("File not found: $file")
 
             // Get structure handler for this file's language

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.MinusculeMatcher
 import com.intellij.psi.codeStyle.NameUtil
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.DelegatingGlobalSearchScope
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.util.indexing.FindSymbolParameters
 import kotlinx.serialization.json.JsonObject
@@ -114,7 +115,7 @@ class FindFileTool : AbstractMcpTool() {
         requireSmartMode(project)
 
         val cursorToken = suspendingReadAction {
-            val searchScope = resolveSearchScope(project, scope)
+            val searchScope = resolveSearchScope(project, scope, optionalStringArg(arguments, ParamNames.PROJECT_PATH))
             val matcher = createMatcher(query)
             val files = searchFiles(project, query, searchScope, scope, collectLimit, matcher)
 
@@ -124,7 +125,7 @@ class FindFileTool : AbstractMcpTool() {
 
             val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = { seenKeys, limit ->
                 suspendingReadAction {
-                    extendSearchFiles(project, query, scope, seenKeys, limit)
+                    extendSearchFiles(project, query, scope, optionalStringArg(arguments, ParamNames.PROJECT_PATH), seenKeys, limit)
                 }
             }
 
@@ -172,10 +173,11 @@ class FindFileTool : AbstractMcpTool() {
         project: Project,
         query: String,
         scope: BuiltInSearchScope,
+        preferredRoot: String?,
         seenKeys: Set<String>,
         limit: Int
     ): List<PaginationService.SerializedResult> {
-        val searchScope = resolveSearchScope(project, scope)
+        val searchScope = resolveSearchScope(project, scope, preferredRoot)
         val matcher = createMatcher(query)
         val files = searchFiles(project, query, searchScope, scope, limit + seenKeys.size, matcher)
 
@@ -295,8 +297,20 @@ class FindFileTool : AbstractMcpTool() {
         }
     }
 
-    private fun resolveSearchScope(project: Project, scope: BuiltInSearchScope): GlobalSearchScope {
-        return BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+    private fun resolveSearchScope(project: Project, scope: BuiltInSearchScope, preferredRoot: String?): GlobalSearchScope {
+        val baseScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, scope)
+        if (preferredRoot.isNullOrBlank()) return baseScope
+
+        val normalizedRoot = ProjectResolver.normalizePath(preferredRoot)
+        return object : DelegatingGlobalSearchScope(baseScope) {
+            override fun contains(file: VirtualFile): Boolean {
+                if (scope == BuiltInSearchScope.PROJECT_AND_LIBRARIES && ProjectUtils.isDependencyFile(project, file)) {
+                    return true
+                }
+                val normalizedFile = ProjectResolver.normalizePath(file.path)
+                return super.contains(file) && (normalizedFile == normalizedRoot || normalizedFile.startsWith("$normalizedRoot/"))
+            }
+        }
     }
 
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/ReadFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/ReadFileTool.kt
@@ -77,7 +77,11 @@ class ReadFileTool : AbstractMcpTool() {
                         ?: return@suspendingReadAction createErrorResult("Class not found: $qualifiedName")
                     element.containingFile?.virtualFile
                 }
-                !filePath.isNullOrBlank() -> PsiUtils.resolveVirtualFileAnywhere(project, filePath)
+                !filePath.isNullOrBlank() -> PsiUtils.resolveVirtualFileAnywhere(
+                    project,
+                    filePath,
+                    optionalStringArg(arguments, ParamNames.PROJECT_PATH)
+                )
                 else -> null
             } ?: return@suspendingReadAction createErrorResult("File not found: ${filePath ?: qualifiedName}")
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/AttachRepoToWorkspaceTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/AttachRepoToWorkspaceTool.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.WorkspaceRepoManager
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.AttachRepoToWorkspaceResult
@@ -25,7 +26,12 @@ class AttachRepoToWorkspaceTool : AbstractMcpTool() {
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val repoPath = requiredStringArg(arguments, ParamNames.REPO_PATH)
             .getOrElse { return createErrorResult(it.message ?: "Missing required parameter: ${ParamNames.REPO_PATH}") }
-        val entry = RepoScopeRegistry.getInstance().attach(repoPath)
+        val attachedPath = try {
+            WorkspaceRepoManager.attachContentRoot(project, repoPath)
+        } catch (e: Exception) {
+            return createErrorResult(e.message ?: "Failed to attach repository to workspace.")
+        }
+        val entry = RepoScopeRegistry.getInstance().attach(attachedPath)
         return createJsonResult(
             AttachRepoToWorkspaceResult(
                 repoId = entry.repoId,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/AttachRepoToWorkspaceTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/AttachRepoToWorkspaceTool.kt
@@ -1,0 +1,36 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.AttachRepoToWorkspaceResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+
+class AttachRepoToWorkspaceTool : AbstractMcpTool() {
+    override val requiresPsiSync: Boolean = false
+    override val name = ToolNames.ATTACH_REPO_TO_WORKSPACE
+    override val description = """
+        Attach an existing repository root to the active workspace and publish its deterministic repo-scoped MCP route.
+        Parameters: repo_path (required absolute repository root), project_path (optional workspace project).
+    """.trimIndent()
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .projectPath()
+        .stringProperty(ParamNames.REPO_PATH, "Absolute path to the repository root to attach.", required = true)
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val repoPath = requiredStringArg(arguments, ParamNames.REPO_PATH)
+            .getOrElse { return createErrorResult(it.message ?: "Missing required parameter: ${ParamNames.REPO_PATH}") }
+        val entry = RepoScopeRegistry.getInstance().attach(repoPath)
+        return createJsonResult(
+            AttachRepoToWorkspaceResult(
+                repoId = entry.repoId,
+                repoPath = entry.rootPath
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/DetachRepoFromWorkspaceTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/DetachRepoFromWorkspaceTool.kt
@@ -1,0 +1,36 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DetachRepoFromWorkspaceResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+
+class DetachRepoFromWorkspaceTool : AbstractMcpTool() {
+    override val requiresPsiSync: Boolean = false
+    override val name = ToolNames.DETACH_REPO_FROM_WORKSPACE
+    override val description = """
+        Detach a repository from the active workspace by its published repo id and remove its repo-scoped MCP route.
+        Parameters: repo_id (required), project_path (optional workspace project).
+    """.trimIndent()
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .projectPath()
+        .stringProperty(ParamNames.REPO_ID, "Published repo id to detach from the workspace.", required = true)
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val repoId = requiredStringArg(arguments, ParamNames.REPO_ID)
+            .getOrElse { return createErrorResult(it.message ?: "Missing required parameter: ${ParamNames.REPO_ID}") }
+        val detached = RepoScopeRegistry.getInstance().detach(repoId)
+        return createJsonResult(
+            DetachRepoFromWorkspaceResult(
+                repoId = repoId,
+                detached = detached
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/DetachRepoFromWorkspaceTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/DetachRepoFromWorkspaceTool.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.WorkspaceRepoManager
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DetachRepoFromWorkspaceResult
@@ -25,11 +26,13 @@ class DetachRepoFromWorkspaceTool : AbstractMcpTool() {
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val repoId = requiredStringArg(arguments, ParamNames.REPO_ID)
             .getOrElse { return createErrorResult(it.message ?: "Missing required parameter: ${ParamNames.REPO_ID}") }
-        val detached = RepoScopeRegistry.getInstance().detach(repoId)
+        val entry = RepoScopeRegistry.getInstance().find(repoId)
+        val workspaceDetached = entry?.let { WorkspaceRepoManager.detachContentRoot(project, it.rootPath) } ?: false
+        val registryDetached = RepoScopeRegistry.getInstance().detach(repoId)
         return createJsonResult(
             DetachRepoFromWorkspaceResult(
                 repoId = repoId,
-                detached = detached
+                detached = workspaceDetached || registryDetached
             )
         )
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetRepoScopedClientConfigTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetRepoScopedClientConfigTool.kt
@@ -1,0 +1,42 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.GetRepoScopedClientConfigResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ClientConfigGenerator
+import com.intellij.openapi.project.Project
+import kotlinx.serialization.json.JsonObject
+
+class GetRepoScopedClientConfigTool : AbstractMcpTool() {
+    override val requiresPsiSync: Boolean = false
+    override val name = ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG
+    override val description = """
+        Export broad-plus-repo-scoped Codex MCP registration commands for all published workspace repo ids.
+        Parameters: project_path (optional workspace project).
+    """.trimIndent()
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val broadUrl = ClientConfigGenerator.getStreamableHttpUrl()
+        val baseName = ClientConfigGenerator.getDefaultServerName()
+        val commands = RepoScopeRegistry.getInstance().entries().map { entry ->
+            ClientConfigGenerator.buildRepoScopedCodexCommand(
+                broadStreamableHttpUrl = broadUrl,
+                baseServerName = baseName,
+                repoId = entry.repoId
+            )
+        }
+        return createJsonResult(
+            GetRepoScopedClientConfigResult(
+                broadServerName = baseName,
+                broadStreamableHttpUrl = broadUrl,
+                codexCommands = commands
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetRepoScopedClientConfigTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetRepoScopedClientConfigTool.kt
@@ -5,6 +5,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.GetRepoScopedClientConfigResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RepoScopedClientConfig
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ClientConfigGenerator
 import com.intellij.openapi.project.Project
@@ -24,18 +25,26 @@ class GetRepoScopedClientConfigTool : AbstractMcpTool() {
     override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
         val broadUrl = ClientConfigGenerator.getStreamableHttpUrl()
         val baseName = ClientConfigGenerator.getDefaultServerName()
-        val commands = RepoScopeRegistry.getInstance().entries().map { entry ->
-            ClientConfigGenerator.buildRepoScopedCodexCommand(
-                broadStreamableHttpUrl = broadUrl,
-                baseServerName = baseName,
-                repoId = entry.repoId
+        val scopedServers = RepoScopeRegistry.getInstance().entries().map { entry ->
+            val serverName = ClientConfigGenerator.buildRepoScopedServerName(baseName, entry.repoId)
+            val streamableHttpUrl = ClientConfigGenerator.buildRepoScopedStreamableHttpUrl(broadUrl, entry.repoId)
+            RepoScopedClientConfig(
+                repoId = entry.repoId,
+                repoPath = entry.rootPath,
+                serverName = serverName,
+                streamableHttpUrl = streamableHttpUrl,
+                codexCommand = ClientConfigGenerator.buildCodexCommand(
+                    serverUrl = streamableHttpUrl,
+                    serverName = serverName
+                )
             )
         }
         return createJsonResult(
             GetRepoScopedClientConfigResult(
                 broadServerName = baseName,
                 broadStreamableHttpUrl = broadUrl,
-                codexCommands = commands
+                scopedServers = scopedServers,
+                codexCommands = scopedServers.map { it.codexCommand }
             )
         )
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ClientConfigGenerator.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ClientConfigGenerator.kt
@@ -35,6 +35,8 @@ object ClientConfigGenerator {
             }
     }
 
+    fun getStreamableHttpUrl(): String = getStreamableHttpUrlOrDefault()
+
     /**
      * Gets the legacy SSE server URL, using the running server URL if available,
      * or constructing a URL from settings if the server is not running.
@@ -219,6 +221,32 @@ object ClientConfigGenerator {
         val addCmd = "codex mcp add $serverName --url $serverUrl"
         return "$removeCmd$separator$addCmd"
     }
+
+    internal fun buildRepoScopedServerName(baseServerName: String, repoId: String): String =
+        "$baseServerName-$repoId"
+
+    internal fun buildRepoScopedStreamableHttpUrl(
+        broadStreamableHttpUrl: String,
+        repoId: String
+    ): String {
+        val broadEndpoint = McpConstants.STREAMABLE_HTTP_ENDPOINT_PATH
+        require(broadStreamableHttpUrl.endsWith(broadEndpoint)) {
+            "Broad Streamable HTTP URL must end with $broadEndpoint"
+        }
+        return broadStreamableHttpUrl.removeSuffix(broadEndpoint) +
+            "${McpConstants.MCP_ENDPOINT_PATH}/repos/$repoId/streamable-http"
+    }
+
+    internal fun buildRepoScopedCodexCommand(
+        broadStreamableHttpUrl: String,
+        baseServerName: String,
+        repoId: String,
+        platform: CommandPlatform = CommandPlatform.POSIX
+    ): String = buildCodexCommand(
+        serverUrl = buildRepoScopedStreamableHttpUrl(broadStreamableHttpUrl, repoId),
+        serverName = buildRepoScopedServerName(baseServerName, repoId),
+        platform = platform
+    )
 
     private fun generateCodexConfig(
         serverUrl: String,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
@@ -114,12 +114,12 @@ object PsiUtils {
         return PsiManager.getInstance(project).findFile(virtualFile)
     }
 
-    fun getVirtualFile(project: Project, relativePath: String): VirtualFile? {
+    fun getVirtualFile(project: Project, relativePath: String, preferredRoot: String? = null): VirtualFile? {
         val basePath = project.basePath ?: return null
-        return resolveLocalFile(relativePath, sequenceOf(basePath))
+        return resolveLocalFile(relativePath, rootCandidates(project, preferredRoot, includeModuleRoots = false))
     }
 
-    fun resolveVirtualFileAnywhere(project: Project, path: String): VirtualFile? {
+    fun resolveVirtualFileAnywhere(project: Project, path: String, preferredRoot: String? = null): VirtualFile? {
         // On Windows, \ is a path separator (and is forbidden in filenames), so normalizing is
         // always safe and necessary. On POSIX, \ is a valid filename character and must not be
         // treated as a separator.
@@ -142,7 +142,10 @@ object PsiUtils {
                 val internalPath = parts[1]
 
                 val homeExpandedJarPath = expandHome(jarPath)
-                val absoluteJarPath = resolveAbsolutePathString(homeExpandedJarPath, listOfNotNull(project.basePath).asSequence())
+                val absoluteJarPath = resolveAbsolutePathString(
+                    homeExpandedJarPath,
+                    rootCandidates(project, preferredRoot, includeModuleRoots = false)
+                )
                     ?: homeExpandedJarPath
 
                 val projectLibraryJars = project.getProjectLibraryJars()
@@ -158,19 +161,14 @@ object PsiUtils {
             }
         }
 
-        return getVirtualFile(project, normalizedPath)
+        return getVirtualFile(project, normalizedPath, preferredRoot)
     }
 
     fun resolveNavigableVirtualFile(project: Project, path: String): VirtualFile? {
         // Match resolveVirtualFileAnywhere() semantics for path normalization.
         val normalizedPath = if (SystemInfo.isWindows) path.replace('\\', '/') else path
         val virtualFileManager = VirtualFileManager.getInstance()
-        val rootCandidates = sequence {
-            project.basePath?.let { yield(it) }
-            for (root in ProjectUtils.getModuleContentRoots(project)) {
-                yield(root)
-            }
-        }
+        val rootCandidates = rootCandidates(project, preferredRoot = null, includeModuleRoots = true)
 
         val resolved = when {
             normalizedPath.startsWith("jar://") -> virtualFileManager.findFileByUrl(normalizedPath)
@@ -213,6 +211,20 @@ object PsiUtils {
 
     fun resolveAbsolutePathString(path: String, rootCandidates: Sequence<String> = emptySequence()): String? =
         resolveAbsolutePath(path, rootCandidates)?.toString()?.replace('\\', '/')
+
+    private fun rootCandidates(
+        project: Project,
+        preferredRoot: String?,
+        includeModuleRoots: Boolean
+    ): Sequence<String> = sequence {
+        preferredRoot?.takeIf { it.isNotBlank() }?.let { yield(it) }
+        project.basePath?.let { yield(it) }
+        if (includeModuleRoots) {
+            for (root in ProjectUtils.getModuleContentRoots(project)) {
+                if (root != preferredRoot && root != project.basePath) yield(root)
+            }
+        }
+    }
 
     private fun resolveAgainstRoot(path: String, root: String?): Path? {
         val rootPath = toPathOrNull(root) ?: return null

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -15,6 +15,8 @@ Complete parameter reference for all IDE MCP tools. All tools use JSON-RPC via M
 
 **Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
 
+**Repo-scoped routes:** Attached repository roots can be called through `/index-mcp/repos/{repoId}/streamable-http`. The route injects that repo root as `project_path`; requests that supply a conflicting `project_path` are rejected.
+
 ## Response Format
 
 All tools return: `{ "content": [{"type": "text", "text": "<JSON>"}], "isError": false|true }`
@@ -340,6 +342,40 @@ Force sync IDE's virtual file system with external file changes.
 
 **Returns**: `{ syncedPaths, syncedAll, message }`
 Call this when files were created/modified outside the IDE and search tools miss them.
+
+### ide_attach_repo_to_workspace
+Attach a repository root to the active workspace and publish its repo-scoped MCP route.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `repo_path` | string | yes | Absolute path to the repository root to attach |
+| `project_path` | string | no | Workspace project path |
+
+**Returns**: `{ repoId, repoPath }`
+`repoId` is the repository folder name when unique; duplicate folder names get an 8-character path-hash suffix.
+The scoped Streamable HTTP route is `/index-mcp/repos/{repoId}/streamable-http`.
+
+### ide_detach_repo_from_workspace
+Detach a repository root from the active workspace and remove its repo-scoped MCP route.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `repo_id` | string | yes | Repo id returned by `ide_attach_repo_to_workspace` or `ide_get_repo_scoped_client_config` |
+| `project_path` | string | no | Workspace project path |
+
+**Returns**: `{ repoId, detached }`
+
+### ide_get_repo_scoped_client_config
+Export broad-plus-repo-scoped client configuration for currently attached repository roots.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_path` | string | no | Workspace project path |
+
+**Returns**: `{ broadServerName, broadStreamableHttpUrl, scopedServers, codexCommands }`
+
+Each `scopedServers` item is `{ repoId, repoPath, serverName, streamableHttpUrl, codexCommand }`.
+Use `streamableHttpUrl` to register an MCP server dedicated to one attached repo while keeping the broader workspace open in the IDE.
 
 ### ide_build_project (disabled by default)
 Build project using IDE's build system (JPS, Gradle, Maven).

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/RepoScopedAgentWorkspaceIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/RepoScopedAgentWorkspaceIntegrationTest.kt
@@ -12,12 +12,16 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorMcpSe
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorSseSessionManager
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbService
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -26,6 +30,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import java.nio.file.Path
 import java.net.ServerSocket
 import java.net.URI
 import java.net.http.HttpClient
@@ -44,6 +49,8 @@ class RepoScopedAgentWorkspaceIntegrationTest : BasePlatformTestCase() {
     private lateinit var coroutineScope: CoroutineScope
     private lateinit var server: KtorMcpServer
     private var port: Int = 0
+
+    override fun runInDispatchThread(): Boolean = false
 
     override fun setUp() {
         super.setUp()
@@ -130,6 +137,90 @@ class RepoScopedAgentWorkspaceIntegrationTest : BasePlatformTestCase() {
         assertEquals("Detached repo route should no longer be published", 404, afterDetach.statusCode())
     }
 
+    fun testRepoScopedReadFileUsesScopedRootWithDuplicatePaths() = runBlocking {
+        withDuplicatePathTopology {
+            val readResult = scopedToolCall(
+                repoId = "beta-repo",
+                toolName = ToolNames.READ_FILE,
+                arguments = buildJsonObject {
+                    put(ParamNames.FILE, "README.md")
+                }
+            )
+            assertFalse("Scoped read_file should succeed", readResult.isError)
+            assertTrue("read_file should read beta repo content", readResult.text().contains("BETA_ONLY"))
+            assertFalse("read_file should not read sibling repo content", readResult.text().contains("ALPHA_ONLY"))
+        }
+    }
+
+    fun testRepoScopedOpenFileUsesScopedRootWithDuplicatePaths() = runBlocking {
+        withDuplicatePathTopology {
+            val openResult = scopedToolCall(
+                repoId = "beta-repo",
+                toolName = ToolNames.OPEN_FILE,
+                arguments = buildJsonObject {
+                    put(ParamNames.FILE, "README.md")
+                }
+            )
+            assertFalse("Scoped open_file should succeed", openResult.isError)
+            assertTrue("open_file result should stay repo-relative", openResult.text().contains("\"file\":\"README.md\""))
+        }
+    }
+
+    fun testRepoScopedOpenFileNotificationReturnsAcceptedWithDuplicatePaths() = runBlocking {
+        withDuplicatePathTopology {
+            val response = postScoped(
+                "beta-repo",
+                json.encodeToString(
+                    JsonRpcRequest.serializer(),
+                    JsonRpcRequest(
+                        id = null,
+                        method = "tools/call",
+                        params = buildJsonObject {
+                            put("name", ToolNames.OPEN_FILE)
+                            put("arguments", buildJsonObject {
+                                put(ParamNames.FILE, "README.md")
+                            })
+                        }
+                    )
+                )
+            )
+
+            assertEquals("Scoped open_file notification should return 202", 202, response.statusCode())
+            assertTrue("Scoped open_file notification should have an empty body", response.body().isBlank())
+        }
+    }
+
+    fun testRepoScopedFileStructureUsesScopedRootWithDuplicatePaths() = runBlocking {
+        withDuplicatePathTopology {
+            val structureResult = scopedToolCall(
+                repoId = "beta-repo",
+                toolName = ToolNames.FILE_STRUCTURE,
+                arguments = buildJsonObject {
+                    put(ParamNames.FILE, "docs/outline.md")
+                }
+            )
+            assertFalse("Scoped file_structure should succeed", structureResult.isError)
+            assertTrue("file_structure should inspect beta repo markdown", structureResult.text().contains("BETA_ONLY"))
+            assertFalse("file_structure should not inspect alpha repo markdown", structureResult.text().contains("ALPHA_ONLY"))
+        }
+    }
+
+    fun testRepoScopedFindFileUsesScopedRootWithDuplicatePaths() = runBlocking {
+        withDuplicatePathTopology {
+            val findResult = scopedToolCall(
+                repoId = "beta-repo",
+                toolName = ToolNames.FIND_FILE,
+                arguments = buildJsonObject {
+                    put(ParamNames.QUERY, "README.md")
+                    put("pageSize", 10)
+                }
+            )
+            assertFalse("Scoped find_file should succeed", findResult.isError)
+            assertTrue("find_file should include scoped repo README", findResult.text().contains("\"path\":\"README.md\""))
+            assertFalse("find_file should not include alpha repo path", findResult.text().contains("alpha-repo"))
+        }
+    }
+
     private suspend fun callTool(toolName: String, arguments: kotlinx.serialization.json.JsonObject): ToolCallResult {
         val request = JsonRpcRequest(
             id = JsonPrimitive(10),
@@ -145,7 +236,95 @@ class RepoScopedAgentWorkspaceIntegrationTest : BasePlatformTestCase() {
         return json.decodeFromJsonElement(ToolCallResult.serializer(), response.result!!)
     }
 
-    private fun postScoped(repoId: String, body: String): HttpResponse<String> {
+    private suspend fun attachRepo(repoPath: Path) {
+        val result = callTool(
+            ToolNames.ATTACH_REPO_TO_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_PATH, repoPath.toString().replace('\\', '/'))
+            }
+        )
+        assertFalse("Attach should succeed for $repoPath", result.isError)
+    }
+
+    private suspend fun createDuplicatePathTopology(): DuplicatePathTopology {
+        val parent = Files.createTempDirectory("repo-safe-scope")
+        val alpha = createRepoWithDuplicateFiles(parent, "alpha-repo", "ALPHA_ONLY")
+        val beta = createRepoWithDuplicateFiles(parent, "beta-repo", "BETA_ONLY")
+
+        attachRepo(alpha)
+        attachRepo(beta)
+        DumbService.getInstance(project).waitForSmartMode()
+        return DuplicatePathTopology(alpha = alpha, beta = beta)
+    }
+
+    private suspend fun withDuplicatePathTopology(block: suspend () -> Unit) {
+        val topology = createDuplicatePathTopology()
+        try {
+            block()
+        } finally {
+            closeOpenFilesUnder(topology.beta, topology.alpha)
+            detachRepo("beta-repo")
+            detachRepo("alpha-repo")
+        }
+    }
+
+    private fun closeOpenFilesUnder(vararg roots: Path) {
+        val normalizedRoots = roots.map { it.toAbsolutePath().normalize().toString().replace('\\', '/') }
+        ApplicationManager.getApplication().invokeAndWait {
+            val editorManager = FileEditorManager.getInstance(project)
+            editorManager.openFiles
+                .filter { openFile ->
+                    val filePath = openFile.path.replace('\\', '/')
+                    normalizedRoots.any { root -> filePath == root || filePath.startsWith("$root/") }
+                }
+                .forEach { editorManager.closeFile(it) }
+        }
+    }
+
+    private suspend fun detachRepo(repoId: String) {
+        val result = callTool(
+            ToolNames.DETACH_REPO_FROM_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_ID, repoId)
+            }
+        )
+        assertFalse("Detach should succeed for $repoId", result.isError)
+    }
+
+    private suspend fun scopedToolCall(
+        repoId: String,
+        toolName: String,
+        arguments: kotlinx.serialization.json.JsonObject
+    ): ToolCallResult {
+        val request = JsonRpcRequest(
+            id = JsonPrimitive(20),
+            method = "tools/call",
+            params = buildJsonObject {
+                put("name", toolName)
+                put("arguments", arguments)
+            }
+        )
+        val response = postScoped(repoId, json.encodeToString(JsonRpcRequest.serializer(), request))
+        assertEquals("Scoped tool call should return HTTP 200", 200, response.statusCode())
+        val rpcResponse = json.decodeFromString<JsonRpcResponse>(response.body())
+        assertNull("Scoped tool call should not return JSON-RPC error", rpcResponse.error)
+        return json.decodeFromJsonElement(ToolCallResult.serializer(), rpcResponse.result!!)
+    }
+
+    private fun createRepoWithDuplicateFiles(parent: Path, repoName: String, marker: String): Path {
+        val repo = parent.resolve(repoName)
+        Files.createDirectories(repo.resolve("docs"))
+        Files.writeString(repo.resolve("README.md"), "$marker readme\n")
+        Files.writeString(repo.resolve("docs/outline.md"), "# $marker\n")
+        return repo
+    }
+
+    private data class DuplicatePathTopology(
+        val alpha: Path,
+        val beta: Path
+    )
+
+    private suspend fun postScoped(repoId: String, body: String): HttpResponse<String> {
         val request = HttpRequest.newBuilder(
             URI.create("http://127.0.0.1:$port${McpConstants.MCP_ENDPOINT_PATH}/repos/$repoId/streamable-http")
         )
@@ -153,7 +332,10 @@ class RepoScopedAgentWorkspaceIntegrationTest : BasePlatformTestCase() {
             .header("Content-Type", "application/json")
             .POST(HttpRequest.BodyPublishers.ofString(body))
             .build()
-        return httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+        return withContext(Dispatchers.IO) {
+            httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        }
     }
 
     private fun ToolCallResult.text(): String =

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/RepoScopedAgentWorkspaceIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/RepoScopedAgentWorkspaceIntegrationTest.kt
@@ -1,0 +1,161 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.integration
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.JsonRpcHandler
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcRequest
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcResponse
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorMcpServer
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorSseSessionManager
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.net.ServerSocket
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+
+class RepoScopedAgentWorkspaceIntegrationTest : BasePlatformTestCase() {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+    private val httpClient = HttpClient.newHttpClient()
+
+    private lateinit var registry: ToolRegistry
+    private lateinit var coroutineScope: CoroutineScope
+    private lateinit var server: KtorMcpServer
+    private var port: Int = 0
+
+    override fun setUp() {
+        super.setUp()
+        registry = ToolRegistry().also { it.registerBuiltInTools() }
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        port = ServerSocket(0).use { it.localPort }
+        server = KtorMcpServer(
+            port = port,
+            jsonRpcHandler = JsonRpcHandler(registry),
+            sseSessionManager = KtorSseSessionManager(),
+            coroutineScope = coroutineScope
+        )
+        assertEquals(KtorMcpServer.StartResult.Success, server.start())
+    }
+
+    override fun tearDown() {
+        try {
+            server.stop()
+            RepoScopeRegistry.getInstance().replaceOpenRoots(emptyList())
+        } finally {
+            coroutineScope.cancel()
+            super.tearDown()
+        }
+    }
+
+    fun testAttachConfigConflictAndDetachForNestedWorkspaceTopology() = runBlocking {
+        val parent = Files.createTempDirectory("repo-scoped-workspace")
+        val shippingRepo = parent.resolve("master-project/submodules/shipping-repo").toFile()
+        assertTrue(shippingRepo.mkdirs() || shippingRepo.isDirectory)
+        val repoPath = shippingRepo.path.replace('\\', '/')
+
+        val attach = callTool(
+            ToolNames.ATTACH_REPO_TO_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_PATH, repoPath)
+            }
+        )
+        assertFalse("Attach should succeed", attach.isError)
+        assertTrue("Attached repo should become a workspace content root", ProjectUtils.getModuleContentRoots(project).contains(repoPath))
+
+        val config = callTool(ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG, buildJsonObject { })
+        val scopedServers = json.parseToJsonElement(config.text()).jsonObject["scopedServers"]!!.jsonArray.map { it.jsonObject }
+        val shippingServer = scopedServers.firstOrNull { it["repoId"]?.jsonPrimitive?.content == "shipping-repo" }
+        assertNotNull("Client config should publish the shipping repo scoped route", shippingServer)
+        assertTrue(
+            "Published scoped URL should target the repo route",
+            shippingServer!!["streamableHttpUrl"]?.jsonPrimitive?.content?.endsWith("/index-mcp/repos/shipping-repo/streamable-http") == true
+        )
+
+        val scopedPing = postScoped("shipping-repo", """{"jsonrpc":"2.0","id":1,"method":"ping"}""")
+        assertEquals(200, scopedPing.statusCode())
+
+        val conflict = postScoped(
+            "shipping-repo",
+            json.encodeToString(
+                JsonRpcRequest.serializer(),
+                JsonRpcRequest(
+                    id = JsonPrimitive(2),
+                    method = "tools/call",
+                    params = buildJsonObject {
+                        put("name", ToolNames.INDEX_STATUS)
+                        put("arguments", buildJsonObject {
+                            put(ParamNames.PROJECT_PATH, parent.resolve("other-repo").toString().replace('\\', '/'))
+                        })
+                    }
+                )
+            )
+        )
+        val conflictResponse = json.decodeFromString<JsonRpcResponse>(conflict.body())
+        val conflictResult = json.decodeFromJsonElement(ToolCallResult.serializer(), conflictResponse.result!!)
+        assertTrue("Conflicting project_path should be rejected on repo scoped route", conflictResult.isError)
+        assertTrue(conflictResult.text().contains("repo_scope_conflict"))
+
+        val detach = callTool(
+            ToolNames.DETACH_REPO_FROM_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_ID, "shipping-repo")
+            }
+        )
+        assertFalse("Detach should succeed", detach.isError)
+        assertFalse("Detached repo should leave workspace content roots", ProjectUtils.getModuleContentRoots(project).contains(repoPath))
+
+        val afterDetach = postScoped("shipping-repo", """{"jsonrpc":"2.0","id":3,"method":"ping"}""")
+        assertEquals("Detached repo route should no longer be published", 404, afterDetach.statusCode())
+    }
+
+    private suspend fun callTool(toolName: String, arguments: kotlinx.serialization.json.JsonObject): ToolCallResult {
+        val request = JsonRpcRequest(
+            id = JsonPrimitive(10),
+            method = "tools/call",
+            params = buildJsonObject {
+                put("name", toolName)
+                put("arguments", arguments)
+            }
+        )
+        val responseJson = JsonRpcHandler(registry).handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
+        assertNull("Tool call should not return JSON-RPC error", response.error)
+        return json.decodeFromJsonElement(ToolCallResult.serializer(), response.result!!)
+    }
+
+    private fun postScoped(repoId: String, body: String): HttpResponse<String> {
+        val request = HttpRequest.newBuilder(
+            URI.create("http://127.0.0.1:$port${McpConstants.MCP_ENDPOINT_PATH}/repos/$repoId/streamable-http")
+        )
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build()
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    private fun ToolCallResult.text(): String =
+        (content.firstOrNull() as? com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock.Text)?.text.orEmpty()
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
@@ -485,6 +485,9 @@ class ToolExecutionIntegrationTest : BasePlatformTestCase() {
             ToolNames.BUILD_PROJECT,
             ToolNames.INDEX_STATUS,
             ToolNames.SYNC_FILES,
+            ToolNames.ATTACH_REPO_TO_WORKSPACE,
+            ToolNames.DETACH_REPO_FROM_WORKSPACE,
+            ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG,
             // Refactoring tools
             ToolNames.REFACTOR_RENAME,
             ToolNames.REFACTOR_MOVE,

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandlerUnitTest.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.JsonRpcMethods
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcErrorCodes
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcRequest
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcResponse
@@ -191,5 +192,38 @@ class JsonRpcHandlerUnitTest : TestCase() {
         val responseJson = handler.handleRequest(requestJson)
 
         assertNull("Notification should return null (no response)", responseJson)
+    }
+
+    fun testRepoScopedToolCallRejectsConflictingProjectPath() = runBlocking {
+        val request = JsonRpcRequest(
+            id = JsonPrimitive(9),
+            method = JsonRpcMethods.TOOLS_CALL,
+            params = buildJsonObject {
+                put(ParamNames.NAME, ToolNames.INDEX_STATUS)
+                put(ParamNames.ARGUMENTS, buildJsonObject {
+                    put(ParamNames.PROJECT_PATH, "C:/workspaces/other-repo")
+                })
+            }
+        )
+
+        val responseJson = handler.handleRequest(
+            json.encodeToString(JsonRpcRequest.serializer(), request),
+            protocolVersion = McpConstants.MCP_PROTOCOL_VERSION,
+            repoScope = RepoScopeEntry(
+                repoId = "api",
+                rootPath = "C:/workspaces/api"
+            )
+        )
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
+
+        assertNull("Repo scope conflicts should be tool-result errors, not JSON-RPC errors", response.error)
+        val result = json.decodeFromJsonElement(
+            com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult.serializer(),
+            response.result!!
+        )
+        assertTrue("Conflicting project_path should be rejected", result.isError)
+        val text = (result.content.first() as com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock.Text).text
+        assertTrue("Error should identify repo scope conflict", text.contains("repo_scope_conflict"))
+        assertTrue("Error should include scoped repo id", text.contains("api"))
     }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/MultiProjectResolutionTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/MultiProjectResolutionTest.kt
@@ -1,6 +1,8 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcRequest
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.JsonRpcResponse
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
@@ -10,9 +12,11 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import java.nio.file.Files
 
 /**
  * Platform-dependent tests for multi-project resolution.
@@ -110,4 +114,55 @@ class MultiProjectResolutionTest : BasePlatformTestCase() {
         assertEquals("project_not_found", errorJson["error"]?.jsonPrimitive?.content)
         assertNotNull("Should include available_projects", errorJson["available_projects"])
     }
+
+    fun testAttachAndDetachRefreshWorkspaceContentRoots() = runBlocking {
+        val repoRoot = Files.createTempDirectory("repo-lifecycle").resolve("shipping-repo").toFile()
+        assertTrue("Fixture repo root should be created", repoRoot.mkdirs() || repoRoot.isDirectory)
+        assertFalse("Fixture repo root should start outside content roots", ProjectUtils.getModuleContentRoots(project).contains(repoRoot.path.replace('\\', '/')))
+
+        val attachResult = callTool(
+            ToolNames.ATTACH_REPO_TO_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_PATH, repoRoot.path.replace('\\', '/'))
+            }
+        )
+        assertFalse("Attach should succeed", attachResult.isError)
+
+        val attachJson = json.parseToJsonElement(attachResult.text()).jsonObject
+        val repoId = attachJson["repoId"]?.jsonPrimitive?.contentOrNull
+        assertEquals("shipping-repo", repoId)
+        assertTrue("Attach should add repo root to workspace content roots", ProjectUtils.getModuleContentRoots(project).contains(repoRoot.path.replace('\\', '/')))
+
+        val detachResult = callTool(
+            ToolNames.DETACH_REPO_FROM_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_ID, repoId!!)
+            }
+        )
+        assertFalse("Detach should succeed", detachResult.isError)
+
+        val detachJson = json.parseToJsonElement(detachResult.text()).jsonObject
+        assertEquals("true", detachJson["detached"]?.jsonPrimitive?.content)
+        assertFalse("Detach should remove repo root from workspace content roots", ProjectUtils.getModuleContentRoots(project).contains(repoRoot.path.replace('\\', '/')))
+    }
+
+    private suspend fun callTool(toolName: String, arguments: kotlinx.serialization.json.JsonObject): ToolCallResult {
+        val request = JsonRpcRequest(
+            id = JsonPrimitive(10),
+            method = "tools/call",
+            params = buildJsonObject {
+                put("name", toolName)
+                put("arguments", arguments)
+            }
+        )
+
+        val responseJson = handler.handleRequest(json.encodeToString(JsonRpcRequest.serializer(), request))
+        val response = json.decodeFromString<JsonRpcResponse>(responseJson!!)
+        assertNull("Tool call should not return JSON-RPC error", response.error)
+        assertNotNull("Tool call should return result", response.result)
+        return json.decodeFromJsonElement(ToolCallResult.serializer(), response.result!!)
+    }
+
+    private fun ToolCallResult.text(): String =
+        (content.firstOrNull() as? com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ContentBlock.Text)?.text ?: ""
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/MultiProjectResolutionTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/MultiProjectResolutionTest.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -144,6 +145,52 @@ class MultiProjectResolutionTest : BasePlatformTestCase() {
         val detachJson = json.parseToJsonElement(detachResult.text()).jsonObject
         assertEquals("true", detachJson["detached"]?.jsonPrimitive?.content)
         assertFalse("Detach should remove repo root from workspace content roots", ProjectUtils.getModuleContentRoots(project).contains(repoRoot.path.replace('\\', '/')))
+    }
+
+    fun testRepoScopedClientConfigReflectsAttachAndDetach() = runBlocking {
+        val repoRoot = Files.createTempDirectory("repo-config").resolve("billing-api").toFile()
+        assertTrue("Fixture repo root should be created", repoRoot.mkdirs() || repoRoot.isDirectory)
+        val repoPath = repoRoot.path.replace('\\', '/')
+
+        val attachResult = callTool(
+            ToolNames.ATTACH_REPO_TO_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_PATH, repoPath)
+            }
+        )
+        assertFalse("Attach should succeed", attachResult.isError)
+
+        val configResult = callTool(ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG, buildJsonObject { })
+        assertFalse("Config export should succeed", configResult.isError)
+
+        val configJson = json.parseToJsonElement(configResult.text()).jsonObject
+        assertEquals("intellij-index", configJson["broadServerName"]?.jsonPrimitive?.content)
+        assertTrue(
+            "Broad URL should use streamable HTTP",
+            configJson["broadStreamableHttpUrl"]?.jsonPrimitive?.content?.endsWith("/index-mcp/streamable-http") == true
+        )
+        val scopedServers = configJson["scopedServers"]!!.jsonArray.map { it.jsonObject }
+        val billingServer = scopedServers.firstOrNull { it["repoId"]?.jsonPrimitive?.content == "billing-api" }
+        assertNotNull("Config should include attached repo scoped server", billingServer)
+        assertEquals(repoPath, billingServer!!["repoPath"]?.jsonPrimitive?.content)
+        assertEquals("intellij-index-billing-api", billingServer["serverName"]?.jsonPrimitive?.content)
+        assertTrue(
+            "Scoped URL should include repo route",
+            billingServer["streamableHttpUrl"]?.jsonPrimitive?.content?.endsWith("/index-mcp/repos/billing-api/streamable-http") == true
+        )
+
+        val detachResult = callTool(
+            ToolNames.DETACH_REPO_FROM_WORKSPACE,
+            buildJsonObject {
+                put(ParamNames.REPO_ID, "billing-api")
+            }
+        )
+        assertFalse("Detach should succeed", detachResult.isError)
+
+        val refreshedConfig = callTool(ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG, buildJsonObject { })
+        val refreshedJson = json.parseToJsonElement(refreshedConfig.text()).jsonObject
+        val refreshedServers = refreshedJson["scopedServers"]!!.jsonArray.map { it.jsonObject }
+        assertFalse("Detached repo should disappear from client config", refreshedServers.any { it["repoId"]?.jsonPrimitive?.content == "billing-api" })
     }
 
     private suspend fun callTool(toolName: String, arguments: kotlinx.serialization.json.JsonObject): ToolCallResult {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/RepoScopeRegistryUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/RepoScopeRegistryUnitTest.kt
@@ -1,0 +1,53 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import junit.framework.TestCase
+
+class RepoScopeRegistryUnitTest : TestCase() {
+
+    fun testDuplicateLeafNamesUseStablePathHashSuffixes() {
+        val first = testPath("workspace/service")
+        val second = testPath("submodules/service")
+
+        val entries = RepoScopeRegistry.buildEntries(listOf(first, second))
+
+        val idsByPath = entries.associate { it.rootPath to it.repoId }
+        assertEquals("service-${RepoScopeRegistry.pathHash8(first)}", idsByPath[RepoScopeRegistry.normalizeRootPath(first)])
+        assertEquals("service-${RepoScopeRegistry.pathHash8(second)}", idsByPath[RepoScopeRegistry.normalizeRootPath(second)])
+        assertFalse("Duplicate repo ids must not use ordinal suffixes", entries.any { it.repoId.endsWith("-2") })
+    }
+
+    fun testUniqueLeafNamesStayReadable() {
+        val entries = RepoScopeRegistry.buildEntries(listOf(testPath("workspace/api"), testPath("workspace/web")))
+
+        assertEquals(listOf("api", "web"), entries.map { it.repoId })
+    }
+
+    fun testRepoIdsAreStableAcrossInputOrder() {
+        val first = testPath("workspace/service")
+        val second = testPath("submodules/service")
+
+        val forward = RepoScopeRegistry.buildEntries(listOf(first, second)).associate { it.rootPath to it.repoId }
+        val reversed = RepoScopeRegistry.buildEntries(listOf(second, first)).associate { it.rootPath to it.repoId }
+
+        assertEquals(forward, reversed)
+    }
+
+    fun testDetachRemovesOneRepoWithoutRenamingRemainingRepos() {
+        val registry = RepoScopeRegistry()
+        val first = testPath("workspace/service")
+        val second = testPath("submodules/service")
+        val web = testPath("workspace/web")
+
+        registry.replaceOpenRoots(listOf(first, second, web))
+        val removedId = registry.entries().first { it.rootPath == RepoScopeRegistry.normalizeRootPath(first) }.repoId
+        val remainingBefore = registry.entries().filterNot { it.repoId == removedId }.associate { it.rootPath to it.repoId }
+
+        assertTrue(registry.detach(removedId))
+
+        assertEquals(remainingBefore, registry.entries().associate { it.rootPath to it.repoId })
+        assertFalse(registry.entries().any { it.repoId == removedId })
+    }
+
+    private fun testPath(relative: String): String =
+        "C:/Users/Tanner/Documents/Workspaces/Projects/$relative"
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/KtorMcpServerUnitTest.kt
@@ -2,6 +2,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.JsonRpcHandler
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
 import io.ktor.http.HttpStatusCode
 import junit.framework.TestCase
@@ -45,6 +46,7 @@ class KtorMcpServerUnitTest : TestCase() {
 
     override fun tearDown() {
         server.stop()
+        RepoScopeRegistry.getInstance().replaceOpenRoots(emptyList())
         coroutineScope.cancel()
         super.tearDown()
     }
@@ -184,6 +186,21 @@ class KtorMcpServerUnitTest : TestCase() {
 
         assertEquals(HttpStatusCode.OK.value, response.statusCode())
 
+        val responseBody = json.parseToJsonElement(response.body()).jsonObject
+        assertEquals("1", responseBody["id"]!!.jsonPrimitive.content)
+        assertNotNull(responseBody["result"])
+    }
+
+    fun testRepoScopedStreamableRequestUsesRepoRoute() {
+        RepoScopeRegistry.getInstance().replaceOpenRoots(listOf("C:/workspaces/api"))
+
+        val response = sendRequest(
+            method = "POST",
+            path = "${McpConstants.MCP_ENDPOINT_PATH}/repos/api/streamable-http",
+            body = """{"jsonrpc":"2.0","id":1,"method":"ping"}"""
+        )
+
+        assertEquals(HttpStatusCode.OK.value, response.statusCode())
         val responseBody = json.parseToJsonElement(response.body()).jsonObject
         assertEquals("1", responseBody["id"]!!.jsonPrimitive.content)
         assertNotNull(responseBody["result"])

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
@@ -751,6 +751,26 @@ class ToolsTest : BasePlatformTestCase() {
         assertTrue("Should error with line < 1", result.isError)
     }
 
+    fun testOpenFileToolOpensFixtureRootFile() = runBlocking {
+        val contentRoot = Files.createTempDirectory("open-file-tool-root")
+        val readme = contentRoot.resolve("README.md")
+        Files.writeString(readme, "ROOT_ONLY\n")
+        val rootVFile = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(contentRoot)
+        assertNotNull("Expected temp content root in local VFS", rootVFile)
+        ModuleRootModificationUtil.addContentRoot(module, rootVFile!!)
+
+        val tool = OpenFileTool()
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", readme.toString())
+        })
+
+        assertFalse("open_file should succeed for a fixture root file: ${errorText(result)}", result.isError)
+        val resultJson = json.parseToJsonElement((result.content.first() as ContentBlock.Text).text).jsonObject
+        assertEquals("README.md", resultJson["file"]?.jsonPrimitive?.content)
+        assertEquals("true", resultJson["opened"]?.jsonPrimitive?.content)
+    }
+
     // Reformat Code Tool Tests
 
     fun testReformatCodeToolMissingParams() = runBlocking {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -20,6 +20,9 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SearchTex
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.AttachRepoToWorkspaceTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.DetachRepoFromWorkspaceTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetRepoScopedClientConfigTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.SyncFilesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.MoveFileTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.OptimizeImportsTool
@@ -125,6 +128,44 @@ class ToolsUnitTest : TestCase() {
         val tool = registry.getTool(ToolNames.BUILD_PROJECT)
         assertNotNull("ide_build_project should be registered", tool)
         assertEquals(ToolNames.BUILD_PROJECT, tool?.name)
+    }
+
+    fun testAttachRepoToWorkspaceToolSchema() {
+        val tool = AttachRepoToWorkspaceTool()
+        val properties = tool.inputSchema[SchemaConstants.PROPERTIES]?.jsonObject
+
+        assertEquals(ToolNames.ATTACH_REPO_TO_WORKSPACE, tool.name)
+        assertNotNull("Should have project_path property", properties?.get(ParamNames.PROJECT_PATH))
+        assertNotNull("Should have repo_path property", properties?.get(ParamNames.REPO_PATH))
+        assertTrue("repo_path should be required", tool.inputSchema[SchemaConstants.REQUIRED].toString().contains(ParamNames.REPO_PATH))
+    }
+
+    fun testDetachRepoFromWorkspaceToolSchema() {
+        val tool = DetachRepoFromWorkspaceTool()
+        val properties = tool.inputSchema[SchemaConstants.PROPERTIES]?.jsonObject
+
+        assertEquals(ToolNames.DETACH_REPO_FROM_WORKSPACE, tool.name)
+        assertNotNull("Should have project_path property", properties?.get(ParamNames.PROJECT_PATH))
+        assertNotNull("Should have repo_id property", properties?.get(ParamNames.REPO_ID))
+        assertTrue("repo_id should be required", tool.inputSchema[SchemaConstants.REQUIRED].toString().contains(ParamNames.REPO_ID))
+    }
+
+    fun testGetRepoScopedClientConfigToolSchema() {
+        val tool = GetRepoScopedClientConfigTool()
+        val properties = tool.inputSchema[SchemaConstants.PROPERTIES]?.jsonObject
+
+        assertEquals(ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG, tool.name)
+        assertNotNull("Should have project_path property", properties?.get(ParamNames.PROJECT_PATH))
+        assertNull("Should not have required fields", tool.inputSchema[SchemaConstants.REQUIRED])
+    }
+
+    fun testRepoLifecycleToolsAreRegistered() {
+        val registry = ToolRegistry()
+        registry.registerBuiltInTools()
+
+        assertNotNull("ide_attach_repo_to_workspace should be registered", registry.getTool(ToolNames.ATTACH_REPO_TO_WORKSPACE))
+        assertNotNull("ide_detach_repo_from_workspace should be registered", registry.getTool(ToolNames.DETACH_REPO_FROM_WORKSPACE))
+        assertNotNull("ide_get_repo_scoped_client_config should be registered", registry.getTool(ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG))
     }
 
     fun testFindUsagesToolSchema() {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/AttachRepoToWorkspaceToolUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/AttachRepoToWorkspaceToolUnitTest.kt
@@ -1,0 +1,20 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import junit.framework.TestCase
+import kotlinx.serialization.json.jsonObject
+
+class AttachRepoToWorkspaceToolUnitTest : TestCase() {
+
+    fun testSchemaRequiresRepoPathAndIncludesProjectPath() {
+        val tool = AttachRepoToWorkspaceTool()
+        val properties = tool.inputSchema[SchemaConstants.PROPERTIES]?.jsonObject
+
+        assertEquals(ToolNames.ATTACH_REPO_TO_WORKSPACE, tool.name)
+        assertNotNull(properties?.get(ParamNames.PROJECT_PATH))
+        assertNotNull(properties?.get(ParamNames.REPO_PATH))
+        assertTrue(tool.inputSchema[SchemaConstants.REQUIRED].toString().contains(ParamNames.REPO_PATH))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/DetachRepoFromWorkspaceToolUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/DetachRepoFromWorkspaceToolUnitTest.kt
@@ -1,0 +1,20 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import junit.framework.TestCase
+import kotlinx.serialization.json.jsonObject
+
+class DetachRepoFromWorkspaceToolUnitTest : TestCase() {
+
+    fun testSchemaRequiresRepoIdAndIncludesProjectPath() {
+        val tool = DetachRepoFromWorkspaceTool()
+        val properties = tool.inputSchema[SchemaConstants.PROPERTIES]?.jsonObject
+
+        assertEquals(ToolNames.DETACH_REPO_FROM_WORKSPACE, tool.name)
+        assertNotNull(properties?.get(ParamNames.PROJECT_PATH))
+        assertNotNull(properties?.get(ParamNames.REPO_ID))
+        assertTrue(tool.inputSchema[SchemaConstants.REQUIRED].toString().contains(ParamNames.REPO_ID))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetRepoScopedClientConfigToolUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/GetRepoScopedClientConfigToolUnitTest.kt
@@ -1,0 +1,19 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import junit.framework.TestCase
+import kotlinx.serialization.json.jsonObject
+
+class GetRepoScopedClientConfigToolUnitTest : TestCase() {
+
+    fun testSchemaIncludesProjectPathOnly() {
+        val tool = GetRepoScopedClientConfigTool()
+        val properties = tool.inputSchema[SchemaConstants.PROPERTIES]?.jsonObject
+
+        assertEquals(ToolNames.GET_REPO_SCOPED_CLIENT_CONFIG, tool.name)
+        assertNotNull(properties?.get(ParamNames.PROJECT_PATH))
+        assertNull(tool.inputSchema[SchemaConstants.REQUIRED])
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ClientConfigGeneratorUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ClientConfigGeneratorUnitTest.kt
@@ -588,4 +588,21 @@ class ClientConfigGeneratorUnitTest : TestCase() {
             command
         )
     }
+
+    fun testRepoScopedCommandMatchesDerivedScopedNameAndUrl() {
+        val broadUrl = "http://127.0.0.1:29170/index-mcp/streamable-http"
+        val scopedName = ClientConfigGenerator.buildRepoScopedServerName("intellij-index", "billing-api")
+        val scopedUrl = ClientConfigGenerator.buildRepoScopedStreamableHttpUrl(broadUrl, "billing-api")
+
+        assertEquals("intellij-index-billing-api", scopedName)
+        assertEquals("http://127.0.0.1:29170/index-mcp/repos/billing-api/streamable-http", scopedUrl)
+        assertEquals(
+            ClientConfigGenerator.buildCodexCommand(serverUrl = scopedUrl, serverName = scopedName),
+            ClientConfigGenerator.buildRepoScopedCodexCommand(
+                broadStreamableHttpUrl = broadUrl,
+                baseServerName = "intellij-index",
+                repoId = "billing-api"
+            )
+        )
+    }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ClientConfigGeneratorUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/ClientConfigGeneratorUnitTest.kt
@@ -553,4 +553,39 @@ class ClientConfigGeneratorUnitTest : TestCase() {
         assertFalse("Should not use mcp-remote", command.contains("mcp-remote"))
         assertFalse("Should not use npx", command.contains("npx"))
     }
+
+    fun testBuildRepoScopedServerNameAppendsRepoId() {
+        assertEquals(
+            "intellij-index-localhost-ports-dashboard",
+            ClientConfigGenerator.buildRepoScopedServerName(
+                baseServerName = "intellij-index",
+                repoId = "localhost-ports-dashboard"
+            )
+        )
+    }
+
+    fun testBuildRepoScopedStreamableHttpUrlUsesRepoRoute() {
+        assertEquals(
+            "http://127.0.0.1:29170/index-mcp/repos/localhost-ports-dashboard/streamable-http",
+            ClientConfigGenerator.buildRepoScopedStreamableHttpUrl(
+                broadStreamableHttpUrl = "http://127.0.0.1:29170/index-mcp/streamable-http",
+                repoId = "localhost-ports-dashboard"
+            )
+        )
+    }
+
+    fun testBuildRepoScopedCodexCommandUsesScopedNameAndUrl() {
+        val command = ClientConfigGenerator.buildRepoScopedCodexCommand(
+            broadStreamableHttpUrl = "http://127.0.0.1:29170/index-mcp/streamable-http",
+            baseServerName = "intellij-index",
+            repoId = "localhost-ports-dashboard"
+        )
+
+        assertEquals(
+            "codex mcp remove intellij-index-localhost-ports-dashboard >/dev/null 2>&1 ; " +
+                "codex mcp add intellij-index-localhost-ports-dashboard --url " +
+                "http://127.0.0.1:29170/index-mcp/repos/localhost-ports-dashboard/streamable-http",
+            command
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add repo lifecycle tools for attaching and detaching repository roots from an active workspace
- publish repo-scoped Streamable HTTP routes at `/index-mcp/repos/{repoId}/streamable-http` with deterministic repo ids and conflict checks
- export broad-plus-scoped client configuration via `ide_get_repo_scoped_client_config`, including `scopedServers` metadata and Codex registration commands
- keep repo-scoped file tools inside the injected repo root for read/open/find/file-structure calls
- document the attach/detach/client-config lifecycle in README, USAGE, and the IDE skill tools reference

## Bridge Issue Reference
References `tannerpolley/jetbrains-bridge#1`.

This PR intentionally uses a cross-repo reference instead of GitHub closing syntax because the tracked issue lives in `tannerpolley/jetbrains-bridge`, not in this upstream repository.

## Verification
- `./gradlew.bat test --console=plain --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.AttachRepoToWorkspaceToolUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.DetachRepoFromWorkspaceToolUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetRepoScopedClientConfigToolUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolsUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolsTest"`
- `./gradlew.bat test --console=plain --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.server.RepoScopeRegistryUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.server.MultiProjectResolutionTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.server.JsonRpcHandlerUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport.KtorMcpServerUnitTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ClientConfigGeneratorUnitTest"`
- `./gradlew.bat test --console=plain --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.integration.ToolExecutionIntegrationTest" --tests "com.github.hechtcarmel.jetbrainsindexmcpplugin.integration.RepoScopedAgentWorkspaceIntegrationTest"`
- `pwsh.exe -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\hooks\codex-cleanup.ps1" -RepoRoot .`