### PR TITLE
feat: add ide_import_modules — cross-project refactoring via module import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+- **`ide_import_modules`** — import external project directories as Maven modules into the current IntelliJ window for cross-project code intelligence and refactoring. Only available when the Maven plugin is installed. *(disabled by default)*
+
+### Changed
+- Disabled tools are now rejected at `tools/call` time with a clear error message, not just hidden from `tools/list`.
 
 ## [4.24.0] - 2026-06-25
 ### Added

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
@@ -22,6 +22,7 @@ object ToolNames {
     const val INDEX_STATUS = "ide_index_status"
     const val SYNC_FILES = "ide_sync_files"
     const val BUILD_PROJECT = "ide_build_project"
+    const val IMPORT_MODULES = "ide_import_modules"
     const val RELOAD_PROJECT = "ide_reload_project"
 
     // Refactoring tools
@@ -76,6 +77,7 @@ object ToolNames {
         FIND_SYMBOL,
         GET_ACTIVE_FILE,
         GET_PROJECT_MODES,
+        IMPORT_MODULES,
         INDEX_STATUS,
         INSTALL_PLUGIN,
         LIFECYCLE_LOG,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/JsonRpcHandler.kt
@@ -9,6 +9,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandHistoryServ
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandStatus
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.exceptions.IndexNotReadyException
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.*
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -187,6 +188,14 @@ class JsonRpcHandler @JvmOverloads constructor(
 
         val tool = toolRegistry.getTool(toolName)
             ?: return createErrorResponse(request.id, JsonRpcErrorCodes.METHOD_NOT_FOUND, ErrorMessages.toolNotFound(toolName))
+
+        if (!McpSettings.getInstance().isToolEnabled(toolName)) {
+            return createErrorResponse(
+                request.id,
+                JsonRpcErrorCodes.INVALID_PARAMS,
+                "Tool '$toolName' is disabled. Enable it in Settings → Index MCP Server → Available Tools."
+            )
+        }
 
         val projectResult = projectResolver.resolveOrOpen(projectPath)
         if (projectResult.isError) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -35,7 +35,8 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
         var availableProjectsMode: AvailableProjectsMode = AvailableProjectsMode.EXPANDED,
         var responseFormat: ResponseFormat = ResponseFormat.JSON,
         var disabledTools: MutableSet<String> = mutableSetOf(
-            "ide_build_project", "ide_close_project", "ide_reload_project", "ide_file_structure", "ide_find_symbol",
+            "ide_build_project", "ide_close_project", "ide_import_modules", "ide_reload_project",
+            "ide_file_structure", "ide_find_symbol",
             "ide_open_project", "ide_read_file", "ide_get_active_file", "ide_open_file",
             "ide_reformat_code", "ide_optimize_imports", "ide_convert_java_to_kotlin",
             "ide_set_power_save_mode", "ide_install_plugin", "ide_restart",

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -27,6 +27,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProject
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.ReloadProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CloseProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.ImportModulesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.InstallPluginTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.OpenProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.RestartIdeTool
@@ -251,6 +252,9 @@ class ToolRegistry {
         register(SyncFilesTool())
         register(BuildProjectTool())
         register(ReloadProjectTool())
+        if (PluginDetectors.maven.isAvailable) {
+            register(ImportModulesTool())
+        }
         register(InstallPluginTool())
         register(RestartIdeTool())
         register(SetPowerSaveModeTool())

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/ImportModulesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/ImportModulesTool.kt
@@ -1,0 +1,149 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.models.ToolCallResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+
+class ImportModulesTool : AbstractMcpTool() {
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_import_modules"
+
+    override val description = """
+        Import one or more external project directories as modules into the current
+        IntelliJ project window, enabling cross-project code intelligence and refactoring.
+
+        Use this when you need to refactor across multiple repos that share a parent POM
+        or have cross-project dependencies. After importing, ide_find_references,
+        ide_refactor_rename, ide_move_file and other tools will work across all imported
+        modules as if they were part of one project.
+
+        Equivalent to File → New → Module from Existing Sources, repeated for each path.
+
+        Each path must be an absolute directory path containing a pom.xml. Paths that are
+        already imported as modules are skipped. The import triggers a Maven project reload
+        so dependencies are resolved across all modules.
+
+        Parameters:
+        - paths (required): array of absolute directory paths to import as modules
+        - project_path (optional): selects which IntelliJ project window to import into
+
+        Example: { "paths": ["/Users/dev/casehub/drafthouse", "/Users/dev/casehub/worker"] }
+    """.trimIndent()
+
+    override val inputSchema: JsonObject = SchemaBuilder.tool()
+        .property("paths", kotlinx.serialization.json.buildJsonObject {
+            put("type", kotlinx.serialization.json.JsonPrimitive("array"))
+            put("description", kotlinx.serialization.json.JsonPrimitive(
+                "Absolute directory paths to import as modules into the current project window."
+            ))
+            put("items", kotlinx.serialization.json.buildJsonObject {
+                put("type", kotlinx.serialization.json.JsonPrimitive("string"))
+            })
+        }, required = true)
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): ToolCallResult {
+        val pathsJson = arguments["paths"]?.jsonArray
+            ?: return createErrorResult("Missing required parameter: paths (array of directory paths)")
+
+        if (pathsJson.isEmpty()) {
+            return createErrorResult("paths array is empty — provide at least one directory path to import.")
+        }
+
+        val paths = pathsJson.map { it.jsonPrimitive.content }
+
+        for (path in paths) {
+            if (!File(path).isAbsolute) return createErrorResult("Path must be absolute: $path")
+            val dir = File(path)
+            if (!dir.exists()) return createErrorResult("Path does not exist: $path")
+            if (!dir.isDirectory) return createErrorResult("Path is not a directory: $path")
+            if (!File(dir, "pom.xml").exists()) {
+                return createErrorResult("No pom.xml found in $path — only Maven projects are supported.")
+            }
+        }
+
+        val existingRoots = ProjectUtils.getModuleContentRoots(project).map { it.trimEnd('/') }.toSet()
+
+        val imported = mutableListOf<String>()
+        val skipped = mutableListOf<String>()
+        val failed = mutableListOf<String>()
+
+        for (path in paths) {
+            if (existingRoots.any { it == path.trimEnd('/') }) {
+                skipped.add("$path: already imported as a module")
+                continue
+            }
+            val dirVf = LocalFileSystem.getInstance().refreshAndFindFileByPath(path)
+            if (dirVf == null) {
+                failed.add("$path: could not resolve directory in VFS")
+                continue
+            }
+            try {
+                val modules = linkMavenProject(project, dirVf)
+                if (modules != null) {
+                    imported.add(path)
+                } else {
+                    failed.add("$path: Maven plugin not available — is it enabled?")
+                }
+            } catch (e: Exception) {
+                val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
+                failed.add("$path: ${cause.message}")
+            }
+        }
+
+        val lines = mutableListOf<String>()
+        if (imported.isNotEmpty()) {
+            lines.add("Imported ${imported.size} module(s):")
+            imported.forEach { lines.add("  + $it") }
+        }
+        if (skipped.isNotEmpty()) {
+            if (lines.isNotEmpty()) lines.add("")
+            lines.add("Skipped ${skipped.size}:")
+            skipped.forEach { lines.add("  - $it") }
+        }
+        if (failed.isNotEmpty()) {
+            if (lines.isNotEmpty()) lines.add("")
+            lines.add("Failed ${failed.size}:")
+            failed.forEach { lines.add("  ! $it") }
+        }
+
+        return if (imported.isEmpty() && failed.isNotEmpty()) {
+            createErrorResult(lines.joinToString("\n"))
+        } else {
+            createSuccessResult(lines.joinToString("\n"))
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun linkMavenProject(project: Project, directoryVf: VirtualFile): List<Module>? {
+        val builderClass = try {
+            Class.forName("org.jetbrains.idea.maven.wizards.MavenProjectAsyncBuilder")
+        } catch (_: ClassNotFoundException) {
+            return null
+        }
+        val providerClass = Class.forName(
+            "com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider"
+        )
+        val builder = builderClass.getDeclaredConstructor().newInstance()
+        val commitSync = builderClass.getMethod(
+            "commitSync",
+            Project::class.java,
+            VirtualFile::class.java,
+            providerClass
+        )
+        return commitSync.invoke(builder, project, directoryVf, null) as List<Module>
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PluginDetectors.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PluginDetectors.kt
@@ -48,4 +48,10 @@ object PluginDetectors {
         pluginIds = listOf("org.jetbrains.kotlin"),
         fallbackClass = "org.jetbrains.kotlin.psi.KtFile"
     )
+
+    val maven = PluginDetector(
+        name = "Maven",
+        pluginIds = listOf("org.jetbrains.idea.maven"),
+        fallbackClass = "org.jetbrains.idea.maven.project.MavenProjectsManager"
+    )
 }

--- a/src/main/resources/META-INF/maven-features.xml
+++ b/src/main/resources/META-INF/maven-features.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+    <!-- Maven-specific extensions can be added here if needed in the future -->
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -132,6 +132,9 @@ for detailed documentation and examples.</p>
     <!-- Optional Markdown support (bundled Markdown plugin) -->
     <depends optional="true" config-file="markdown-features.xml">org.intellij.plugins.markdown</depends>
 
+    <!-- Optional Maven support (bundled in IntelliJ IDEA, used by ide_import_modules) -->
+    <depends optional="true" config-file="maven-features.xml">org.jetbrains.idea.maven</depends>
+
     <resource-bundle>messages.McpBundle</resource-bundle>
 
     <!-- Declare Kotlin K1/K2 plugin mode compatibility -->

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
@@ -61,6 +61,7 @@ class ConstantsUnitTest : TestCase() {
             ToolNames.INDEX_STATUS,
             ToolNames.SYNC_FILES,
             ToolNames.BUILD_PROJECT,
+            ToolNames.IMPORT_MODULES,
             ToolNames.REFACTOR_RENAME,
             ToolNames.REFACTOR_SAFE_DELETE,
             ToolNames.REFACTOR_MOVE,

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ProjectWindowToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ProjectWindowToolsUnitTest.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CloseProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.ImportModulesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.OpenProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.ReloadProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.SetPowerSaveModeTool
@@ -95,5 +96,24 @@ class ProjectWindowToolsUnitTest : TestCase() {
     fun testReloadProjectToolIsDisabledByDefault() {
         val defaults = McpSettings.State().disabledTools
         assertTrue("ide_reload_project must be opt-in by default", defaults.contains(ToolNames.RELOAD_PROJECT))
+    }
+
+    fun testImportModulesToolName() {
+        assertEquals(ToolNames.IMPORT_MODULES, ImportModulesTool().name)
+    }
+
+    fun testImportModulesToolRequiresPaths() {
+        val required = ImportModulesTool().inputSchema["required"]?.jsonArray
+        assertNotNull("schema must have required fields", required)
+        assertTrue("paths must be required", required!!.any { it.jsonPrimitive.content == "paths" })
+    }
+
+    fun testImportModulesToolIsDisabledByDefault() {
+        val defaults = McpSettings.State().disabledTools
+        assertTrue("ide_import_modules must be opt-in by default", defaults.contains(ToolNames.IMPORT_MODULES))
+    }
+
+    fun testImportModulesToolNameInAll() {
+        assertTrue("IMPORT_MODULES must be in ToolNames.ALL", ToolNames.ALL.contains(ToolNames.IMPORT_MODULES))
     }
 }


### PR DESCRIPTION
## Summary

Adds `ide_import_modules` — a tool that imports external project directories as Maven modules into the current IntelliJ project window, enabling cross-project code intelligence and refactoring.

## Problem

When AI agents need to refactor across multiple repos (e.g., move code from `casehub/drafthouse` into `casehub/qhorus`), IntelliJ needs all repos visible in a single project window. Currently each repo opens in its own window with its own index — `ide_find_references` and `ide_refactor_rename` don't work across separate windows.

## What it does

- Accepts an array of absolute directory paths (each must contain a `pom.xml`)
- Imports via `MavenProjectAsyncBuilder.commitSync()` — the same synchronous code path as **File → New → Module from Existing Sources**
- Paths already imported as modules are skipped (detected via `ModuleManager` content roots)
- Returns a per-path summary: imported / skipped / failed
- Disabled by default (enable in Settings → Index MCP Server)
- Only registered when Maven plugin is available (optional plugin dependency declared)

### Implementation details

- **Optional Maven dependency**: `plugin.xml` declares `<depends optional="true">org.jetbrains.idea.maven</depends>`, and `PluginDetectors.maven` gates tool registration
- **Single source of truth**: `commitSync()` is synchronous — "Imported" status is accurate when returned
- **VFS-safe**: uses `refreshAndFindFileByPath()` so freshly cloned repos resolve correctly
- **Disabled-tool enforcement**: `JsonRpcHandler.processToolCall()` now rejects disabled tools at `tools/call` time (general fix, not import-specific)

## Example

```json
{
  "name": "ide_import_modules",
  "arguments": {
    "paths": ["/Users/dev/casehub/drafthouse", "/Users/dev/casehub/worker"],
    "project_path": "/Users/dev/casehub/qhorus"
  }
}
```

## Test plan

- [x] Unit tests: tool name, paths required, disabled by default, constant in ALL
- [x] `check-pr.sh` passes (10/10)
- [x] Manual: import engine into platform, `ide_find_class ReadOnlyPanelException` returns engine class from platform scope
- [x] Manual: `ide_find_class CaseContext` returns 8 classes across engine submodules
- [x] Manual: engine does NOT open as a separate project window (verified via `ide_project_status`)
- [x] Manual: call again with same path → reports "already imported"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)