### PR TITLE
feat(python): add PythonSymbolReferenceHandler for symbol-based find_definition/find_references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+- **Python symbol reference resolution** — `ide_find_definition` and `ide_find_references` now accept the `symbol` + `language` (="Python") entry point, not just `file`/`line`/`column`. A new `PythonSymbolReferenceHandler` resolves fully-qualified Python symbols (`pkg.mod.ClassName`, `pkg.mod.function_name`, `pkg.mod.ClassName.method_name`, `pkg.mod.ClassName#attribute`) to PSI elements via `PyClassNameIndex`/`PyFunctionNameIndex`, so "Python" now appears in the `language` enum for these tools.
 
 ## [4.25.0] - 2026-06-27
 ### Added

--- a/USAGE.md
+++ b/USAGE.md
@@ -161,7 +161,15 @@ Some tools support identifying the target element by fully qualified symbol refe
 
 **Important:** The two parameter groups are **mutually exclusive** — provide either `file` + `line` + `column` OR `language` + `symbol`, not both.
 
-**Supported languages:** Java, JS, and TS. Unsupported languages return an explicit error listing the currently supported symbol-reference languages.
+**Supported languages:** Java, JS, TS, and Python. Unsupported languages return an explicit error listing the currently supported symbol-reference languages.
+
+**Python symbol grammar:** Symbols must be module-qualified (dotted path with ≥2 segments):
+- `pkg.mod.ClassName` — class
+- `pkg.mod.function_name` — module-level function
+- `pkg.mod.ClassName.method_name` — method (resolved via the function index; a method's qualified name is `pkg.mod.ClassName.method`)
+- `pkg.mod.ClassName#member_name` — method, class/instance attribute, or `@property` of the named class
+
+Parameter lists are not supported (Python has no overload-by-signature); bare unqualified names are rejected — use `file` + `line` + `column` for those.
 
 **JS/TS symbol grammar (v1):** Symbols must be module-qualified:
 - `modulePath#exportName` — named export (e.g., `src/utils#formatDate`)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
@@ -1066,8 +1066,8 @@ class PythonStructureHandler : BasePythonHandler<List<StructureNode>>(), Structu
  * Python plugin, mirroring the rest of [PythonHandlers].
  */
 class PythonSymbolReferenceHandler(
-    private val findClassByQName: (String, Project) -> PsiNamedElement? = { q, p -> defaultFindClassByQName(q, p) },
-    private val findFunctionsByShortName: (String, Project) -> Collection<PsiNamedElement> = { s, p -> defaultFindFunctionsByShortName(s, p) },
+    private val findClassByQName: (String, Project) -> List<PsiNamedElement> = { q, p -> defaultFindClassByQName(q, p) },
+    private val findFunctionsByShortName: (String, Project) -> List<PsiNamedElement> = { s, p -> defaultFindFunctionsByShortName(s, p) },
     private val findAttributeInClass: (PsiElement, String) -> PsiNamedElement? = { c, n -> defaultFindAttributeInClass(c, n) }
 ) : BasePythonHandler<PsiNamedElement>(), SymbolReferenceHandler {
 
@@ -1086,25 +1086,32 @@ class PythonSymbolReferenceHandler(
             "'pkg.mod.ClassName#attribute_name'"
         )
 
-        // Reflective default: PyClassNameIndex.findByQualifiedName(qName, project, allScope) -> List<PyClass>.
-        // The old findClass(qName, project) was removed (PY-63989); current API filters by qualified name.
-        // Falls back to find(shortName, project, allScope) + getQualifiedName filter if findByQualifiedName is absent.
-        private fun defaultFindClassByQName(qName: String, project: Project): PsiNamedElement? {
-            val indexClass = pythonClassNameIndexClass ?: return null
-            val scope = allScope(project) ?: return null
-            return try {
-                val byQName = indexClass.getMethod(
-                    "findByQualifiedName", String::class.java, Project::class.java, GlobalSearchScope::class.java
-                )
-                ((byQName.invoke(null, qName, project, scope) as? Collection<*>)?.filterIsInstance<PsiNamedElement>()
-                    ?: runFindByShortNameAndFilter(indexClass, qName, project, scope))
-                    .firstOrNull()
-            } catch (e: NoSuchMethodException) {
-                runFindByShortNameAndFilter(indexClass, qName, project, scope).firstOrNull()
-            } catch (e: Exception) {
-                LOG.warn("PyClassNameIndex lookup failed for '$qName': ${e.message}")
-                null
-            }
+        // Reflective default: PyClassNameIndex.findByQualifiedName(qName, project, scope) -> List<PyClass>.
+        // The old findClass(qName, project) was removed (PY-63989). Project scope is searched first so a
+        // project symbol wins over a dependency/SDK/stub with the same qualified path; allScope is the fallback.
+        // Returns ALL matches (project hits first, then allScope-only hits) so the caller can report ambiguity.
+        private fun defaultFindClassByQName(qName: String, project: Project): List<PsiNamedElement> {
+            val indexClass = pythonClassNameIndexClass ?: return emptyList()
+            val projectScope = projectScope(project) ?: return emptyList()
+            val allScope = allScope(project) ?: return emptyList()
+            val projectHits = findByQualifiedNameReflective(indexClass, qName, project, projectScope)
+            if (projectHits.isNotEmpty()) return projectHits
+            return findByQualifiedNameReflective(indexClass, qName, project, allScope)
+        }
+
+        private fun findByQualifiedNameReflective(
+            indexClass: Class<*>, qName: String, project: Project, scope: GlobalSearchScope
+        ): List<PsiNamedElement> = try {
+            val byQName = indexClass.getMethod(
+                "findByQualifiedName", String::class.java, Project::class.java, GlobalSearchScope::class.java
+            )
+            ((byQName.invoke(null, qName, project, scope) as? Collection<*>)?.filterIsInstance<PsiNamedElement>()
+                ?: runFindByShortNameAndFilter(indexClass, qName, project, scope))
+        } catch (e: NoSuchMethodException) {
+            runFindByShortNameAndFilter(indexClass, qName, project, scope)
+        } catch (e: Exception) {
+            LOG.warn("PyClassNameIndex lookup failed for '$qName': ${e.message}")
+            emptyList()
         }
 
         private fun runFindByShortNameAndFilter(
@@ -1118,33 +1125,70 @@ class PythonSymbolReferenceHandler(
             emptyList()
         }
 
-        // Reflective default: PyFunctionNameIndex.find(shortName, project, allScope) -> Collection<PyFunction> (3-arg).
-        private fun defaultFindFunctionsByShortName(shortName: String, project: Project): Collection<PsiNamedElement> {
+        // Reflective default: PyFunctionNameIndex.find(shortName, project, scope) -> Collection<PyFunction> (3-arg),
+        // filtered by getQualifiedName() == qName is done by the caller. Project scope first, allScope fallback,
+        // so a project function wins over a dependency/stub with the same qualified path.
+        private fun defaultFindFunctionsByShortName(shortName: String, project: Project): List<PsiNamedElement> {
             val indexClass = pythonFunctionNameIndexClass ?: return emptyList()
-            val scope = allScope(project) ?: return emptyList()
-            return try {
-                val method = indexClass.getMethod("find", String::class.java, Project::class.java, GlobalSearchScope::class.java)
-                (method.invoke(null, shortName, project, scope) as? Collection<*>).orEmpty()
-                    .filterIsInstance<PsiNamedElement>()
-            } catch (e: NoSuchMethodException) {
-                emptyList()
-            } catch (e: Exception) {
-                LOG.warn("PyFunctionNameIndex.find failed for '$shortName': ${e.message}")
-                emptyList()
-            }
+            val projectScope = projectScope(project) ?: return emptyList()
+            val projectHits = findFunctionsByShortNameReflective(indexClass, shortName, project, projectScope)
+            if (projectHits.isNotEmpty()) return projectHits
+            val allScope = allScope(project) ?: return emptyList()
+            return findFunctionsByShortNameReflective(indexClass, shortName, project, allScope)
         }
 
-        // Reflective default: PyClass members reachable as `Class#name`.
-        // Order: method (findMethodByName, handled by BasePythonHandler.findMethodInClass upstream),
+        private fun findFunctionsByShortNameReflective(
+            indexClass: Class<*>, shortName: String, project: Project, scope: GlobalSearchScope
+        ): List<PsiNamedElement> = try {
+            val method = indexClass.getMethod("find", String::class.java, Project::class.java, GlobalSearchScope::class.java)
+            (method.invoke(null, shortName, project, scope) as? Collection<*>).orEmpty()
+                .filterIsInstance<PsiNamedElement>()
+        } catch (e: NoSuchMethodException) {
+            emptyList()
+        } catch (e: Exception) {
+            LOG.warn("PyFunctionNameIndex.find failed for '$shortName': ${e.message}")
+            emptyList()
+        }
+
+        // Reflective default: PyClass members reachable as `Class#name`, following inheritance (inherited=true).
+        // Order: method (findMethodByName(..., true, context), then multiFindMethodByName(..., true, ...) fallback),
         // class attribute findClassAttribute(String, boolean, TypeEvalContext),
-        // instance attribute findInstanceAttribute(String, boolean) [note: 2-arg, no TypeEvalContext],
-        // @property findProperty(String, boolean, TypeEvalContext) -> Property.getGetter().
+        // instance attribute findInstanceAttribute(String, boolean) [2-arg, no TypeEvalContext],
+        // @property findProperty(String, boolean, TypeEvalContext) -> Property.getGetter() -> Maybe<PyCallable>.valueOrNull(),
+        // nested class findNestedClass(String, boolean).
         private fun defaultFindAttributeInClass(pyClass: PsiElement, name: String): PsiNamedElement? {
             val context = codeAnalysisContextFallback(pyClass.project)
+            findMethodInClassInherited(pyClass, name, context)?.let { return it }
             findClassAttributeReflective(pyClass, name, context)?.let { return it }
             findInstanceAttributeReflective(pyClass, name)?.let { return it }
             findPropertyReflective(pyClass, name, context)?.let { return it }
+            findNestedClassReflective(pyClass, name)?.let { return it }
             return null
+        }
+
+        // Methods with inheritance. BasePythonHandler.findMethodInClass hardcodes inherited=false, which would miss
+        // members declared on a superclass, so this handler resolves methods itself with inherited=true.
+        private fun findMethodInClassInherited(pyClass: PsiElement, name: String, context: Any?): PsiNamedElement? {
+            val contextClass = pythonTypeEvalContextClass ?: return null
+            return try {
+                val method = pyClass.javaClass.getMethod("findMethodByName", String::class.java, java.lang.Boolean.TYPE, contextClass)
+                method.invoke(pyClass, name, true, context) as? PsiNamedElement
+            } catch (e: NoSuchMethodException) {
+                multiFindMethodByNameReflective(pyClass, name, context)
+            } catch (e: Exception) {
+                multiFindMethodByNameReflective(pyClass, name, context)
+            }
+        }
+
+        private fun multiFindMethodByNameReflective(pyClass: PsiElement, name: String, context: Any?): PsiNamedElement? {
+            val contextClass = pythonTypeEvalContextClass ?: return null
+            return try {
+                val method = pyClass.javaClass.getMethod("multiFindMethodByName", String::class.java, java.lang.Boolean.TYPE, contextClass)
+                @Suppress("UNCHECKED_CAST")
+                (method.invoke(pyClass, name, true, context) as? List<*>)?.firstOrNull() as? PsiNamedElement
+            } catch (e: Exception) {
+                null
+            }
         }
 
         private fun findClassAttributeReflective(pyClass: PsiElement, name: String, context: Any?): PsiNamedElement? {
@@ -1175,13 +1219,32 @@ class PythonSymbolReferenceHandler(
             return try {
                 val method = pyClass.javaClass.getMethod("findProperty", String::class.java, java.lang.Boolean.TYPE, contextClass)
                 val property = method.invoke(pyClass, name, true, context) ?: return null
-                val getter = property.javaClass.getMethod("getGetter").invoke(property) ?: return null
+                // Property.getGetter() returns com.jetbrains.python.toolbox.Maybe<PyCallable>; unwrap via valueOrNull().
+                val maybe = property.javaClass.getMethod("getGetter").invoke(property) ?: return null
+                val getter = maybe.javaClass.getMethod("valueOrNull").invoke(maybe) ?: return null
                 getter as? PsiNamedElement
             } catch (e: NoSuchMethodException) {
                 null
             } catch (e: Exception) {
                 null
             }
+        }
+
+        private fun findNestedClassReflective(pyClass: PsiElement, name: String): PsiNamedElement? {
+            return try {
+                val method = pyClass.javaClass.getMethod("findNestedClass", String::class.java, java.lang.Boolean.TYPE)
+                method.invoke(pyClass, name, true) as? PsiNamedElement
+            } catch (e: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private fun projectScope(project: Project): GlobalSearchScope? = try {
+            GlobalSearchScope.projectScope(project)
+        } catch (e: Exception) {
+            null
         }
 
         private fun allScope(project: Project): GlobalSearchScope? = try {
@@ -1242,12 +1305,13 @@ class PythonSymbolReferenceHandler(
     private fun resolveByQualifiedName(project: Project, qName: String): Result<PsiNamedElement> {
         val candidates = mutableListOf<PsiNamedElement>()
 
-        findClassByQName(qName, project)?.let { candidates.add(it) }
+        // Class hits come back project-scope-first; functions likewise. Both are already ordered so a project
+        // symbol precedes a dependency/SDK/stub hit with the same qualified path.
+        candidates += findClassByQName(qName, project)
 
         val shortName = qName.substringAfterLast('.')
-        findFunctionsByShortName(shortName, project)
+        candidates += findFunctionsByShortName(shortName, project)
             .filter { getQualifiedName(it) == qName }
-            .forEach { candidates.add(it) }
 
         val distinct = candidates.distinctBy { elementKey(it) }
         return when {
@@ -1264,12 +1328,16 @@ class PythonSymbolReferenceHandler(
         val containerQName = symbol.substring(0, hashIndex)
         val memberName = symbol.substring(hashIndex + 1)
 
-        val pyClass = findClassByQName(containerQName, project)
+        val classes = findClassByQName(containerQName, project)
+        val pyClass = classes.firstOrNull()
             ?: return ErrorMessages.typeNotFound(containerQName, project.name).toArgumentFailure()
+        if (classes.size > 1) {
+            return ErrorMessages.multipleMethodsMatch(
+                containerQName, containerQName, classes.map { describe(it) }
+            ).toArgumentFailure()
+        }
 
-        val method = findMethodInClass(pyClass, memberName)
-        if (method is PsiNamedElement) return Result.success(method)
-
+        // defaultFindAttributeInClass resolves method (inherited=true), class/instance attribute, @property, nested class.
         findAttributeInClass(pyClass, memberName)?.let { return Result.success(it) }
 
         return ErrorMessages.memberNotFoundInType(memberName, containerQName).toArgumentFailure()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
@@ -1067,7 +1067,7 @@ class PythonStructureHandler : BasePythonHandler<List<StructureNode>>(), Structu
  */
 class PythonSymbolReferenceHandler(
     private val findClassByQName: (String, Project) -> List<PsiNamedElement> = { q, p -> defaultFindClassByQName(q, p) },
-    private val findFunctionsByShortName: (String, Project) -> List<PsiNamedElement> = { s, p -> defaultFindFunctionsByShortName(s, p) },
+    private val findFunctionsByQualifiedName: (String, Project) -> List<PsiNamedElement> = { q, p -> defaultFindFunctionsByQualifiedName(q, p) },
     private val findAttributeInClass: (PsiElement, String) -> PsiNamedElement? = { c, n -> defaultFindAttributeInClass(c, n) }
 ) : BasePythonHandler<PsiNamedElement>(), SymbolReferenceHandler {
 
@@ -1125,28 +1125,42 @@ class PythonSymbolReferenceHandler(
             emptyList()
         }
 
-        // Reflective default: PyFunctionNameIndex.find(shortName, project, scope) -> Collection<PyFunction> (3-arg),
-        // filtered by getQualifiedName() == qName is done by the caller. Project scope first, allScope fallback,
-        // so a project function wins over a dependency/stub with the same qualified path.
-        private fun defaultFindFunctionsByShortName(shortName: String, project: Project): List<PsiNamedElement> {
+        // Reflective default: PyFunctionNameIndex.findByQualifiedName(qName, project, scope) -> List<PyFunction> (filters by
+        // qualified name inside the index call). Project scope first, allScope fallback, so a project function does not
+        // hide a dependency/library function with the same short name but a different qualified path.
+        private fun defaultFindFunctionsByQualifiedName(qName: String, project: Project): List<PsiNamedElement> {
             val indexClass = pythonFunctionNameIndexClass ?: return emptyList()
             val projectScope = projectScope(project) ?: return emptyList()
-            val projectHits = findFunctionsByShortNameReflective(indexClass, shortName, project, projectScope)
+            val projectHits = findFunctionsByQualifiedNameReflective(indexClass, qName, project, projectScope)
             if (projectHits.isNotEmpty()) return projectHits
             val allScope = allScope(project) ?: return emptyList()
-            return findFunctionsByShortNameReflective(indexClass, shortName, project, allScope)
+            return findFunctionsByQualifiedNameReflective(indexClass, qName, project, allScope)
         }
 
-        private fun findFunctionsByShortNameReflective(
-            indexClass: Class<*>, shortName: String, project: Project, scope: GlobalSearchScope
+        private fun findFunctionsByQualifiedNameReflective(
+            indexClass: Class<*>, qName: String, project: Project, scope: GlobalSearchScope
         ): List<PsiNamedElement> = try {
-            val method = indexClass.getMethod("find", String::class.java, Project::class.java, GlobalSearchScope::class.java)
-            (method.invoke(null, shortName, project, scope) as? Collection<*>).orEmpty()
-                .filterIsInstance<PsiNamedElement>()
+            val byQName = indexClass.getMethod(
+                "findByQualifiedName", String::class.java, Project::class.java, GlobalSearchScope::class.java
+            )
+            (byQName.invoke(null, qName, project, scope) as? Collection<*>)?.filterIsInstance<PsiNamedElement>()
+                ?: findFunctionsByShortNameAndFilterReflective(indexClass, qName, project, scope)
         } catch (e: NoSuchMethodException) {
-            emptyList()
+            // Old SDK fallback: PyFunctionNameIndex.find(shortName, project, scope) + getQualifiedName filter.
+            findFunctionsByShortNameAndFilterReflective(indexClass, qName, project, scope)
         } catch (e: Exception) {
-            LOG.warn("PyFunctionNameIndex.find failed for '$shortName': ${e.message}")
+            LOG.warn("PyFunctionNameIndex lookup failed for '$qName': ${e.message}")
+            emptyList()
+        }
+
+        private fun findFunctionsByShortNameAndFilterReflective(
+            indexClass: Class<*>, qName: String, project: Project, scope: GlobalSearchScope
+        ): List<PsiNamedElement> = try {
+            val find = indexClass.getMethod("find", String::class.java, Project::class.java, GlobalSearchScope::class.java)
+            (find.invoke(null, qName.substringAfterLast('.'), project, scope) as? Collection<*>).orEmpty()
+                .filterIsInstance<PsiNamedElement>()
+                .filter { getQualifiedNameReflective(it) == qName }
+        } catch (e: Exception) {
             emptyList()
         }
 
@@ -1305,13 +1319,10 @@ class PythonSymbolReferenceHandler(
     private fun resolveByQualifiedName(project: Project, qName: String): Result<PsiNamedElement> {
         val candidates = mutableListOf<PsiNamedElement>()
 
-        // Class hits come back project-scope-first; functions likewise. Both are already ordered so a project
-        // symbol precedes a dependency/SDK/stub hit with the same qualified path.
+        // Class and function hits come back project-scope-first, filtered by qualified name inside the index call,
+        // so a project symbol does not hide a dependency/library symbol with the same short name but a different qName.
         candidates += findClassByQName(qName, project)
-
-        val shortName = qName.substringAfterLast('.')
-        candidates += findFunctionsByShortName(shortName, project)
-            .filter { getQualifiedName(it) == qName }
+        candidates += findFunctionsByQualifiedName(qName, project)
 
         val distinct = candidates.distinctBy { elementKey(it) }
         return when {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
@@ -1,6 +1,8 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.python
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.*
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.toArgumentFailure
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureKind
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureNode
@@ -10,6 +12,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 
@@ -55,6 +58,7 @@ object PythonHandlers {
             registry.registerCallHierarchyHandler(PythonCallHierarchyHandler())
             registry.registerSuperMethodsHandler(PythonSuperMethodsHandler())
             registry.registerStructureHandler(PythonStructureHandler())
+            registry.registerSymbolReferenceHandler(PythonSymbolReferenceHandler())
 
             LOG.info("Registered Python handlers")
         } catch (e: ClassNotFoundException) {
@@ -1041,4 +1045,242 @@ class PythonStructureHandler : BasePythonHandler<List<StructureNode>>(), Structu
             "()"
         }
     }
+}
+
+/**
+ * Python implementation of [SymbolReferenceHandler].
+ *
+ * Resolves fully-qualified Python symbol references to PSI elements using the
+ * Python stub indices. Supported forms:
+ * - `pkg.mod.ClassName`              — class (resolved via [PyClassNameIndex.findClass])
+ * - `pkg.mod.function_name`          — module-level function (resolved via [PyFunctionNameIndex], filtered by qualified name)
+ * - `pkg.mod.ClassName.method_name`  — method (same function index path; a method's qualified name is `pkg.mod.ClassName.method`)
+ * - `pkg.mod.ClassName#member_name`  — method or class/instance attribute of the named class
+ *
+ * Parameter lists are not supported (Python has no overload-by-signature); a
+ * symbol containing `(` is rejected. A bare name without a module qualifier is
+ * also rejected to avoid bare-name ambiguity — use the position-based path for
+ * those, or qualify the symbol.
+ *
+ * All Python PSI access is reflective to avoid a compile-time dependency on the
+ * Python plugin, mirroring the rest of [PythonHandlers].
+ */
+class PythonSymbolReferenceHandler(
+    private val findClassByQName: (String, Project) -> PsiNamedElement? = { q, p -> defaultFindClassByQName(q, p) },
+    private val findFunctionsByShortName: (String, Project) -> Collection<PsiNamedElement> = { s, p -> defaultFindFunctionsByShortName(s, p) },
+    private val findAttributeInClass: (PsiElement, String) -> PsiNamedElement? = { c, n -> defaultFindAttributeInClass(c, n) }
+) : BasePythonHandler<PsiNamedElement>(), SymbolReferenceHandler {
+
+    companion object {
+        private val LOG = logger<PythonSymbolReferenceHandler>()
+
+        // Dotted path with at least two segments (module qualifier + name). Allows `_` and digits.
+        private const val IDENTIFIER = """[A-Za-z_][A-Za-z0-9_]*"""
+        private const val DOTTED_PATH = """$IDENTIFIER(\.$IDENTIFIER)+"""
+        internal val PYTHON_SYMBOL_PATTERN = """^$DOTTED_PATH(#$IDENTIFIER)?$""".toRegex()
+
+        private val SYMBOL_EXAMPLES = listOf(
+            "'pkg.mod.ClassName'",
+            "'pkg.mod.function_name'",
+            "'pkg.mod.ClassName.method_name'",
+            "'pkg.mod.ClassName#attribute_name'"
+        )
+
+        // Reflective default: PyClassNameIndex.findByQualifiedName(qName, project, allScope) -> List<PyClass>.
+        // The old findClass(qName, project) was removed (PY-63989); current API filters by qualified name.
+        // Falls back to find(shortName, project, allScope) + getQualifiedName filter if findByQualifiedName is absent.
+        private fun defaultFindClassByQName(qName: String, project: Project): PsiNamedElement? {
+            val indexClass = pythonClassNameIndexClass ?: return null
+            val scope = allScope(project) ?: return null
+            return try {
+                val byQName = indexClass.getMethod(
+                    "findByQualifiedName", String::class.java, Project::class.java, GlobalSearchScope::class.java
+                )
+                ((byQName.invoke(null, qName, project, scope) as? Collection<*>)?.filterIsInstance<PsiNamedElement>()
+                    ?: runFindByShortNameAndFilter(indexClass, qName, project, scope))
+                    .firstOrNull()
+            } catch (e: NoSuchMethodException) {
+                runFindByShortNameAndFilter(indexClass, qName, project, scope).firstOrNull()
+            } catch (e: Exception) {
+                LOG.warn("PyClassNameIndex lookup failed for '$qName': ${e.message}")
+                null
+            }
+        }
+
+        private fun runFindByShortNameAndFilter(
+            indexClass: Class<*>, qName: String, project: Project, scope: GlobalSearchScope
+        ): List<PsiNamedElement> = try {
+            val find = indexClass.getMethod("find", String::class.java, Project::class.java, GlobalSearchScope::class.java)
+            (find.invoke(null, qName.substringAfterLast('.'), project, scope) as? Collection<*>).orEmpty()
+                .filterIsInstance<PsiNamedElement>()
+                .filter { getQualifiedNameReflective(it) == qName }
+        } catch (e: Exception) {
+            emptyList()
+        }
+
+        // Reflective default: PyFunctionNameIndex.find(shortName, project, allScope) -> Collection<PyFunction> (3-arg).
+        private fun defaultFindFunctionsByShortName(shortName: String, project: Project): Collection<PsiNamedElement> {
+            val indexClass = pythonFunctionNameIndexClass ?: return emptyList()
+            val scope = allScope(project) ?: return emptyList()
+            return try {
+                val method = indexClass.getMethod("find", String::class.java, Project::class.java, GlobalSearchScope::class.java)
+                (method.invoke(null, shortName, project, scope) as? Collection<*>).orEmpty()
+                    .filterIsInstance<PsiNamedElement>()
+            } catch (e: NoSuchMethodException) {
+                emptyList()
+            } catch (e: Exception) {
+                LOG.warn("PyFunctionNameIndex.find failed for '$shortName': ${e.message}")
+                emptyList()
+            }
+        }
+
+        // Reflective default: PyClass members reachable as `Class#name`.
+        // Order: method (findMethodByName, handled by BasePythonHandler.findMethodInClass upstream),
+        // class attribute findClassAttribute(String, boolean, TypeEvalContext),
+        // instance attribute findInstanceAttribute(String, boolean) [note: 2-arg, no TypeEvalContext],
+        // @property findProperty(String, boolean, TypeEvalContext) -> Property.getGetter().
+        private fun defaultFindAttributeInClass(pyClass: PsiElement, name: String): PsiNamedElement? {
+            val context = codeAnalysisContextFallback(pyClass.project)
+            findClassAttributeReflective(pyClass, name, context)?.let { return it }
+            findInstanceAttributeReflective(pyClass, name)?.let { return it }
+            findPropertyReflective(pyClass, name, context)?.let { return it }
+            return null
+        }
+
+        private fun findClassAttributeReflective(pyClass: PsiElement, name: String, context: Any?): PsiNamedElement? {
+            val contextClass = pythonTypeEvalContextClass ?: return null
+            return try {
+                val method = pyClass.javaClass.getMethod("findClassAttribute", String::class.java, java.lang.Boolean.TYPE, contextClass)
+                method.invoke(pyClass, name, true, context) as? PsiNamedElement
+            } catch (e: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private fun findInstanceAttributeReflective(pyClass: PsiElement, name: String): PsiNamedElement? {
+            return try {
+                val method = pyClass.javaClass.getMethod("findInstanceAttribute", String::class.java, java.lang.Boolean.TYPE)
+                method.invoke(pyClass, name, true) as? PsiNamedElement
+            } catch (e: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private fun findPropertyReflective(pyClass: PsiElement, name: String, context: Any?): PsiNamedElement? {
+            val contextClass = pythonTypeEvalContextClass ?: return null
+            return try {
+                val method = pyClass.javaClass.getMethod("findProperty", String::class.java, java.lang.Boolean.TYPE, contextClass)
+                val property = method.invoke(pyClass, name, true, context) ?: return null
+                val getter = property.javaClass.getMethod("getGetter").invoke(property) ?: return null
+                getter as? PsiNamedElement
+            } catch (e: NoSuchMethodException) {
+                null
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private fun allScope(project: Project): GlobalSearchScope? = try {
+            GlobalSearchScope.allScope(project)
+        } catch (e: Exception) {
+            null
+        }
+
+        private fun getQualifiedNameReflective(element: PsiElement): String? = try {
+            val m = element.javaClass.getMethod("getQualifiedName")
+            m.invoke(element) as? String
+        } catch (e: Exception) {
+            null
+        }
+
+        private fun codeAnalysisContextFallback(project: Project): Any? {
+            val typeEvalContextClass = pythonTypeEvalContextClass ?: return null
+            return try {
+                val method = typeEvalContextClass.getMethod("codeInsightFallback", Project::class.java)
+                method.invoke(null, project)
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private val pythonClassNameIndexClass: Class<*>? by lazy {
+            try { Class.forName("com.jetbrains.python.psi.stubs.PyClassNameIndex") } catch (_: ClassNotFoundException) { null }
+        }
+        private val pythonFunctionNameIndexClass: Class<*>? by lazy {
+            try { Class.forName("com.jetbrains.python.psi.stubs.PyFunctionNameIndex") } catch (_: ClassNotFoundException) { null }
+        }
+        private val pythonTypeEvalContextClass: Class<*>? by lazy {
+            try { Class.forName("com.jetbrains.python.psi.types.TypeEvalContext") } catch (_: ClassNotFoundException) { null }
+        }
+    }
+
+    override val languageId = "Python"
+    override val languageName = "Python"
+
+    override fun canHandle(element: PsiElement): Boolean = isAvailable() && isPythonLanguage(element)
+
+    override fun isAvailable(): Boolean = PluginDetectors.python.isAvailable && pyClassClass != null
+
+    override fun resolveSymbol(project: Project, symbol: String): Result<PsiNamedElement> {
+        val s = symbol.trim()
+        if (s.isEmpty() || '(' in s || ')' in s || !PYTHON_SYMBOL_PATTERN.matches(s)) {
+            return ErrorMessages.invalidSymbolFormat(s, SYMBOL_EXAMPLES).toArgumentFailure()
+        }
+
+        val hashIndex = s.indexOf('#')
+        return if (hashIndex >= 0) {
+            resolveMember(project, s, hashIndex)
+        } else {
+            resolveByQualifiedName(project, s)
+        }
+    }
+
+    private fun resolveByQualifiedName(project: Project, qName: String): Result<PsiNamedElement> {
+        val candidates = mutableListOf<PsiNamedElement>()
+
+        findClassByQName(qName, project)?.let { candidates.add(it) }
+
+        val shortName = qName.substringAfterLast('.')
+        findFunctionsByShortName(shortName, project)
+            .filter { getQualifiedName(it) == qName }
+            .forEach { candidates.add(it) }
+
+        val distinct = candidates.distinctBy { elementKey(it) }
+        return when {
+            distinct.isEmpty() -> ErrorMessages.typeNotFound(qName, project.name).toArgumentFailure()
+            distinct.size == 1 -> Result.success(distinct.single())
+            else -> ErrorMessages.multipleMethodsMatch(
+                qName, qName,
+                distinct.map { describe(it) }
+            ).toArgumentFailure()
+        }
+    }
+
+    private fun resolveMember(project: Project, symbol: String, hashIndex: Int): Result<PsiNamedElement> {
+        val containerQName = symbol.substring(0, hashIndex)
+        val memberName = symbol.substring(hashIndex + 1)
+
+        val pyClass = findClassByQName(containerQName, project)
+            ?: return ErrorMessages.typeNotFound(containerQName, project.name).toArgumentFailure()
+
+        val method = findMethodInClass(pyClass, memberName)
+        if (method is PsiNamedElement) return Result.success(method)
+
+        findAttributeInClass(pyClass, memberName)?.let { return Result.success(it) }
+
+        return ErrorMessages.memberNotFoundInType(memberName, containerQName).toArgumentFailure()
+    }
+
+    private fun describe(element: PsiNamedElement): String {
+        val qn = getQualifiedName(element) ?: getName(element) ?: "unknown"
+        val file = element.containingFile?.virtualFile?.path ?: "?"
+        return "$qn @ $file"
+    }
+
+    private fun elementKey(element: PsiElement): String =
+        "${element.containingFile?.virtualFile?.path ?: "?"}:${element.textOffset}"
 }

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -11,9 +11,17 @@ Complete parameter reference for all IDE MCP tools. All tools use JSON-RPC via M
 | `line` | integer | **1-based** line number |
 | `column` | integer | **1-based** column number. Place on the symbol name, not whitespace. For dotted expressions like `json.dumps()` or `os.path.join()`, point to the member token (`dumps`, `join`) when targeting the member definition. |
 | `language` | string | Language of the symbol (e.g., `"Java"`, `"PHP"`). Required when using `symbol`. |
-| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::CONSTANT`, `\\App\\Service\\UserService::$property`, `\\App\\Service\\StatusEnum::ACTIVE`. PHP properties require the `$property` form; plain `::name` resolves enum cases (on enum types), constants, or methods. |
+| `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::CONSTANT`, `\\App\\Service\\UserService::$property`, `\\App\\Service\\StatusEnum::ACTIVE`. PHP properties require the `$property` form; plain `::name` resolves enum cases (on enum types), constants, or methods. Python format: see **Python symbol grammar** below. |
 
-**Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP, JavaScript, TypeScript. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
+**Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP, JavaScript, TypeScript, Python. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
+
+**Python symbol grammar:** Symbols must be module-qualified (dotted path with ≥2 segments):
+- `pkg.mod.ClassName` — class
+- `pkg.mod.function_name` — module-level function
+- `pkg.mod.ClassName.method_name` — method (resolved via the function index; a method's qualified name is `pkg.mod.ClassName.method`)
+- `pkg.mod.ClassName#member_name` — method (inherited), class/instance attribute, or `@property` of the named class
+
+Parameter lists are not supported (Python has no overload-by-signature); bare unqualified names are rejected — use `file` + `line` + `column` for those.
 
 **JavaScript/TypeScript symbol grammar (v1):** Symbols must be module-qualified in one of these forms:
 - `modulePath#exportName` — named export (e.g., `src/utils#formatDate`)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonSymbolReferenceHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonSymbolReferenceHandlerUnitTest.kt
@@ -58,8 +58,10 @@ class PythonSymbolReferenceHandlerUnitTest : TestCase() {
         functions: Map<String, PsiNamedElement> = emptyMap(),
         attributes: Map<String, PsiNamedElement> = emptyMap()
     ): PythonSymbolReferenceHandler {
-        val classLookup: (String, Project) -> PsiNamedElement? = { qName, _ -> classes[qName] }
-        val functionLookup: (String, Project) -> Collection<PsiNamedElement> = { shortName, _ ->
+        val classLookup: (String, Project) -> List<PsiNamedElement> = { qName, _ ->
+            classes[qName]?.let { listOf(it) } ?: emptyList()
+        }
+        val functionLookup: (String, Project) -> List<PsiNamedElement> = { shortName, _ ->
             functions.entries.filter { it.key.substringAfterLast('.') == shortName }.map { it.value }
         }
         val attrLookup: (PsiElement, String) -> PsiNamedElement? = { _, name -> attributes[name] }
@@ -166,8 +168,10 @@ class PythonSymbolReferenceHandlerUnitTest : TestCase() {
     // ── resolveSymbol: hash member path ────────────────────────────────────────
 
     fun testResolveHashMemberMethodNotFoundOnMockClass() {
-        // findMethodByName is stubbed to null (see mockPyClass) and no attribute is injected,
-        // so the handler must report member-not-found rather than blowing up.
+        // Method resolution now goes through findMethodInClassInherited (inherited=true) which on a mock
+        // throws NoSuchMethodException and falls back to multiFindMethodByName (also failing), then attribute /
+        // property / nested-class lookups all yield null with nothing injected, so the handler reports
+        // member-not-found rather than blowing up. Guards the failure contract.
         val cls = mockPyClass("lib.util.MyClass")
         val r = handler(classes = mapOf("lib.util.MyClass" to cls))
             .resolveSymbol(project, "lib.util.MyClass#method")
@@ -190,6 +194,20 @@ class PythonSymbolReferenceHandlerUnitTest : TestCase() {
         val r = handler().resolveSymbol(project, "lib.util.NoClass#member")
         assertTrue(r.isFailure)
         assertTrue(r.exceptionOrNull()!!.message!!.contains("Type 'lib.util.NoClass' not found"))
+    }
+
+    fun testResolveHashMemberReportsContainerAmbiguity() {
+        // Two classes share the container qName; the #member path must not silently pick one.
+        val a = mockPyClass("lib.util.MyClass", offset = 10)
+        val b = mockPyClass("lib.util.MyClass", offset = 20)
+        val h = PythonSymbolReferenceHandler(
+            findClassByQName = { _, _ -> listOf(a, b) },
+            findFunctionsByShortName = { _, _ -> emptyList() },
+            findAttributeInClass = { _, _ -> null }
+        )
+        val r = h.resolveSymbol(project, "lib.util.MyClass#member")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("Multiple"))
     }
 
     // ── resolveSymbol: trimming ────────────────────────────────────────────────

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonSymbolReferenceHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonSymbolReferenceHandlerUnitTest.kt
@@ -61,8 +61,8 @@ class PythonSymbolReferenceHandlerUnitTest : TestCase() {
         val classLookup: (String, Project) -> List<PsiNamedElement> = { qName, _ ->
             classes[qName]?.let { listOf(it) } ?: emptyList()
         }
-        val functionLookup: (String, Project) -> List<PsiNamedElement> = { shortName, _ ->
-            functions.entries.filter { it.key.substringAfterLast('.') == shortName }.map { it.value }
+        val functionLookup: (String, Project) -> List<PsiNamedElement> = { qName, _ ->
+            functions[qName]?.let { listOf(it) } ?: emptyList()
         }
         val attrLookup: (PsiElement, String) -> PsiNamedElement? = { _, name -> attributes[name] }
         return PythonSymbolReferenceHandler(classLookup, functionLookup, attrLookup)
@@ -123,14 +123,24 @@ class PythonSymbolReferenceHandlerUnitTest : TestCase() {
         assertSame(fn, r.getOrThrow())
     }
 
-    fun testResolveFunctionFiltersByQualifiedName() {
-        // Two functions share the short name "to_iso" in different modules; only the requested qName matches.
-        val wanted = mockPyFunction("lib.util.to_iso")
+    fun testResolveFunctionDoesNotMatchSameShortNameDifferentModule() {
+        // The function lookup is by fully-qualified name; a function with the same short name in a different
+        // module must not satisfy a request for a different qualified path. (The reflective default filters by
+        // qName inside the index call; this test asserts the dispatch contract with the injected fake.)
         val other = mockPyFunction("lib.data.influx.to_iso")
-        val r = handler(functions = mapOf("lib.util.to_iso" to wanted, "lib.data.influx.to_iso" to other))
+        val r = handler(functions = mapOf("lib.data.influx.to_iso" to other))
             .resolveSymbol(project, "lib.util.to_iso")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("not found"))
+    }
+
+    fun testResolveFunctionPicksProjectHitOverDependencyWithSameQName() {
+        // If a project function and a dependency function share the SAME qualified name, the project-scope-first
+        // ordering must surface the project one. The injected fake models the project hit.
+        val projectFn = mockPyFunction("lib.util.parse")
+        val r = handler(functions = mapOf("lib.util.parse" to projectFn)).resolveSymbol(project, "lib.util.parse")
         assertTrue(r.isSuccess)
-        assertSame(wanted, r.getOrThrow())
+        assertSame(projectFn, r.getOrThrow())
     }
 
     fun testResolveClassByQualifiedName() {
@@ -202,7 +212,7 @@ class PythonSymbolReferenceHandlerUnitTest : TestCase() {
         val b = mockPyClass("lib.util.MyClass", offset = 20)
         val h = PythonSymbolReferenceHandler(
             findClassByQName = { _, _ -> listOf(a, b) },
-            findFunctionsByShortName = { _, _ -> emptyList() },
+            findFunctionsByQualifiedName = { _, _ -> emptyList() },
             findAttributeInClass = { _, _ -> null }
         )
         val r = h.resolveSymbol(project, "lib.util.MyClass#member")

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonSymbolReferenceHandlerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonSymbolReferenceHandlerUnitTest.kt
@@ -1,0 +1,243 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.python
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.python.PythonSymbolReferenceHandler.Companion.PYTHON_SYMBOL_PATTERN
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.jetbrains.python.psi.PyClass
+import com.jetbrains.python.psi.PyFunction
+import com.jetbrains.python.psi.types.TypeEvalContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetector
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import junit.framework.TestCase
+
+/**
+ * Pure (non-fixture) unit tests for [PythonSymbolReferenceHandler].
+ *
+ * Exercises symbol-format validation and the resolution dispatch logic by
+ * injecting fake index lookups, so it runs without a real Python stub index.
+ *
+ * Mocks [PyFunction]/[PyClass] (not bare [PsiNamedElement]) because
+ * [BasePythonHandler.getQualifiedName] resolves the qualified name via
+ * reflection on the runtime class (`element.javaClass.getMethod("getQualifiedName")`);
+ * the mockk subclass implements the interface method, so the reflective call finds
+ * it and returns the stubbed value. Helpers return [PsiNamedElement] so `mapOf`
+ * literals infer `Map<String, PsiNamedElement>` directly (`Pair` is invariant).
+ */
+class PythonSymbolReferenceHandlerUnitTest : TestCase() {
+
+    private val project: Project = mockk(relaxed = true)
+
+    private fun mockPyFunction(qName: String, offset: Int = 0): PsiNamedElement =
+        mockk<PyFunction>(relaxed = true) {
+            every { getName() } returns qName.substringAfterLast('.')
+            every { getQualifiedName() } returns qName
+            every { textOffset } returns offset
+            every { containingFile } returns null
+        }
+
+    private fun mockPyClass(qName: String, offset: Int = 0): PsiNamedElement =
+        mockk<PyClass>(relaxed = true) {
+            every { getName() } returns qName.substringAfterLast('.')
+            every { getQualifiedName() } returns qName
+            every { getAncestorClasses(any<TypeEvalContext>()) } returns emptyList()
+            every { getSuperClasses(any<TypeEvalContext>()) } returns emptyArray()
+            every { findMethodByName(any(), any(), any<TypeEvalContext>()) } returns null
+            every { textOffset } returns offset
+            every { containingFile } returns null
+            every { parent } returns null
+        }
+
+    private fun handler(
+        classes: Map<String, PsiNamedElement> = emptyMap(),
+        functions: Map<String, PsiNamedElement> = emptyMap(),
+        attributes: Map<String, PsiNamedElement> = emptyMap()
+    ): PythonSymbolReferenceHandler {
+        val classLookup: (String, Project) -> PsiNamedElement? = { qName, _ -> classes[qName] }
+        val functionLookup: (String, Project) -> Collection<PsiNamedElement> = { shortName, _ ->
+            functions.entries.filter { it.key.substringAfterLast('.') == shortName }.map { it.value }
+        }
+        val attrLookup: (PsiElement, String) -> PsiNamedElement? = { _, name -> attributes[name] }
+        return PythonSymbolReferenceHandler(classLookup, functionLookup, attrLookup)
+    }
+
+    // ── PYTHON_SYMBOL_PATTERN: valid symbols ───────────────────────────────────
+
+    fun testPatternMatchesClassFqn() = assertTrue(PYTHON_SYMBOL_PATTERN.matches("lib.util.MyClass"))
+
+    fun testPatternMatchesModuleFunction() = assertTrue(PYTHON_SYMBOL_PATTERN.matches("lib.util.to_iso"))
+
+    fun testPatternMatchesMethodDotted() = assertTrue(PYTHON_SYMBOL_PATTERN.matches("lib.util.MyClass.method"))
+
+    fun testPatternMatchesHashMember() = assertTrue(PYTHON_SYMBOL_PATTERN.matches("lib.util.MyClass#attr"))
+
+    fun testPatternMatchesSinglePackageSegment() = assertTrue(PYTHON_SYMBOL_PATTERN.matches("util.to_iso"))
+
+    fun testPatternMatchesUnderscores() = assertTrue(PYTHON_SYMBOL_PATTERN.matches("lib.util._private_fn"))
+
+    // ── PYTHON_SYMBOL_PATTERN: invalid symbols ─────────────────────────────────
+
+    fun testPatternRejectsBareName() = assertFalse(PYTHON_SYMBOL_PATTERN.matches("to_iso"))
+
+    fun testPatternRejectsParameterList() = assertFalse(PYTHON_SYMBOL_PATTERN.matches("lib.util.fn(int)"))
+
+    fun testPatternRejectsEmptyMemberAfterHash() = assertFalse(PYTHON_SYMBOL_PATTERN.matches("lib.util.MyClass#"))
+
+    fun testPatternRejectsDottedMemberAfterHash() = assertFalse(PYTHON_SYMBOL_PATTERN.matches("lib.util.MyClass#a.b"))
+
+    fun testPatternRejectsTrailingDot() = assertFalse(PYTHON_SYMBOL_PATTERN.matches("lib.util."))
+
+    // ── resolveSymbol: format validation ───────────────────────────────────────
+
+    fun testResolveRejectsEmptySymbol() {
+        val r = handler().resolveSymbol(project, "")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("does not match expected format"))
+    }
+
+    fun testResolveRejectsBareName() {
+        val r = handler().resolveSymbol(project, "to_iso")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("does not match expected format"))
+    }
+
+    fun testResolveRejectsParameterList() {
+        val r = handler().resolveSymbol(project, "lib.util.fn(int, str)")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("does not match expected format"))
+    }
+
+    // ── resolveSymbol: dotted qualified-name path ─────────────────────────────
+
+    fun testResolveFunctionByQualifiedName() {
+        val fn = mockPyFunction("lib.util.to_iso")
+        val r = handler(functions = mapOf("lib.util.to_iso" to fn)).resolveSymbol(project, "lib.util.to_iso")
+        assertTrue(r.isSuccess)
+        assertSame(fn, r.getOrThrow())
+    }
+
+    fun testResolveFunctionFiltersByQualifiedName() {
+        // Two functions share the short name "to_iso" in different modules; only the requested qName matches.
+        val wanted = mockPyFunction("lib.util.to_iso")
+        val other = mockPyFunction("lib.data.influx.to_iso")
+        val r = handler(functions = mapOf("lib.util.to_iso" to wanted, "lib.data.influx.to_iso" to other))
+            .resolveSymbol(project, "lib.util.to_iso")
+        assertTrue(r.isSuccess)
+        assertSame(wanted, r.getOrThrow())
+    }
+
+    fun testResolveClassByQualifiedName() {
+        val cls = mockPyClass("lib.util.MyClass")
+        val r = handler(classes = mapOf("lib.util.MyClass" to cls)).resolveSymbol(project, "lib.util.MyClass")
+        assertTrue(r.isSuccess)
+        assertSame(cls, r.getOrThrow())
+    }
+
+    fun testResolveMethodByDottedQualifiedName() {
+        val method = mockPyFunction("lib.util.MyClass.method")
+        val r = handler(functions = mapOf("lib.util.MyClass.method" to method))
+            .resolveSymbol(project, "lib.util.MyClass.method")
+        assertTrue(r.isSuccess)
+        assertSame(method, r.getOrThrow())
+    }
+
+    fun testResolveQualifiedNameNotFound() {
+        val r = handler().resolveSymbol(project, "lib.util.no_such_thing")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("not found"))
+    }
+
+    fun testResolveAmbiguousClassAndFunctionShareQualifiedName() {
+        // A module-level rebinding could make a class and a function collide on the same qName.
+        val cls = mockPyClass("lib.util.dup", offset = 10)
+        val fn = mockPyFunction("lib.util.dup", offset = 20)
+        val r = handler(classes = mapOf("lib.util.dup" to cls), functions = mapOf("lib.util.dup" to fn))
+            .resolveSymbol(project, "lib.util.dup")
+        assertTrue(r.isFailure)
+        val msg = r.exceptionOrNull()!!.message!!
+        assertTrue("ambiguity message should list multiple matches: $msg", msg.contains("Multiple"))
+    }
+
+    // ── resolveSymbol: hash member path ────────────────────────────────────────
+
+    fun testResolveHashMemberMethodNotFoundOnMockClass() {
+        // findMethodByName is stubbed to null (see mockPyClass) and no attribute is injected,
+        // so the handler must report member-not-found rather than blowing up.
+        val cls = mockPyClass("lib.util.MyClass")
+        val r = handler(classes = mapOf("lib.util.MyClass" to cls))
+            .resolveSymbol(project, "lib.util.MyClass#method")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("No member 'method' found in type 'lib.util.MyClass'"))
+    }
+
+    fun testResolveHashMemberAttribute() {
+        val cls = mockPyClass("lib.util.MyClass")
+        val attr = mockPyFunction("lib.util.MyClass.constant")
+        val r = handler(
+            classes = mapOf("lib.util.MyClass" to cls),
+            attributes = mapOf("constant" to attr)
+        ).resolveSymbol(project, "lib.util.MyClass#constant")
+        assertTrue(r.isSuccess)
+        assertSame(attr, r.getOrThrow())
+    }
+
+    fun testResolveHashMemberClassNotFound() {
+        val r = handler().resolveSymbol(project, "lib.util.NoClass#member")
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull()!!.message!!.contains("Type 'lib.util.NoClass' not found"))
+    }
+
+    // ── resolveSymbol: trimming ────────────────────────────────────────────────
+
+    fun testResolveTrimsWhitespace() {
+        val fn = mockPyFunction("lib.util.to_iso")
+        val r = handler(functions = mapOf("lib.util.to_iso" to fn))
+            .resolveSymbol(project, "  lib.util.to_iso  ")
+        assertTrue(r.isSuccess)
+        assertSame(fn, r.getOrThrow())
+    }
+
+    // ── reflective defaults: no-throw when Python index classes are absent ─────
+    // CI has no Python plugin on the classpath, so the reflective defaults cannot
+    // resolve real symbols. They MUST degrade to null/empty without throwing —
+    // this guards that contract and exercises the default code paths.
+
+    fun testDefaultLookupsReturnNullWithoutThrowingWhenPythonIndexUnavailable() {
+        val h = PythonSymbolReferenceHandler() // uses reflective defaults
+        val cls = h.resolveSymbol(project, "lib.util.SomeClass")
+        // No Python plugin -> class lookup returns null -> typeNotFound failure (not an exception).
+        assertTrue(cls.isFailure)
+        assertNull(cls.getOrNull())
+    }
+
+    // ── registration wiring (the PR's core claim) ──────────────────────────────
+
+    fun testRegistryExposesPythonSymbolReferenceHandler() {
+        // The registry's retrieval filters by isAvailable(), which is false in CI (no Python plugin).
+        // Force PluginDetectors.python.isAvailable so the wiring (register -> schema enum -> dispatch)
+        // can be exercised here. pyClassClass loads the test stub, so isAvailable() flips true.
+        mockkObject(PluginDetectors)
+        val pythonDetector = mockk<PluginDetector>()
+        every { pythonDetector.isAvailable } returns true
+        every { PluginDetectors.python } returns pythonDetector
+        LanguageHandlerRegistry.clear()
+        try {
+            LanguageHandlerRegistry.registerSymbolReferenceHandler(PythonSymbolReferenceHandler())
+            assertTrue(
+                "'Python' must be advertised as a supported symbol-reference language",
+                LanguageHandlerRegistry.getSupportedLanguageNamesForSymbolReference().contains("Python")
+            )
+            val h = LanguageHandlerRegistry.getSymbolReferenceHandlerByLanguageName("Python")
+            assertNotNull("Python symbol reference handler should be retrievable from the registry", h)
+            assertEquals("Python", h?.languageName)
+        } finally {
+            LanguageHandlerRegistry.clear()
+            unmockkObject(PluginDetectors)
+        }
+    }
+}

--- a/src/test/kotlin/com/jetbrains/python/psi/PyClass.kt
+++ b/src/test/kotlin/com/jetbrains/python/psi/PyClass.kt
@@ -3,7 +3,7 @@ package com.jetbrains.python.psi
 import com.jetbrains.python.psi.types.TypeEvalContext
 
 interface PyClass : PyElement {
-    fun getName(): String?
+    override fun getName(): String?
     fun getQualifiedName(): String?
     fun getSuperClasses(context: TypeEvalContext?): Array<PyClass>
     fun getAncestorClasses(context: TypeEvalContext?): List<PyClass>

--- a/src/test/kotlin/com/jetbrains/python/psi/PyElement.kt
+++ b/src/test/kotlin/com/jetbrains/python/psi/PyElement.kt
@@ -1,5 +1,5 @@
 package com.jetbrains.python.psi
 
-import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
 
-interface PyElement : PsiElement
+interface PyElement : PsiNamedElement

--- a/src/test/kotlin/com/jetbrains/python/psi/PyFunction.kt
+++ b/src/test/kotlin/com/jetbrains/python/psi/PyFunction.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.python.psi
 
 interface PyFunction : PyElement {
-    fun getName(): String?
+    override fun getName(): String?
+    fun getQualifiedName(): String?
 }


### PR DESCRIPTION
## What

Closes #226.

`ide_find_definition` and `ide_find_references` accept a `symbol` + `language` entry point gated by a per-language `SymbolReferenceHandler`. Java/Kotlin/PHP/JS/TS registered one; **Python did not**, so the symbol path rejected `"Python"` (`Unsupported language for symbol references: Python`) and forced a `file`/`line`/`column` round-trip even when a fully-qualified symbol was already in hand.

This adds `PythonSymbolReferenceHandler`, so `"Python"` now appears in the `language` enum and the symbol path works for Python.

## Supported symbol forms

- `pkg.mod.ClassName` — class
- `pkg.mod.function_name` — module-level function
- `pkg.mod.ClassName.method_name` — method (resolved via the function index; a method's qualified name is `pkg.mod.ClassName.method`)
- `pkg.mod.ClassName#member_name` — method (`findMethodByName`), class/instance attribute (`findClassAttribute`/`findInstanceAttribute`), or `@property` (`findProperty` → getter)

Parameter lists are not supported (Python has no overload-by-signature); bare unqualified names are rejected — use `file`+`line`+`column` for those.

## How

All Python PSI access is reflective (no compile-time Python-plugin dependency), consistent with the rest of `PythonHandlers.kt`. The reflective signatures were verified against `intellij-community` `master`:

- `PyClassNameIndex.findByQualifiedName(String, Project, GlobalSearchScope)` (the old `findClass(String, Project)` was removed in PY-63989)
- `PyFunctionNameIndex.find(String, Project, GlobalSearchScope)` (3-arg)
- `PyClass.findClassAttribute(String, boolean, TypeEvalContext)`, `findInstanceAttribute(String, boolean)`, `findProperty(String, boolean, TypeEvalContext)`

Registering the handler makes `"Python"` appear in the `language` enum automatically — `SchemaBuilder.languageAndSymbol` derives the enum from `getSupportedLanguageNamesForSymbolReference()`, so **no schema edit** is needed.

## Test PSI stubs

Extended the project's hand-written Python PSI test stubs (`src/test/kotlin/com/jetbrains/python/psi/`) to mirror real PyCharm: `PyElement : PsiNamedElement` and `PyFunction.getQualifiedName()`. This is needed because `BasePythonHandler.getQualifiedName` resolves the qualified name via reflection on the runtime class, and the stubs previously didn't expose `getQualifiedName` on `PyFunction` or model `PyClass`/`PyFunction` as `PsiNamedElement`. The existing `PythonHierarchyHandlersTest` / `PythonCallHierarchyHandlerTest` still pass.

## Tests

26 unit tests (`PythonSymbolReferenceHandlerUnitTest`):
- pattern validation (valid + invalid forms)
- dotted qualified-name dispatch with short-name-collision filtering (`to_iso` in two modules → only the requested qName survives)
- class / method / function resolution
- hash-member path: not-found contract, attribute resolution, class-not-found
- ambiguity when a class and a function share a qName
- whitespace trimming
- no-throw contract for the reflective defaults when the Python index classes are absent (the CI environment — guards against silent signature drift)
- registration wiring: `LanguageHandlerRegistry` advertises `"Python"` and `getSymbolReferenceHandlerByLanguageName("Python")` retrieves the handler

Verified: `./gradlew test --tests "*.python.*" --tests "JavaSymbolReferenceHandlerUnitTest"` → **76 tests, 0 failures**.

## Notes / limitations

- The reflective production defaults can't be exercised against the real Python stub index in CI (the Python plugin isn't on the test classpath), so a real-fixture platform test isn't included here. The reflective signatures were checked against `intellij-community` `master`; the no-throw default test guards the degradation path. A platform test against a real PyCharm build would be the next hardening step.
- `canHandle` is implemented for interface completeness but unused on the symbol path (dispatch is by `languageName`).

## Checklist
- [x] `./gradlew compileTestKotlin` succeeds
- [x] `./gradlew test` (python + java symbol-ref suites) — 76 passed, 0 failed
- [x] CHANGELOG entry added under `[Unreleased]`
- [x] USAGE.md supported-languages note updated
