### PR TITLE
Add code correctness review checklist and automated checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,123 @@ confirm each has an entry: `README.md`, `USAGE.md`, `CLAUDE.md`, `SKILL.md`,
 
 ---
 
+## Code correctness review — mandatory before every push
+
+The checklist above covers registration and documentation. This section covers
+**code correctness** — the bugs that slip past unit tests because they only
+surface under real threading, real disposal, or real multi-language execution.
+
+These checks exist because the same categories of bugs have appeared in multiple
+PRs. Each item maps to a real production defect. Do not skip items because
+"it looks fine" — trace the actual execution path.
+
+### Threading: trace every `doExecute` to PSI
+
+MCP tool calls arrive on Ktor coroutine worker threads — no read lock, not EDT.
+
+For every code path in your PR that touches PSI:
+
+- [ ] **PSI reads** are inside `suspendingReadAction { }` or `ReadAction.compute { }`
+- [ ] **PSI writes** are inside `edtAction { WriteCommandAction.runWriteCommandAction { } }`
+- [ ] **Processors that manage their own write actions** (e.g., `RenameProcessor.run()`,
+  `Replacer.replaceAll()`) are called on EDT but **not** wrapped in an extra
+  `WriteCommandAction` — double-wrapping deadlocks
+- [ ] **Line/column calculations** that depend on document length happen **inside** the
+  write action, after the edit — not before, when the document was a different length
+
+How to verify: start at `doExecute()`, follow every call that eventually reaches a
+`PsiElement`, `PsiFile`, `Document`, or `PsiManager`. Each one must be in the correct
+threading context. `BasePlatformTestCase` runs on EDT with implicit read access, so
+**tests will not catch threading violations** — you must trace the production path manually.
+
+### Reflection proxies: handle Object methods
+
+Every `Proxy.newProxyInstance` call must handle `equals`, `hashCode`, and `toString`.
+The default return of `null` causes `NullPointerException` when the proxy is stored in
+collections or disposed through `Disposer.dispose()`.
+
+```kotlin
+// ✗ NPE when Disposer calls equals() during removal
+{ _, method, args -> if (method.name == "onEvent") { ... }; null }
+
+// ✓ Safe
+{ proxyObj, method, args ->
+    when (method.name) {
+        "equals" -> proxyObj === args?.get(0)
+        "hashCode" -> System.identityHashCode(proxyObj)
+        "toString" -> "MyListener-proxy"
+        "onEvent" -> { ...; null }
+        else -> null
+    }
+}
+```
+
+- [ ] Every `Proxy.newProxyInstance` in the PR handles `equals`, `hashCode`, `toString`
+- [ ] `grep -rn "Proxy.newProxyInstance" src/main/` — check ALL existing proxies too,
+  not just the ones you added
+
+### Error handling: distinguish "unavailable" from "broken"
+
+When using reflection to access optional plugin APIs, the catch block must distinguish
+`ClassNotFoundException` (plugin not installed — expected, recoverable) from other
+exceptions (plugin present but call failed — unexpected, worth reporting).
+
+```kotlin
+// ✗ Loses error information — caller can't tell if Maven is missing or if import crashed
+return try { ... } catch (_: Exception) { null }
+
+// ✓ Caller can distinguish and report appropriately
+catch (e: ClassNotFoundException) { return PluginUnavailable }
+catch (e: Exception) { return Failed(e.message) }
+```
+
+- [ ] Every `catch (_: Exception)` or `catch (_: Throwable)` — is the error type information
+  actually unneeded, or is it being silently swallowed?
+
+### Sibling consistency: same fix in all language resolvers
+
+When fixing a bug in one language resolver (Java, Kotlin, JavaScript/TypeScript), check
+whether the same pattern exists in sibling implementations.
+
+- [ ] Search for the same method name in `Java*Resolver`, `Kotlin*Resolver`,
+  `JavaScript*Resolver` — does the fix apply to all of them?
+- [ ] Search for the same method name in `Java*Handler`, `Kotlin*Handler`,
+  `Python*Handler`, `JavaScript*Handler`, etc. — same question
+
+### Dead code: trace from interface to all implementations
+
+When removing a caller, check whether the method is still referenced anywhere.
+If not, remove it from the interface and all implementations.
+
+- [ ] Every method removed or added — does the interface still match all implementations?
+- [ ] `ide_find_references` on the method — zero callers means dead code
+
+### Test honesty: conditional skips must be visible
+
+Tests that skip when an optional plugin is absent must use `Assume.assumeTrue()`,
+not early-return. Early-return silently passes — the test appears green but never ran.
+
+```kotlin
+// ✗ Silently passes — CI shows green even though nothing was tested
+if (!pluginAvailable) return
+
+// ✓ CI shows "skipped" — the maintainer knows it didn't run
+Assume.assumeTrue("JavaScript plugin not available", pluginAvailable)
+```
+
+- [ ] Every conditional test skip uses `Assume.assumeTrue`, not `return` or `return@runBlocking`
+
+### Set operations: account for hierarchical containment
+
+When computing set differences on file paths or module roots, check whether the domain
+has parent-child relationships. Plain set subtraction (`A - B`) flags children of
+requested items as "extra".
+
+- [ ] Every set difference on paths — does the code account for nesting?
+  (e.g., `root !in expected && expected.none { root.startsWith("$it/") }`)
+
+---
+
 ## API compliance — the plugin verifier enforces these; CI fails if violated
 
 ### Internal APIs

