### PR TITLE
fix: ide_search_text supports multi-line queries

### DIFF
--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
@@ -123,9 +123,11 @@ class SearchTextTool : AbstractMcpTool() {
         } catch (e: PatternSyntaxException) {
             return createErrorResult("Invalid filePattern mask: ${e.message}")
         }
-        val findModel = if (regex) {
+        val isMultiline = !regex && query.contains("\n")
+        val findModel = if (regex || isMultiline) {
             try {
-                createFindModel(project, query, caseSensitive, filePattern, findSearchContext)
+                val effectiveQuery = if (isMultiline) java.util.regex.Pattern.quote(query) else query
+                createFindModel(project, effectiveQuery, caseSensitive, filePattern, findSearchContext)
             } catch (e: PatternSyntaxException) {
                 return createErrorResult("Invalid regex query: ${e.message}")
             } catch (e: IllegalArgumentException) {


### PR DESCRIPTION
## Summary

- Non-regex queries containing newlines now auto-route to the FindInFiles path instead of the word index
- The word index (`PsiSearchHelper.processElementsWithWord`) splits text into individual words and fundamentally cannot match multi-line patterns
- Multi-line queries are escaped with `Pattern.quote()` to preserve literal matching, then routed through `FindModel` which already has `isMultiline = true`

## Example

Before: `{"query": "Map.class,\n            input"}` → no results (word index splits on whitespace/newlines)

After: same query → finds the multi-line match via FindInFiles

## Test plan

- [x] Unit tests pass
- [ ] Manual verification with multi-line query in runIde

🤖 Generated with [Claude Code](https://claude.com/claude-code)