### PR TITLE
ci: activate JetBrains Marketplace publishing from GitHub Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,10 +237,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(./gradlew properties --property version --quiet --console=plain | tail -n 1 | cut -f2- -d ' ')
+
+          # All drafts were deleted above, so any remaining release with this tag is published
+          if gh release view "$VERSION" &>/dev/null; then
+            echo "Release $VERSION already published — skipping draft creation."
+            exit 0
+          fi
+
+          # Draft notes: prefer the version's own section (populated by the version-bump PR),
+          # fall back to [Unreleased] for the template flow where entries move at release time
           RELEASE_NOTE="./build/tmp/release_note.txt"
-          ./gradlew getChangelog --unreleased --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
-          
-          gh release create $VERSION \
+          if grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            ./gradlew getChangelog --project-version="$VERSION" --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
+          else
+            ./gradlew getChangelog --unreleased --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
+          fi
+
+          gh release create "$VERSION" \
             --draft \
-            --title $VERSION \
+            --title "$VERSION" \
             --notes-file $RELEASE_NOTE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,19 @@ jobs:
         with:
           cache-read-only: true
 
-      # Update the Unreleased section with the current release note
+      # Move the Unreleased section under the released version. Skipped when CHANGELOG.md
+      # already contains this version's section (entries moved manually in the version-bump PR).
       - name: Patch Changelog
         if: ${{ github.event.release.body != '' }}
         env:
           CHANGELOG: ${{ github.event.release.body }}
         run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          if grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "CHANGELOG.md already contains a [$VERSION] section — skipping patch."
+            exit 0
+          fi
+
           RELEASE_NOTE="./build/tmp/release_note.txt"
           mkdir -p "$(dirname "$RELEASE_NOTE")"
           echo "$CHANGELOG" > $RELEASE_NOTE
@@ -71,12 +78,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
-      # Create a pull request
+      # Open a PR with the patched CHANGELOG.md (no-op when Patch Changelog was skipped)
       - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged — skipping pull request."
