### PR TITLE
v4.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+
+## [4.28.0] - 2026-07-18
 ### Added
 - **`ide_open_workspace`** — scan a root directory for Maven projects and open them all in one IntelliJ window with full cross-project code intelligence. Creates a temporary Maven aggregator POM with relative module paths. Also accepts an explicit `modules` array of absolute paths for ad-hoc workspaces — same module combination (in any order) reuses the cached workspace via SHA-based naming. Only available when the Maven plugin is installed. *(disabled by default)*
 - **`ide_structural_search_replace`** — Pattern-based code search and transformation using IntelliJ's Structural Search and Replace engine. Accepts a `searchPattern` with optional `replacePattern` for search-only or search-and-replace operations. Supports `filePattern` and `scope` filtering. Returns match count, replaced count, and match list. *(disabled by default)* — Java, Kotlin.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.27.0
+pluginVersion = 4.28.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Release 4.28.0

Cuts the accumulated `[Unreleased]` changes as **4.28.0** (minor bump — 5 new tools since 4.27.0).

### Changes
- Bump `pluginVersion` 4.27.0 → 4.28.0
- Promote `CHANGELOG.md` `[Unreleased]` → `## [4.28.0] - 2026-07-18`, leaving a fresh empty `[Unreleased]`

### Included in this release (Added)
- **`ide_open_workspace`** — scan a root dir for Maven projects and open them all in one window *(disabled by default)*
- **`ide_structural_search_replace`** — Structural Search and Replace engine (Java, Kotlin) *(disabled by default)*
- **`ide_change_signature`** — change method signature with caller updates (Java) *(disabled by default)*
- **`ide_replace_text_in_file`** — find/replace via IntelliJ Document API *(disabled by default)*
- **`ide_create_file`** — create a source file through IntelliJ VFS, immediately indexed *(disabled by default)*

All five tools were already documented across README/USAGE/CLAUDE/SKILL/tools-reference in their feature PRs, so no other docs required changes.

### Validation
- `./scripts/check-pr.sh` — 13/13 passed (unit tests green on JDK 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)