### PR TITLE
Fix find references position lookup with stray language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Treat lone `language` or `symbol` placeholders as position-mode noise when `ide_find_references` receives a complete file/line/column target.
+
 ## [4.23.2] - 2026-06-14
 ### Fixed
 - Build failures that only report compiler output now return diagnostics instead of an empty error list when possible.

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -505,18 +505,25 @@ abstract class AbstractMcpTool : McpTool {
     /**
      * Resolves whether arguments represent position lookup, symbol lookup, conflict, or missing mode.
      * Blank string fields do not count as present.
+     * A symbol-mode intent requires both `language` and `symbol`; a lone optional field can be a
+     * client/schema placeholder and must not conflict with a complete position lookup.
      */
     protected fun resolveLookupMode(arguments: JsonObject): LookupModeState {
-        val hasSymbol = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
-            optionalStringArg(arguments, ParamNames.SYMBOL) != null
-        val hasPosition = optionalStringArg(arguments, ParamNames.FILE) != null ||
-            arguments[ParamNames.LINE]?.jsonPrimitive?.int != null ||
-            arguments[ParamNames.COLUMN]?.jsonPrimitive?.int != null
+        val hasLanguage = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
+        val hasSymbol = optionalStringArg(arguments, ParamNames.SYMBOL) != null
+        val hasAnySymbol = hasLanguage || hasSymbol
+        val hasCompleteSymbol = hasLanguage && hasSymbol
+        val hasFile = optionalStringArg(arguments, ParamNames.FILE) != null
+        val hasLine = arguments[ParamNames.LINE]?.jsonPrimitive?.int != null
+        val hasColumn = arguments[ParamNames.COLUMN]?.jsonPrimitive?.int != null
+        val hasAnyPosition = hasFile || hasLine || hasColumn
+        val hasCompletePosition = hasFile && hasLine && hasColumn
 
         return when {
-            hasSymbol && hasPosition -> LookupModeState.CONFLICT
-            hasSymbol -> LookupModeState.SYMBOL
-            hasPosition -> LookupModeState.POSITION
+            hasCompleteSymbol && hasAnyPosition -> LookupModeState.CONFLICT
+            hasCompletePosition -> LookupModeState.POSITION
+            hasAnySymbol -> LookupModeState.SYMBOL
+            hasAnyPosition -> LookupModeState.POSITION
             else -> LookupModeState.MISSING
         }
     }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpToolArgumentNormalizationUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpToolArgumentNormalizationUnitTest.kt
@@ -87,6 +87,42 @@ class AbstractMcpToolArgumentNormalizationUnitTest : TestCase() {
         )
     }
 
+    fun testLoneLanguageWithCompletePositionUsesPositionMode() {
+        val arguments = buildJsonObject {
+            put("file", JsonPrimitive("src/Main.kt"))
+            put("line", JsonPrimitive(12))
+            put("column", JsonPrimitive(5))
+            put("language", JsonPrimitive("Java"))
+        }
+
+        assertEquals("POSITION", tool.lookupModeNameForTest(arguments))
+    }
+
+    fun testLoneSymbolWithCompletePositionUsesPositionMode() {
+        val arguments = buildJsonObject {
+            put("file", JsonPrimitive("src/Main.kt"))
+            put("line", JsonPrimitive(12))
+            put("column", JsonPrimitive(5))
+            put("symbol", JsonPrimitive("com.example.Main#run()"))
+        }
+
+        assertEquals("POSITION", tool.lookupModeNameForTest(arguments))
+    }
+
+    fun testLoneLanguageWithoutCompletePositionStillRequiresSymbol() {
+        val arguments = buildJsonObject {
+            put("language", JsonPrimitive("Java"))
+        }
+
+        val result = tool.resolveElementForTest(project, arguments)
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            ErrorMessages.missingParamForSymbol("symbol"),
+            result.exceptionOrNull()?.message
+        )
+    }
+
     private fun invokeOptionalStringArg(arguments: JsonObject, name: String): String? {
         val method = findMethod("optionalStringArg")
         return method.invoke(tool, arguments, name) as String?
@@ -122,6 +158,10 @@ class AbstractMcpToolArgumentNormalizationUnitTest : TestCase() {
 
         fun requiredStringForTest(arguments: JsonObject, name: String): Result<String> {
             return requiredStringArg(arguments, name)
+        }
+
+        fun lookupModeNameForTest(arguments: JsonObject): String {
+            return resolveLookupMode(arguments).name
         }
     }
 }


### PR DESCRIPTION
Fixes #222.

- Treat incomplete symbol args as placeholders when file/line/column is complete.
- Keep full symbol+position XOR conflict.
- Add lookup-mode regression coverage.

Test: `./gradlew test --tests com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpToolArgumentNormalizationUnitTest`