### PR TITLE
docs: centralize contributing guidance into CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,11 +342,12 @@ Tests are split into two categories to optimize execution time:
 # Run all tests
 ./gradlew test
 
-# Run only fast unit tests (recommended for quick feedback)
+# Run only fast unit tests — use this locally (< 30s, no IDE needed)
 ./gradlew test --tests "*UnitTest*"
 
-# Run only platform tests
-./gradlew test --tests "*Test" --tests "!*UnitTest*"
+# Platform tests — DO NOT run locally; they require full IntelliJ Platform
+# initialization and hang on headless machines. Let CI run these.
+# ./gradlew test --tests "*Test" --tests "!*UnitTest*"
 
 # Run specific test class
 ./gradlew test --tests "McpPluginUnitTest"
@@ -527,32 +528,21 @@ VirtualFileManager   // Virtual file system
 
 ## Contributing / PR Checklist
 
-Every PR **must** include:
+**Every PR — without exception — must comply with [CONTRIBUTING.md](CONTRIBUTING.md).**
+Read it before writing a single line of code. It is the authoritative guide for this repo.
 
-1. **CHANGELOG.md update** — Add an entry under `## [Unreleased]` following [Keep a Changelog](https://keepachangelog.com) format. Use sections: `Added`, `Changed`, `Fixed`, `Removed`, `Breaking`
-2. Follow existing code patterns and use `SchemaBuilder` for new tool schemas
-3. Add tests for new functionality
-4. Update this documentation (`CLAUDE.md`) for any structural or architectural changes
-5. Run `./gradlew test` to verify all tests pass (do NOT run platform tests yourself)
+Before pushing, run the pre-push validation script to catch common mistakes automatically:
 
-Only update `pluginVersion` in `gradle.properties` when the user explicitly asks to update the version. When requested, follow [SemVer](https://semver.org):
-- **Patch** (3.x.**Y**): Bug fixes, internal refactoring with no behavior change
-- **Minor** (3.**Y**.0): New features, new tools, protocol improvements
-- **Major** (**Y**.0.0): Breaking changes to tool schemas, transport, or client configuration
+```bash
+./scripts/check-pr.sh
+```
 
----
-
-## Smoke Test Protocol
-
-After any `./gradlew buildPlugin` → install → restart cycle, offer to run the smoke
-test at `docs/smoke-test-protocol.md`. It covers HTTP-level behaviour, tool registration,
-and end-to-end paths that the automated test suite cannot catch.
-
-**Offer the smoke test when changes touch:** HTTP transport (`KtorMcpServer.kt`,
-`JsonRpcHandler.kt`), tool registration (`ToolRegistry.kt`, `McpServerService.kt`),
-or any tool covered by the protocol.
-
-**Skip for:** documentation-only, test-only, or `gradle.properties` version-bump changes.
+Quick summary of the non-negotiables:
+1. `CHANGELOG.md` — empty `[Unreleased]` section (maintainer adds the release entry)
+2. No `.idea/gradle.xml`, no `scripts/build-install.sh`, no `docs/pr-*.md`
+3. New tools: registered in `ToolNames`, `McpSettings.disabledTools`, `ToolRegistry`, and all six doc locations (`README.md`, `USAGE.md`, `CLAUDE.md`, `SKILL.md`, `tools-reference.md`, `ToolNames.ALL` sorted)
+4. No `@Internal` API, no `ModalityState.NON_MODAL` (deprecated)
+5. Unit tests pass: `./gradlew test --tests "*UnitTest*"` (never run full `./gradlew test` locally)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,298 @@
+# Contributing to IDE Index MCP Server
+
+This document is the single source of truth for contributors — human or AI.
+Follow every rule here before opening a pull request.
+
+---
+
+## Quick start
+
+### Local feedback loop (run these yourself)
+
+```bash
+./gradlew test --tests "*UnitTest*"   # fast unit tests, no IDE needed (< 30 s)
+./gradlew runIde                       # launch sandboxed IDE with plugin installed
+./scripts/check-pr.sh                  # pre-push validation — run before every push
+```
+
+### CI / maintainer-only (do not run locally unless explicitly asked)
+
+```bash
+./gradlew test               # includes platform tests — times out on headless machines
+./gradlew build              # depends on ./gradlew test, same issue
+./gradlew runPluginVerifier  # Marketplace compatibility check — run in CI
+```
+
+`./gradlew test` registers `TestFrameworkType.Platform` via `build.gradle.kts`, which means
+it includes platform tests that require a full IntelliJ Platform environment. Running it
+locally hangs on headless machines. Stick to `--tests "*UnitTest*"` for local iteration.
+
+---
+
+## PR rules
+
+### CHANGELOG.md
+
+- **DO** add an entry under `## [Unreleased]` for every user-visible change.
+  Use sections: `Added`, `Changed`, `Fixed`, `Removed`, `Breaking`.
+- **DO NOT** add release version entries (`## [x.y.z]`) — the maintainer creates those at merge time.
+- **DO NOT** re-list tools that already shipped in a previous release. After a rebase,
+  check that already-released tool entries have not bled back into `[Unreleased]`.
+
+### Files that must NOT appear in PRs
+
+| File | Reason |
+|------|--------|
+| `.idea/gradle.xml` | Contains local JDK name (`gradleJvm`); breaks on other machines |
+| `scripts/build-install.sh` | Local build helper; not for upstream |
+| `docs/pr-*.md` | Rename to drop the `pr-` prefix before submitting |
+
+### Version bumps
+
+Do **not** change `pluginVersion` in `gradle.properties` unless explicitly requested.
+When requested, follow [SemVer](https://semver.org):
+
+| Change type | Version part |
+|-------------|-------------|
+| Bug fix / internal refactor | Patch (`x.y.Z`) |
+| New tool / new feature | Minor (`x.Y.0`) |
+| Breaking schema / transport change | Major (`X.0.0`) |
+
+---
+
+## Adding a new tool — complete checklist
+
+Every item is required. CI will catch missing registrations and test count mismatches.
+
+### Implementation
+
+- [ ] Extend `AbstractMcpTool`, implement `doExecute()` (never `execute()`)
+- [ ] Set `override val requiresPsiSync = false` unless the tool reads PSI indexes
+- [ ] Set `override val participatesInLifecycle = false` for infrastructure / observer tools
+  (tools that manage lifecycle state, or bulk-operate across all projects)
+- [ ] Use `SchemaBuilder` for `inputSchema` — never construct `JsonObject` manually
+- [ ] Add `project_path` via `.projectPath()` on the builder for any multi-project tool
+
+### Registration
+
+- [ ] Add constant to `ToolNames.kt` in the correct group
+- [ ] Add constant to `ToolNames.ALL` in **strict alphabetical order by full string value**
+  (compare the complete `ide_*` string character by character:
+  `ide_release_all_projects` < `ide_release_project` < `ide_restart` because `all` < `project` < `start`
+  lexicographically at position 12). A sort test in `ConstantsUnitTest` will fail if the order is wrong.
+- [ ] Add tool name string to `McpSettings.State.disabledTools` — all new tools are opt-in
+- [ ] Register in `ToolRegistry.registerUniversalTools()` (or the appropriate method)
+
+### Documentation
+
+- [ ] Add a row to the **`README.md` universal tools table** and update the tool count in the
+  "The plugin provides **N MCP tools**" sentence
+- [ ] Add a section to `USAGE.md` with a parameters table and a request/response example
+- [ ] Add one-line entry to the tool inventory in `CLAUDE.md`
+- [ ] Add tool name to `SKILL.md` trigger list (frontmatter description) and disabled-tools section,
+  both **in alphabetical order**
+- [ ] Add the tool to `src/main/resources/skill/ide-index-mcp/references/tools-reference.md`
+  (the bundled detailed parameter/return reference linked from SKILL.md)
+
+**Quick consistency check** — after adding the tool, grep its name across all six locations and
+confirm each has an entry: `README.md`, `USAGE.md`, `CLAUDE.md`, `SKILL.md`,
+`tools-reference.md`, `ToolNames.kt` / `McpSettings.kt` / `ToolRegistry.kt`, and tests.
+
+### Tests
+
+- [ ] Add unit tests in the appropriate `*UnitTest.kt` file:
+  - tool name matches the `ToolNames` constant
+  - required fields are present / absent as expected
+  - tool appears in `McpSettings.State.disabledTools`
+- [ ] Update `ConstantsUnitTest.testToolNamesAllContainsEveryConstant` — add the new constant
+  and verify `ToolNames.ALL.size` still matches
+- [ ] Update `ToolExecutionIntegrationTest.testAllToolsRegistered` — add the new constant
+  in the same alphabetical position as in `ToolNames.ALL`
+- [ ] For opt-in features with a toggle (e.g. `lifecycleEnabled`): tests that exercise
+  opt-in behaviour must enable the flag in `setUp()` and restore it in `tearDown()`
+
+### Test quality rules
+
+- Assertions must **actually fail** if the implementation is deleted (no vacuous tests)
+- Do not simulate the system under test with a private helper and then assert on the helper
+- Do not leave placeholder tests with comments referencing non-existent code
+- `McpServerWatchdogTest`-style tests (simulate stop-handler locally, assert on local simulation)
+  should be deleted; the real integration test (`KtorMcpServerWatchdogTest`) is the one that counts
+
+---
+
+## API compliance — the plugin verifier enforces these; CI fails if violated
+
+### Internal APIs
+
+- **NEVER** use `@ApiStatus.Internal` / `@Internal` classes or methods, even via reflection.
+  `getDeclaredField` on an internal class still references it and is flagged.
+- Use the public builder API: `OpenProjectTask.build().withForceOpenInNewFrame(true)`
+  not `getDeclaredField("forceOpenInNewFrame")`.
+- Cast-guarded access (`as? SomeInternalClass`) is still an internal reference.
+
+### Deprecated APIs
+
+- Use `ModalityState.nonModal()` — **not** `ModalityState.NON_MODAL` (deprecated field)
+- Use `ModalityState.any()` — **not** `ModalityState.ANY` (deprecated field)
+
+### Service registration
+
+- `@Service(Service.Level.APP)` on the class **and** `<applicationService>` in `plugin.xml`
+  is a duplicate — use one or the other, not both. The annotation alone is sufficient for
+  light services.
+- `@Storage` for services that persist machine-specific paths (absolute filesystem paths,
+  project root paths) **must** include `roamingType = RoamingType.DISABLED`.
+  Without it, Settings Sync will copy local paths to other machines.
+
+---
+
+## Threading — IntelliJ's threading model
+
+### The two locks
+
+- **Read lock** — required to access PSI. Acquire with `ReadAction.compute { }` or
+  `readAction { }`. Any background thread can acquire a read lock.
+- **Write lock** — required to modify PSI. Acquire with `WriteCommandAction.runWriteCommandAction`.
+  Must run on the EDT.
+
+### EDT rules
+
+| Operation | Thread | How |
+|-----------|--------|-----|
+| PSI read (search, navigate) | Any background thread | `ReadAction.compute { }` |
+| PSI write (rename, reformat) | EDT | `WriteCommandAction.runWriteCommandAction` |
+| UI updates, `DumbService.runWhenSmart` | EDT | `invokeLater` / `edtAction { }` |
+| `PowerSaveMode.setEnabled()` | EDT | `edtAction { }` |
+| `PowerSaveMode.isEnabled()` | Any | direct call |
+
+### Modal dialog safety
+
+`ModalityState.nonModal()` is the **safe default** for PSI, VFS, project-model, and
+write-action work. The IntelliJ SDK modality system exists precisely to prevent these
+operations from running while a modal dialog is waiting for user input — using
+`ModalityState.any()` here risks corrupting state the dialog depends on.
+
+`ModalityState.any()` is appropriate **only** for pure UI/status notifications where running
+during a modal is intentional and no PSI/VFS/project-model mutation occurs.
+
+If `nonModal()` blocks a long-running MCP wait (e.g. `DumbService.runWhenSmart` hanging
+because a modal dialog is open), the correct fix is a **timeout**, not a modality switch:
+
+```kotlin
+withTimeoutOrNull(120_000L) {
+    suspendCancellableCoroutine { continuation ->
+        ApplicationManager.getApplication().invokeLater({
+            DumbService.getInstance(project).runWhenSmart { continuation.resume(Unit) }
+        }, ModalityState.nonModal())
+    }
+}
+```
+
+If you need a modal-tolerant EDT helper for a specific case, create a distinctly named
+function (e.g. `uiNotifyAction { }`) and document explicitly that it must not mutate
+PSI, VFS, or the project model. Do not change the shared `edtAction { }` helper.
+
+### Concurrent collections
+
+Sets mutated from multiple threads (Ktor coroutines, Alarm callbacks, EDT) must use
+`ConcurrentHashMap.newKeySet()`, not `mutableSetOf()` (which is `LinkedHashSet` — not thread-safe).
+
+### Alarm lifecycle
+
+`Alarm.cancelAllRequests()` stops pending callbacks but does **not** free the `Alarm` object.
+On permanent project release or close, call `Disposer.dispose(alarm)` and remove it from any
+map it lives in. Abandoned `Alarm` objects accumulate silently.
+
+---
+
+## Error messages — make them actionable
+
+Every error a tool returns should tell the caller exactly what to do next.
+
+| Situation | Required guidance in error message |
+|-----------|----------------------------------|
+| IDE in dumb mode (indexing) | DO NOT fall back to bash/grep; call `ide_index_status` until `isDumbMode` is false; retry the same call |
+| Outdated stub in index (PSI cache stale) | Call `ide_sync_files`; retry |
+| Build system not linked in IDE | Explain how to link it (Maven/Gradle tool window → Import) |
+| Project not open | What to do to open it |
+
+Never return a raw Java stack trace as the error message. Catch known exception types
+and convert them to user-facing messages.
+
+---
+
+## Memory — avoid accumulation
+
+- **History result strings**: tool responses stored in `CommandHistoryService` must be
+  truncated before storage (current cap: 4 KB). `ide_find_references` on a popular class
+  can return 100 KB+; at 100 entries × 10 projects this becomes significant.
+- **Alarm objects**: dispose AND remove from maps on permanent release — do not only cancel.
+- **PSI references**: do not store `PsiElement`, `PsiFile`, or `VirtualFile` references
+  in long-lived services. They become invalid when projects close and prevent GC.
+
+---
+
+## Detecting linked build systems
+
+When a tool needs to know whether a project uses Maven or Gradle, check whether the
+build system is **actually linked in IntelliJ** — not just whether a build file exists on disk.
+
+```kotlin
+// Correct: checks IntelliJ's project model
+val linked = ProjectDataManager.getInstance().getExternalProjectsData(project, systemId)
+val isLinked = linked.isNotEmpty()
+
+// Wrong: only checks filesystem
+val hasPom = File(project.basePath ?: "", "pom.xml").exists()
+```
+
+If a build file exists but the project is not linked, tell the user how to link it rather
+than claiming success.
+
+---
+
+## Smoke test protocol
+
+After any `./gradlew buildPlugin` → install → restart cycle, run the smoke test at
+`docs/smoke-test-protocol.md` when changes touch:
+
+- HTTP transport (`KtorMcpServer.kt`, `JsonRpcHandler.kt`)
+- Tool registration (`ToolRegistry.kt`, `McpServerService.kt`)
+- Any tool covered by the protocol
+
+Skip for documentation-only, test-only, or version-bump changes.
+
+---
+
+## Project structure quick reference
+
+```
+src/main/kotlin/.../
+├── constants/          ToolNames.kt — all tool name constants + ALL list
+├── history/            Per-project command history (bounded ring buffer)
+├── lifecycle/          ProjectModeService, LifecycleEventLog, focus tracking
+├── server/             JsonRpcHandler, ProjectResolver, McpServerService, Ktor transport
+├── settings/           McpSettings (app-level persisted state)
+├── tools/
+│   ├── AbstractMcpTool.kt   — extend this, implement doExecute()
+│   ├── ToolRegistry.kt      — register new tools here
+│   ├── schema/SchemaBuilder.kt  — always use for inputSchema
+│   ├── editor/         ide_get_active_file, ide_open_file
+│   ├── intelligence/   ide_diagnostics
+│   ├── lifecycle/      lifecycle management tools
+│   ├── navigation/     ide_find_*, ide_search_text, ide_*_hierarchy
+│   ├── project/        ide_index_status, ide_sync_files, ide_build_project
+│   └── refactoring/    ide_refactor_*, ide_reformat_code
+└── util/               Threading helpers, PSI utilities
+```
+
+---
+
+## Adding dependencies
+
+1. Add version to `gradle/libs.versions.toml`
+2. Reference in `build.gradle.kts` via `libs.<name>`
+3. If the dependency conflicts with IntelliJ's bundled coroutines or slf4j,
+   add `exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")`
+   (see existing Ktor entries for the pattern)

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# check-pr.sh — pre-push validation against CONTRIBUTING.md rules.
+# Run before every push. Exits non-zero if any check fails.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  ✓ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+hdr()  { echo ""; echo "── $1"; }
+
+# ── 1. CHANGELOG ────────────────────────────────────────────────────────────
+hdr "CHANGELOG.md"
+
+if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
+    # [Unreleased] must be empty (just a blank line before the next ## section)
+    UNRELEASED_CONTENT=$(awk '/^## \[Unreleased\]/{found=1; next} found && /^## /{exit} found{print}' CHANGELOG.md | grep -v '^$' || true)
+    if [ -z "$UNRELEASED_CONTENT" ]; then
+        ok "[Unreleased] section is empty"
+    else
+        fail "[Unreleased] has content — maintainer adds release entries, not contributors"
+    fi
+else
+    fail "Missing ## [Unreleased] section"
+fi
+
+# ── 2. Forbidden files ───────────────────────────────────────────────────────
+hdr "Forbidden files"
+
+UPSTREAM_BASE=$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || echo "")
+if [ -n "$UPSTREAM_BASE" ]; then
+    CHANGED=$(git diff --name-only "$UPSTREAM_BASE" HEAD)
+    if echo "$CHANGED" | grep -q "^\.idea/gradle\.xml$"; then
+        fail ".idea/gradle.xml is included — contains local JDK path, must not be in PRs"
+    else
+        ok ".idea/gradle.xml not included"
+    fi
+    if echo "$CHANGED" | grep -q "^scripts/build-install\.sh$"; then
+        fail "scripts/build-install.sh is included — local helper, must not be in PRs"
+    else
+        ok "scripts/build-install.sh not included"
+    fi
+    if echo "$CHANGED" | grep -qE "^docs/pr-.+\.md$"; then
+        fail "docs/pr-*.md file included — rename to remove pr- prefix before submitting"
+    else
+        ok "No docs/pr-*.md files"
+    fi
+else
+    echo "  ? Could not determine upstream base — skipping forbidden-files check"
+fi
+
+# ── 3. Deprecated / internal API ─────────────────────────────────────────────
+hdr "API compliance"
+
+if git diff "${UPSTREAM_BASE:-HEAD~1}" HEAD -- src/main/ 2>/dev/null | grep -q "NON_MODAL\b"; then
+    fail "ModalityState.NON_MODAL found — use ModalityState.nonModal()"
+else
+    ok "No deprecated ModalityState.NON_MODAL"
+fi
+
+if git diff "${UPSTREAM_BASE:-HEAD~1}" HEAD -- src/main/ 2>/dev/null | grep -q "getDeclaredField\|isAccessible = true"; then
+    fail "Reflection on private fields detected — likely internal API usage; use public builder APIs"
+else
+    ok "No reflection on private fields"
+fi
+
+# ── 4. ToolNames.ALL sorted ──────────────────────────────────────────────────
+hdr "ToolNames.ALL sort order"
+
+TOOLNAMES="src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt"
+if [ -f "$TOOLNAMES" ]; then
+    python3 - <<'PYEOF'
+import re, sys
+content = open("src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt").read()
+vals = {m.group(1): m.group(2) for m in re.finditer(r'const val (\w+) = "(ide_\w+)"', content)}
+m = re.search(r'val ALL.*?=.*?listOf\((.*?)\)', content, re.DOTALL)
+if m:
+    names = [n.strip() for n in m.group(1).split(',') if n.strip()]
+    resolved = [vals.get(n, '???' + n) for n in names]
+    if resolved == sorted(resolved):
+        print("  ✓ ToolNames.ALL is sorted")
+        sys.exit(0)
+    else:
+        for i, (a, b) in enumerate(zip(resolved, sorted(resolved))):
+            if a != b:
+                print(f"  ✗ ToolNames.ALL out of order at position {i}: has '{a}', expected '{b}'")
+                break
+        sys.exit(1)
+PYEOF
+    [ $? -eq 0 ] && PASS=$((PASS+1)) || FAIL=$((FAIL+1))
+else
+    echo "  ? ToolNames.kt not found — skipping sort check"
+fi
+
+# ── 5. New tools in disabledTools ────────────────────────────────────────────
+hdr "New tools disabled by default"
+
+if [ -n "$UPSTREAM_BASE" ]; then
+    NEW_TOOLS=$(git diff "$UPSTREAM_BASE" HEAD -- src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt 2>/dev/null \
+        | grep '^+.*const val.*= "ide_' | grep -oE '"ide_[^"]+"' | tr -d '"' || true)
+    DISABLED=$(grep -oE '"ide_[^"]+"' src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt | tr -d '"' || true)
+    for tool in $NEW_TOOLS; do
+        if echo "$DISABLED" | grep -q "^${tool}$"; then
+            ok "$tool is in disabledTools"
+        else
+            fail "$tool is NOT in McpSettings.disabledTools — all new tools must be opt-in"
+        fi
+    done
+    [ -z "$NEW_TOOLS" ] && ok "No new tools added (or none detected)"
+fi
+
+# ── 6. Unit tests ────────────────────────────────────────────────────────────
+hdr "Unit tests"
+
+echo "  Running ./gradlew test --tests \"*UnitTest*\" ..."
+if ./gradlew test --tests "*UnitTest*" 2>&1 | grep -q "BUILD SUCCESSFUL"; then
+    ok "Unit tests pass"
+else
+    fail "Unit tests FAILED — fix before pushing"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────"
+echo "  Passed: $PASS  Failed: $FAIL"
+echo "────────────────────────────────"
+if [ "$FAIL" -gt 0 ]; then
+    echo "Fix the failures above before pushing. See CONTRIBUTING.md for details."
+    exit 1
+else
+    echo "All checks passed."
+fi


### PR DESCRIPTION
## Summary

- Extracts and expands all contributing guidance scattered across `CLAUDE.md` and `README.md` into a single `CONTRIBUTING.md`
- Written to be followed precisely by both human and LLM contributors
- `CLAUDE.md` contributing section replaced with a short summary + link

## What's covered

The new document consolidates and extends existing guidance with lessons from PR reviews:

- **PR rules**: CHANGELOG format, forbidden files (`.idea/gradle.xml`, local scripts), version bumps
- **New tool checklist**: implementation, registration, documentation, and test requirements — all in one place
- **API compliance**: no `@Internal` APIs (even via reflection), no deprecated `ModalityState` fields, service registration rules, `RoamingType.DISABLED` for machine-specific storage
- **Threading model**: EDT rules table, modal dialog safety (`ModalityState.any()` vs `nonModal()`), concurrent collections, Alarm lifecycle (dispose + remove, not just cancel)
- **Actionable error messages**: table of what guidance each error type must include
- **Memory guidelines**: history truncation, alarm disposal, no PSI references in long-lived services
- **Build system detection**: `ProjectDataManager` not filesystem checks
- **Test quality**: no vacuous tests, opt-in flag handling in setUp/tearDown

## Test plan

- [ ] Read through for accuracy and completeness
- [ ] Verify no guidance contradicts existing merged PRs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)