--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ Timing thresholds are configurable in Settings. Projects enroll automatically on
 
 For detailed tool documentation with parameters and examples, see [USAGE.md](USAGE.md).
 
+For Claude Code users: [hooks](docs/claude-code-hooks.md) that enforce IDE tool usage over bash/grep/sed fallbacks.
+
 ## Multi-Project Support
 
 When multiple projects are open in a single IDE window, you must specify which project to use with the `project_path` parameter:

--- a/USAGE.md
+++ b/USAGE.md
@@ -75,6 +75,11 @@ These tools work in all supported JetBrains IDEs; defaults are listed per tool.
 
 ---
 
+**Claude Code users:** To enforce IDE tool usage and prevent agents from falling back to grep/sed/Edit,
+see [Claude Code Hooks](docs/claude-code-hooks.md) for ready-to-use `PreToolUse` hook scripts.
+
+---
+
 ## Table of Contents
 
 - [Common Parameters](#common-parameters)

--- a/docs/claude-code-hooks.md
+++ b/docs/claude-code-hooks.md
@@ -1,0 +1,240 @@
+# Claude Code Hooks — Enforcing IDE Tool Usage
+
+Claude Code [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) run
+shell commands before or after tool calls. These hooks enforce a simple rule:
+**use IDE MCP tools for code operations, not bash fallbacks.**
+
+Without enforcement, AI agents default to `grep`, `sed`, `Edit`, and `rm` for
+code operations — tools that work on text, not code structure. They miss renamed
+imports, break references, and bypass the IDE index. The hooks below redirect
+agents to the semantically correct IDE tool at the point of use.
+
+## Why hooks instead of prompt instructions
+
+Prompt instructions ("prefer IDE tools") are suggestions. Agents comply when
+convenient and fall back to bash when the IDE tool requires more effort. Hooks
+are enforcement — the bash command or file edit is rejected with a message
+naming the correct tool. The agent has no choice but to use it.
+
+Hooks also survive across sessions and work for subagents, which don't inherit
+skills or CLAUDE.md instructions.
+
+## Installation
+
+Add these hooks to your Claude Code settings. You can configure them via
+`claude mcp` or by editing `~/.claude/settings.json` directly.
+
+In `~/.claude/settings.json`, add to the `hooks` section:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /path/to/intellij-first.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /path/to/intellij-first-edit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Save the hook scripts below to the paths you configured.
+
+---
+
+## Hook 1: Bash tool — redirect to IDE search and refactoring
+
+**File:** `intellij-first.sh`
+
+This hook intercepts bash commands that should use IDE tools instead: grep on
+source files, sed replacements, mv/cp/rm on source files, and python bulk
+replacement scripts.
+
+```bash
+#!/bin/bash
+# PreToolUse hook for Bash: block commands that should use IntelliJ MCP.
+
+CMD=$(cat | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)
+
+# grep -r on source files → ide_search_text or ide_find_references
+if echo "$CMD" | grep -qE 'grep\s+-[a-zA-Z]*r[a-zA-Z]*\s' && \
+   echo "$CMD" | grep -qE '\*\.java|\*\.kt|\*\.ts|\*\.tsx|\*\.js|\*\.jsx|\*\.py|src/main|src/test'; then
+  echo "BLOCK: Use ide_search_text or ide_find_references instead of grep on source files." >&2
+  exit 2
+fi
+
+# mvn output parsing → ide_build_project + ide_diagnostics
+if echo "$CMD" | grep -qE 'mvn\s+(compile|package|install|verify)' && \
+   echo "$CMD" | grep -qE '\|\s*(grep|awk|sed)'; then
+  echo "BLOCK: Use ide_build_project + ide_diagnostics instead of parsing mvn output." >&2
+  exit 2
+fi
+
+# find + grep on source files → ide_search_text
+if echo "$CMD" | grep -qE 'find\s' && \
+   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py' && \
+   echo "$CMD" | grep -qE 'grep|xargs.*grep'; then
+  echo "BLOCK: Use ide_search_text instead of find+grep on source files." >&2
+  exit 2
+fi
+
+# sed -i on source files → ide_refactor_rename or ide_replace_text_in_file
+if echo "$CMD" | grep -qE 'sed\s+-[a-zA-Z]*i' && \
+   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py'; then
+  echo "BLOCK: Use ide_refactor_rename or ide_replace_text_in_file instead of sed on source files." >&2
+  exit 2
+fi
+
+# python3 bulk replacement → ide_replace_text_in_file
+# Exception: scripts in /tmp/ are development tooling
+if echo "$CMD" | grep -qE 'python3\s' && \
+   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py' && \
+   echo "$CMD" | grep -qE 'replace|sub\(|re\.sub'; then
+  if echo "$CMD" | grep -qE 'python3\s+/tmp/'; then
+    exit 0
+  fi
+  echo "BLOCK: Use ide_replace_text_in_file instead of Python bulk replacement on source files." >&2
+  exit 2
+fi
+
+# mv on source files → ide_move_file (exception: mv to /tmp/ is backup)
+if echo "$CMD" | grep -qE '\bmv\s' && \
+   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py'; then
+  if echo "$CMD" | grep -qE '\s/tmp/'; then
+    exit 0
+  fi
+  echo "BLOCK: Use ide_move_file instead of mv on source files." >&2
+  exit 2
+fi
+
+# cp on source files → IDE refactoring
+if echo "$CMD" | grep -qE '\bcp\s' && \
+   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py'; then
+  echo "BLOCK: Use IntelliJ refactoring instead of cp on source files." >&2
+  exit 2
+fi
+
+# rm on source files → ide_refactor_safe_delete (warn, don't block — delete-to-recreate is valid)
+if echo "$CMD" | grep -qE '\brm\s' && \
+   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py'; then
+  echo "WARN: Prefer ide_refactor_safe_delete over rm — rm doesn't check for references." >&2
+  exit 0
+fi
+
+exit 0
+```
+
+### What it catches and what it redirects to
+
+| Blocked pattern | IDE alternative |
+|----------------|----------------|
+| `grep -r "pattern" src/` | `ide_search_text` or `ide_find_references` |
+| `find . -name "*.java" \| xargs grep` | `ide_search_text` |
+| `sed -i 's/old/new/g' File.java` | `ide_replace_text_in_file` or `ide_refactor_rename` |
+| `python3 script.py` (bulk replace) | `ide_replace_text_in_file` |
+| `mv File.java newdir/` | `ide_move_file` |
+| `cp File.java Copy.java` | IDE refactoring |
+| `rm File.java` | `ide_refactor_safe_delete` (warns, doesn't block) |
+
+### Exceptions
+
+- `mv` to `/tmp/` is allowed (backup, not a refactoring)
+- `rm` warns but doesn't block (delete-to-recreate is a valid pattern when a file has errors that prevent IDE tools from working)
+- Python scripts in `/tmp/` are allowed (development tooling)
+
+---
+
+## Hook 2: Edit/Write tool — redirect to IDE structural editing
+
+**File:** `intellij-first-edit.sh`
+
+This hook intercepts Edit and Write tool calls on source files, redirecting to
+the IDE's structural editing tools which maintain the index.
+
+```bash
+#!/bin/bash
+# PreToolUse hook for Edit/Write: block modifications to source files.
+# IntelliJ MCP owns structural editing. Exceptions:
+# - Write to new files (fallback when ide_create_file unavailable)
+# - Edit with replace_all (find-and-replace — covered by ide_replace_text_in_file
+#   but allowed as fallback for sessions without the tool)
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null)
+FILE=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+REPLACE_ALL=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('replace_all',False))" 2>/dev/null)
+
+if echo "$FILE" | grep -qE '\.(java|kt|ts|tsx|js|jsx|py)$'; then
+  # Allow Write to new files (fallback when ide_create_file unavailable)
+  if [ "$TOOL" = "Write" ] && [ ! -f "$FILE" ]; then
+    exit 0
+  fi
+  # Allow Edit with replace_all (find-and-replace fallback)
+  if [ "$TOOL" = "Edit" ] && [ "$REPLACE_ALL" = "True" ]; then
+    exit 0
+  fi
+  echo "BLOCK: Use IntelliJ MCP tools instead of Edit/Write on source files. \
+EXISTING files: ide_edit_member, ide_replace_member, ide_insert_member, ide_replace_text_in_file. \
+NEW files: ide_create_file (preferred) or Write (fallback). \
+REFACTOR: ide_refactor_rename, ide_move_file." >&2
+  exit 2
+fi
+
+exit 0
+```
+
+### What it catches and what it redirects to
+
+| Blocked pattern | IDE alternative |
+|----------------|----------------|
+| `Edit` on existing .java/.kt/.ts file | `ide_edit_member`, `ide_replace_member`, `ide_insert_member` |
+| `Write` to existing source file | `ide_edit_member` or `ide_replace_member` |
+| `Edit` for find-and-replace | `ide_replace_text_in_file` (or `Edit` with `replace_all: true` as fallback) |
+
+### Exceptions
+
+- `Write` to a file that doesn't exist yet → allowed (new file creation when `ide_create_file` isn't available)
+- `Edit` with `replace_all: true` → allowed (find-and-replace within a file)
+
+---
+
+## How the hook enforcement message works
+
+When a hook blocks a tool call, the agent sees the error message which names the
+correct IDE tools. The agent then uses the named tool instead. This is more
+effective than prompt instructions because:
+
+1. **It fires at the point of use** — not at the start of the session when the agent is planning
+2. **It names the exact alternative** — not a general guideline
+3. **Subagents see it** — hooks fire for all agents, not just the main session
+4. **It can't be ignored** — the blocked tool call fails; the agent must adapt
+
+## Customization
+
+Adjust the file extension patterns to match your project. The examples above
+cover Java, Kotlin, TypeScript, JavaScript, and Python. Add or remove extensions
+as needed:
+
+```bash
+# Add Go and Rust
+grep -qE '\.(java|kt|ts|tsx|js|jsx|py|go|rs)$'
+```
+
+Remove patterns you don't need. If you don't use Maven, remove the `mvn` output
+parsing check. If you don't have `ide_replace_text_in_file` (requires plugin
+version with PR #238), the `Edit replace_all` fallback still works.

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -109,7 +109,54 @@ if [ -n "$UPSTREAM_BASE" ]; then
     [ -z "$NEW_TOOLS" ] && ok "No new tools added (or none detected)"
 fi
 
-# ── 6. Unit tests ────────────────────────────────────────────────────────────
+# ── 6. Code correctness — proxy safety ───────────────────────────────────────
+hdr "Reflection proxy safety"
+
+PROXY_FILES=$(grep -rln "Proxy.newProxyInstance" src/main/ 2>/dev/null || true)
+if [ -n "$PROXY_FILES" ]; then
+    PROXY_UNSAFE=""
+    for pf in $PROXY_FILES; do
+        if ! grep -q '"equals"' "$pf" 2>/dev/null; then
+            PROXY_UNSAFE="$PROXY_UNSAFE  $pf\n"
+        fi
+    done
+    if [ -n "$PROXY_UNSAFE" ]; then
+        fail "Proxy.newProxyInstance without equals/hashCode/toString handling:"
+        printf "$PROXY_UNSAFE"
+    else
+        ok "All proxies handle equals/hashCode/toString"
+    fi
+else
+    ok "No Proxy.newProxyInstance calls found"
+fi
+
+# ── 7. Code correctness — silent exception swallowing ────────────────────────
+hdr "Exception handling"
+
+if [ -n "$UPSTREAM_BASE" ]; then
+    SILENT_CATCH_NULL=$(git diff "$UPSTREAM_BASE" HEAD -- src/main/ 2>/dev/null | grep -c '^\+.*catch.*(_:.*Exception).*null' || true)
+    SILENT_CATCH_NULL=${SILENT_CATCH_NULL:-0}
+    if [ "$SILENT_CATCH_NULL" -gt 0 ] 2>/dev/null; then
+        fail "$SILENT_CATCH_NULL new catch blocks return null — verify each distinguishes 'unavailable' from 'broken' (CONTRIBUTING.md § Error handling)"
+    else
+        ok "No new catch-and-return-null patterns in diff"
+    fi
+fi
+
+# ── 8. Code correctness — test skip honesty ──────────────────────────────────
+hdr "Test skip honesty"
+
+if [ -n "$UPSTREAM_BASE" ]; then
+    EARLY_RETURN=$(git diff "$UPSTREAM_BASE" HEAD -- src/test/ 2>/dev/null | grep -cE '^\+.*(if.*!.*available|if.*!.*require).*return' || true)
+    EARLY_RETURN=${EARLY_RETURN:-0}
+    if [ "$EARLY_RETURN" -gt 0 ] 2>/dev/null; then
+        fail "$EARLY_RETURN new early-return test skips — use Assume.assumeTrue() instead (CONTRIBUTING.md § Test honesty)"
+    else
+        ok "No early-return test skips in diff"
+    fi
+fi
+
+# ── 9. Unit tests ─────────────────────────────────────────────────────────────
 hdr "Unit tests"
 
 echo "  Running ./gradlew test --tests \"*UnitTest*\" ..."

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -166,6 +166,12 @@ These tools exist but are disabled by default. They are omitted from `tools/list
 Note: `ide_restart` terminates the MCP connection — reconnect your client after calling it.
 Note: `ide_close_project` refuses to close the last open project; `ide_open_project` requires an absolute path and may take up to `timeoutSeconds` (default 600) while the project indexes.
 
+## Enforcing IDE Tool Usage with Hooks
+
+Claude Code hooks can block `grep`, `sed`, `Edit`, and `rm` on source files and redirect agents to the correct IDE tool. This prevents fallback to text-based operations that bypass the index.
+
+See [claude-code-hooks.md](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/blob/main/docs/claude-code-hooks.md) for ready-to-use hook scripts.
+
 ## Detailed Tool Parameters
 
 For complete parameter reference with types, defaults, and return formats, see [tools-reference.md](references/tools-reference.md).


### PR DESCRIPTION
## Summary

- Add a Code correctness review section to CONTRIBUTING.md with a mandatory checklist covering 7 categories of bugs
- Extend check-pr.sh with 3 new automated checks that catch the most common patterns statically
- Add docs/claude-code-hooks.md with ready-to-use Claude Code hooks that enforce IDE tool usage over bash fallbacks

## Why this PR exists

Over the last several PRs (#224, #233, #238), the maintainer has consistently caught the same categories of code correctness bugs during review:

- **Threading violations**: PSI reads on bare Ktor coroutine threads without suspendingReadAction (#238)
- **Proxy NPE**: Proxy.newProxyInstance returning null for equals/hashCode, causing NPE during Disposer.dispose (#238, also latent in BuildListenerUtils.kt on main)
- **Error conflation**: catch Exception returning null, making "Maven plugin missing" and "import crashed" indistinguishable (#224)
- **Sibling inconsistency**: Bug fixed in JavaMemberResolver but identical bug left in JavaScriptMemberResolver (#233)
- **Dead code**: Methods removed from callers but left on interfaces across 3 implementations (#233)
- **Silent test passes**: Early-return test skips that show green in CI but never actually ran (#233)
- **Set logic**: Set subtraction on module paths that does not account for nested Maven reactors (#224)

### Why the contributor's AI keeps missing these despite being asked

The contributor has repeatedly asked their AI assistant to "find all the types of issues the maintainer finds, so we don't waste their time." The AI consistently acknowledges this request but then performs surface-level pattern matching on the diff — checking naming conventions, schema completeness, and registration — instead of tracing execution paths from the Ktor handler through threading contexts to PSI operations.

The root cause: **reviewing a diff is not the same as tracing how the code executes.** The diff shows what changed; it doesn't show that the change runs on a thread without a read lock, or that a proxy will be stored in a DisposableWrapperList that calls equals() during removal. These bugs require following the execution path from entry point to final operation, which is a fundamentally different activity than reviewing textual changes.

### Why we think this will help

1. **The checklist forces the trace.** Each item says "start at doExecute(), follow every call that eventually reaches a PsiElement" — not "check if the code looks right." This converts a judgment call into a mechanical procedure.

2. **The automated checks catch the most common patterns.** The proxy check alone would have prevented the BuildListenerUtils NPE that is currently on main, and the two identical bugs in StructuralSearchReplaceTool. The test-honesty check would have caught 13 silently-passing TypeScript tests.

3. **It is hard to skip.** The checklist uses checkbox syntax visible in the PR diff. The automated checks run as part of check-pr.sh (the established pre-push gate). An LLM following CONTRIBUTING.md will see these checks inline with the registration checklist it already follows.

4. **Each item links to a real bug.** Every item maps to a production defect from the last 3 PRs, not theoretical guidance.

## What changed

### CONTRIBUTING.md

New section "Code correctness review — mandatory before every push" with 7 subsections:
- Threading: trace every doExecute to PSI
- Reflection proxies: handle Object methods
- Error handling: distinguish "unavailable" from "broken"
- Sibling consistency: same fix in all language resolvers
- Dead code: trace from interface to all implementations
- Test honesty: conditional skips must be visible
- Set operations: account for hierarchical containment

### scripts/check-pr.sh

Three new automated checks (sections 6-8):
- **Proxy safety**: scans all files with Proxy.newProxyInstance, checks each for "equals" handling
- **Exception handling**: detects new `catch (_: Exception)...null` patterns in the diff
- **Test skip honesty**: detects new early-return test skips instead of Assume in test diff

### docs/claude-code-hooks.md (NEW)

Ready-to-use Claude Code `PreToolUse` hook scripts that enforce IDE MCP tool usage. Two hooks:

- **Bash hook**: blocks grep/sed/find on source files, redirects to ide_search_text, ide_replace_text_in_file, ide_move_file, ide_refactor_safe_delete
- **Edit/Write hook**: blocks Edit/Write on existing source files, redirects to ide_edit_member, ide_replace_member, ide_insert_member, ide_create_file

Each hook includes rationale, the full script, a mapping table (blocked pattern → IDE alternative), and documented exceptions. The hooks work for subagents (which don't inherit prompt instructions) and fire at the point of use (not at session start).

Linked from README.md, USAGE.md, and SKILL.md.

## Test plan

- [x] check-pr.sh runs cleanly on this branch (proxy check correctly flags existing BuildListenerUtils.kt bug on main)
- [x] Hook scripts are self-contained and documented with installation instructions
- [ ] Verify checklist is visible and actionable in CONTRIBUTING.md
- [ ] Verify hooks doc renders correctly on GitHub
