### PR TITLE
v4.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [4.30.0] - 2026-07-19
+### Added
+- **`ide_edit_member`** — replace an entire class member declaration (signature + body) by structural name, not text match. Targets by file, class, and member name with optional overload disambiguation. Auto-reformats after editing. Supports Java and Kotlin. *(disabled by default)*
+- **`ide_insert_member`** — insert a new member (method, field, inner class) at a structural position relative to an anchor member or at the start/end of a class body. Auto-reformats after insertion. Supports Java and Kotlin. *(disabled by default)*
+- **`ide_replace_member`** — replace the body of a method/function or the initializer of a field/property, preserving the member's signature. Targets by structural name. Auto-reformats after editing. Supports Java and Kotlin. *(disabled by default)*
+- **`ide_file_structure` now includes `endLine`** — each member in the structure tree now reports its end line alongside the start line, enabling precise line-range reads via `ide_read_file(startLine, endLine)`.
+
 ## [4.29.0] - 2026-07-19
 ### Added
 - **`ide_list_tests`** — List all test methods/classes discovered by the IDE's test framework extension points (JUnit, TestNG, etc.) *(disabled by default)*
@@ -16,10 +23,6 @@
 - **`ide_change_signature`** — Change a method's signature (name, return type, visibility, parameters) with automatic caller updates using IntelliJ's Change Signature refactoring. Accepts `file` + `line` + `column` to identify the method, plus optional `newName`, `newReturnType`, `newVisibility`, and `newParameters` array. Supports `generateDelegate` to preserve binary compatibility. *(disabled by default)* — Java.
 - **`ide_replace_text_in_file`** — Find and replace text (literal or regex) in a file through IntelliJ's Document API. Changes are immediately indexed. Use for mechanical text substitutions that don't need structural refactoring. *(disabled by default)*
 - **`ide_create_file`** — Create a new source file through IntelliJ's VFS, immediately indexed and available for all IDE tools without needing `ide_sync_files`. Use instead of the Write tool for `.java`, `.kt`, `.ts`, `.tsx` files. *(disabled by default)*
-- **`ide_edit_member`** — replace an entire class member declaration (signature + body) by structural name, not text match. Targets by file, class, and member name with optional overload disambiguation. Auto-reformats after editing. Supports Java and Kotlin. *(disabled by default)*
-- **`ide_insert_member`** — insert a new member (method, field, inner class) at a structural position relative to an anchor member or at the start/end of a class body. Auto-reformats after insertion. Supports Java and Kotlin. *(disabled by default)*
-- **`ide_replace_member`** — replace the body of a method/function or the initializer of a field/property, preserving the member's signature. Targets by structural name. Auto-reformats after editing. Supports Java and Kotlin. *(disabled by default)*
-- **`ide_file_structure` now includes `endLine`** — each member in the structure tree now reports its end line alongside the start line, enabling precise line-range reads via `ide_read_file(startLine, endLine)`.
 
 ## [4.27.0] - 2026-07-02
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.29.0
+pluginVersion = 4.30.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Release 4.30.0

Version bump + changelog for the AST-level code editing tools that shipped in #233 (merged after 4.29.0).

### Changes
- `gradle.properties`: `pluginVersion` 4.29.0 → **4.30.0** (new tools → minor bump)
- `CHANGELOG.md`: new `[4.30.0]` section listing the user-facing changes since 4.29.0:
  - `ide_edit_member`, `ide_insert_member`, `ide_replace_member` (all *disabled by default*)
  - `ide_file_structure` now includes `endLine`
- Moved those four entries out of the already-released `[4.28.0]` section, where #233 had mis-filed them — they did not exist at 4.28.0 (or 4.29.0). `[Unreleased]` is left empty.

Tool docs (README/USAGE/CLAUDE/SKILL/tools-reference) were already updated by #233, so no further doc changes are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)