+            exit 0
+          fi
+
           VERSION="${{ github.event.release.tag_name }}"
           BRANCH="changelog-update-$VERSION"
           LABEL="release changelog"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,7 +551,7 @@ Before pushing, run the pre-push validation script to catch common mistakes auto
 ```
 
 Quick summary of the non-negotiables:
-1. `CHANGELOG.md` — empty `[Unreleased]` section (maintainer adds the release entry)
+1. `CHANGELOG.md` — user-visible changes go under `[Unreleased]`; never add `## [x.y.z]` version sections (created at release time)
 2. No `.idea/gradle.xml`, no `scripts/build-install.sh`, no `docs/pr-*.md`
 3. New tools: registered in `ToolNames`, `ToolRegistry`, and all six doc locations (`README.md`, `USAGE.md`, `CLAUDE.md`, `SKILL.md`, `tools-reference.md`, `ToolNames.ALL` sorted)
 4. New opt-in tools: add to `McpSettings.DEFAULT_DISABLED_TOOLS`, bump the settings schema, and add a migration so existing users also get the tool disabled by default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,21 @@ When requested, follow [SemVer](https://semver.org):
 | New tool / new feature | Minor (`x.Y.0`) |
 | Breaking schema / transport change | Major (`X.0.0`) |
 
+### Releasing (maintainer)
+
+Releases are published from GitHub — no manual Marketplace upload:
+
+1. Merge a version-bump PR (`pluginVersion` in `gradle.properties`). Changelog entries may stay
+   in `[Unreleased]` — the release pipeline moves them under the new version.
+2. The Build workflow on `main` creates a draft GitHub Release carrying the pending change notes.
+3. Press **Publish release** on the draft. The Release workflow signs the plugin, publishes it to
+   JetBrains Marketplace, attaches the zip to the release, and — if entries were still in
+   `[Unreleased]` — opens a `Changelog update - x.y.z` PR that moves them; merge it.
+
+Manually moving entries into a `## [x.y.z]` section in the bump PR also works: the pipeline
+detects the existing section and skips the changelog patch/PR. A `-beta.N` version suffix
+published as a GitHub **prerelease** goes to the Marketplace `beta` channel instead of stable.
+
 ---
 
 ## Adding a new tool — complete checklist

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,9 +184,10 @@ tasks {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
 
-    publishPlugin {
-        dependsOn(patchChangelog)
-    }
+    // NOTE: publishPlugin intentionally does NOT depend on patchChangelog (upstream template
+    // removed it too). At publish time CHANGELOG.md already contains the version section —
+    // either from the version-bump PR or from the Release workflow's explicit patch step —
+    // and re-patching with an empty [Unreleased] would create a duplicate section.
 
 //    runIde {
 //        jvmArgs("-Xmx20g", "-Xms1g")

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -18,7 +18,7 @@ if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
 else
     fail "Missing ## [Unreleased] section — add one for user-visible changes"
 fi
-if git diff "${UPSTREAM_BASE:-HEAD~1}" HEAD -- CHANGELOG.md 2>/dev/null | grep -qE '"^\+## \[[0-9]"'; then
+if git diff "${UPSTREAM_BASE:-HEAD~1}" HEAD -- CHANGELOG.md 2>/dev/null | grep -qE '^\+## \[[0-9]'; then
     fail "New versioned release entry added — only the maintainer creates ## [x.y.z] sections"
 else
     ok "No versioned release entries added by contributor"


### PR DESCRIPTION
## What

The repo already carried the template's full CD pipeline — and all four publishing secrets (`PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`) have been configured since 2025-11-28 — but `release.yml` has never run and had drifted from upstream. This PR makes the pipeline actually work, supporting **both** changelog flows:

- **Template flow**: leave entries in `[Unreleased]`, bump only `pluginVersion`. On publish, CI moves them under the new version and opens a `Changelog update - x.y.z` PR.
- **Manual flow** (current habit): move entries into `## [x.y.z]` in the bump PR. CI detects the existing section and skips the patch/PR.

## Changes

- **release.yml** — skip `patchChangelog` when `CHANGELOG.md` already contains the version section; replace the dead `steps.properties` condition on the changelog-PR step (stale template leftover — it could never run) with a real `git diff` guard
- **build.gradle.kts** — remove `publishPlugin { dependsOn(patchChangelog) }`: at publish time the changelog is already patched (by the bump PR or by the workflow step), and re-patching an empty `[Unreleased]` would create a duplicate version section. Upstream template removed this dependency too.
- **build.yml** — draft release notes now come from the version's own changelog section when it exists (drafts were empty, e.g. the current 4.30.0 draft); skip draft creation when a published release with that tag already exists, so pushes to `main` after a release don't fail the `releaseDraft` job
- **check-pr.sh** — fix a quoting bug: the "no versioned changelog entries" grep had literal quotes inside the pattern, so it could never fail
- **CONTRIBUTING.md / CLAUDE.md** — document the release flow; fix the CLAUDE.md checklist line that contradicted CONTRIBUTING.md about `[Unreleased]`

## How to release after this merges

1. Merge a version-bump PR (4.31.0+ — **4.30.0 is already on the Marketplace**, so publishing its draft would be rejected as a duplicate version)
2. Wait for Build on `main` to go green → a draft release appears with the change notes
3. Press **Publish release** → signed upload to the Marketplace, zip attached to the release

First run exercises the secrets for the first time; if it fails, it'll be the token (regenerate at Marketplace → My Tokens) or PEM formatting in the certificate secrets — a failed publish leaves the Marketplace untouched and the workflow can simply be re-run. For a zero-risk rehearsal, publish a `x.y.z-beta.1` **prerelease** — it goes to the `beta` channel only.

## Validation

- `./scripts/check-pr.sh` — all 13 checks pass (incl. unit tests with the modified build script)
- Both workflows YAML-parsed; `bash -n` on check-pr.sh
- `--release-note-file` and `--project-version` verified against gradle-changelog-plugin 2.4.0 sources/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)