### PR TITLE
fix: block temp script hook bypass in claude-code-hooks

### DIFF
--- a/docs/claude-code-hooks.md
+++ b/docs/claude-code-hooks.md
@@ -100,15 +100,26 @@ if echo "$CMD" | grep -qE 'sed\s+-[a-zA-Z]*i' && \
   exit 2
 fi
 
-# python3 bulk replacement → ide_replace_text_in_file
-# Exception: scripts in /tmp/ are development tooling
-if echo "$CMD" | grep -qE 'python3\s' && \
-   echo "$CMD" | grep -qE '\.java|\.kt|\.ts|\.tsx|\.js|\.jsx|\.py' && \
-   echo "$CMD" | grep -qE 'replace|sub\(|re\.sub'; then
-  if echo "$CMD" | grep -qE 'python3\s+/tmp/'; then
-    exit 0
-  fi
-  echo "BLOCK: Use ide_replace_text_in_file instead of Python bulk replacement on source files." >&2
+# python3 /tmp/ scripts — common hook bypass pattern.
+# Agents write Python scripts to /tmp that do file I/O on source files,
+# circumventing Edit/Write hooks. Block when python3 /tmp/ is the actual
+# command, not just mentioned in a string argument to another command.
+if echo "$CMD" | grep -qE '^python3\s+/tmp/' || \
+   echo "$CMD" | grep -qE '&&\s*python3\s+/tmp/|;\s*python3\s+/tmp/|\|\s*python3\s+/tmp/'; then
+  echo "BLOCK: Do not use python3 /tmp/ scripts to edit source files — this bypasses IntelliJ MCP hooks. Use ide_replace_text_in_file, ide_edit_member, ide_insert_member, or ide_create_file instead." >&2
+  exit 2
+fi
+
+# python3 -c with source file extensions (inline write scripts)
+# Only matches when python3 is the actual command (start of line or after && ; |).
+# Word-bounded extensions prevent .json/.jsonl false positives.
+# Python (.py) is excluded — Hook 2 does not block Python file edits
+# because there is no IDE structural editing support for Python yet.
+if (echo "$CMD" | grep -qE '^python3\s' || \
+    echo "$CMD" | grep -qE '&&\s*python3\s|;\s*python3\s|\|\s*python3\s') && \
+   echo "$CMD" | grep -qE '\.java\b|\.kt\b|\.ts\b|\.tsx\b|\.js\b|\.jsx\b' && \
+   echo "$CMD" | grep -qE 'write\(|replace|sub\(|re\.sub'; then
+  echo "BLOCK: Use IntelliJ MCP tools instead of Python file manipulation on source files." >&2
   exit 2
 fi
 
@@ -146,6 +157,7 @@ exit 0
 | `grep -r "pattern" src/` | `ide_search_text` or `ide_find_references` |
 | `find . -name "*.java" \| xargs grep` | `ide_search_text` |
 | `sed -i 's/old/new/g' File.java` | `ide_replace_text_in_file` or `ide_refactor_rename` |
+| `python3 /tmp/script.py` (hook bypass) | `ide_replace_text_in_file`, `ide_edit_member`, etc. |
 | `python3 script.py` (bulk replace) | `ide_replace_text_in_file` |
 | `mv File.java newdir/` | `ide_move_file` |
 | `cp File.java Copy.java` | IDE refactoring |
@@ -155,7 +167,7 @@ exit 0
 
 - `mv` to `/tmp/` is allowed (backup, not a refactoring)
 - `rm` warns but doesn't block (delete-to-recreate is a valid pattern when a file has errors that prevent IDE tools from working)
-- Python scripts in `/tmp/` are allowed (development tooling)
+- `python3 /tmp/` is **blocked** — agents use this to bypass Edit/Write hooks by writing Python scripts that do file I/O directly
 
 ---
 

--- a/tests/hook-tests.sh
+++ b/tests/hook-tests.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Tests for intellij-first.sh hook
+# Run: bash tests/hook-tests.sh
+#
+# Each test sends a JSON payload to the hook via stdin (simulating Claude Code's
+# PreToolUse event) and checks the exit code:
+#   0 = allowed
+#   2 = blocked
+#
+# Usage: assert_blocked "test name" "command string"
+#        assert_allowed "test name" "command string"
+
+HOOK="$(dirname "$0")/../docs/intellij-first.sh"
+if [ ! -f "$HOOK" ]; then
+  # Fall back to the installed hook for development
+  HOOK="$HOME/.claude/hooks/intellij-first.sh"
+fi
+
+PASS=0
+FAIL=0
+
+assert_blocked() {
+  local name="$1"
+  local cmd="$2"
+  local json="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":$(echo "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))')}}"
+  local output
+  output=$(echo "$json" | bash "$HOOK" 2>&1)
+  local rc=$?
+  if [ $rc -eq 2 ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL (expected BLOCK): $name"
+    echo "  command: $cmd"
+    echo "  exit: $rc"
+    echo "  output: $output"
+  fi
+}
+
+assert_allowed() {
+  local name="$1"
+  local cmd="$2"
+  local json="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":$(echo "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))')}}"
+  local output
+  output=$(echo "$json" | bash "$HOOK" 2>&1)
+  local rc=$?
+  if [ $rc -eq 0 ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL (expected ALLOW): $name"
+    echo "  command: $cmd"
+    echo "  exit: $rc"
+    echo "  output: $output"
+  fi
+}
+
+echo "=== Pattern 1: grep -r on source files ==="
+assert_blocked "grep -rn on java"            'grep -rn "pattern" --include="*.java" src/'
+assert_blocked "grep -rl on kotlin"           'grep -rl "pattern" --include="*.kt" src/'
+assert_blocked "grep -r on src/main"          'grep -r "something" src/main/'
+assert_blocked "grep -r on src/test"          'grep -r "something" src/test/'
+assert_allowed "grep without -r"              'grep "pattern" file.txt'
+assert_allowed "grep -r on non-source"        'grep -r "pattern" docs/'
+assert_allowed "grep on single file"          'grep "pattern" src/main/java/Foo.java'
+
+echo ""
+echo "=== Pattern 2: mvn piped to grep ==="
+assert_blocked "mvn compile | grep"           'mvn compile | grep ERROR'
+assert_blocked "mvn package | awk"            'mvn package | awk "/ERROR/"'
+assert_allowed "mvn compile alone"            'mvn compile'
+assert_allowed "mvn test (not matched)"        'mvn test | grep FAIL'
+
+echo ""
+echo "=== Pattern 3: find + grep on source files ==="
+assert_blocked "find java + grep"             'find . -name "*.java" | xargs grep "pattern"'
+assert_blocked "find kt + grep"               'find . -name "*.kt" | grep -l "pattern"'
+assert_allowed "find without grep"            'find . -name "*.java" -type f'
+assert_allowed "find non-source + grep"       'find . -name "*.md" | xargs grep "pattern"'
+
+echo ""
+echo "=== Pattern 4: sed -i on source files ==="
+assert_blocked "sed -i on java"               'sed -i "s/old/new/g" src/Foo.java'
+assert_blocked "sed -ie on kotlin"            'sed -ie "s/old/new/" src/Bar.kt'
+assert_allowed "sed without -i"               'sed "s/old/new/" src/Foo.java'
+assert_allowed "sed -i on non-source"         'sed -i "s/old/new/" config.yml'
+
+echo ""
+echo "=== Pattern 5: python3 /tmp/ scripts (hook bypass) ==="
+assert_blocked "python3 /tmp/fix.py"          'python3 /tmp/fix-resolver.py'
+assert_blocked "python3 /tmp/script.py"       'python3 /tmp/script.py'
+assert_blocked "python3 /tmp/edit.py"         'python3 /tmp/edit-member.py'
+
+echo ""
+echo "=== Pattern 5: false positives that should be ALLOWED ==="
+assert_allowed "gh pr create mentioning tmp"  'gh pr create --title "fix" --body "block python3 /tmp/ bypass"'
+assert_allowed "echo mentioning tmp"          'echo "the hook blocks python3 /tmp/ scripts"'
+assert_allowed "git commit with tmp in msg"   'git commit -m "fix: block python3 /tmp/ bypass"'
+assert_allowed "cat a doc mentioning tmp"     'cat docs/hooks.md'
+assert_allowed "grep for tmp pattern"         'grep "python3 /tmp/" docs/hooks.md'
+
+echo ""
+echo "=== Pattern 5: chained commands with tmp scripts ==="
+assert_blocked "cmd && python3 /tmp/"         'echo "setup" && python3 /tmp/fix.py'
+assert_blocked "cmd ; python3 /tmp/"          'cd /project ; python3 /tmp/edit.py'
+assert_blocked "pipe to python3 /tmp/"        'cat data | python3 /tmp/process.py'
+
+echo ""
+echo "=== Pattern 5b: python3 -c inline file manipulation ==="
+assert_blocked "python3 inline write java"    'python3 -c "open(\"Foo.java\",\"w\").write(\"x\")"'
+assert_blocked "python3 inline re.sub kt"     'python3 -c "import re; re.sub(\"x\",\"y\",open(\"Bar.kt\").read())"'
+assert_allowed "python3 -c no file ext"       'python3 -c "print(42)"'
+assert_allowed "python3 -c with .py import"   'python3 -c "import json; print(json.dumps({}))"'
+
+echo ""
+echo "=== Pattern 5b: false positives fixed ==="
+assert_allowed "python3 read package.json"    'python3 -c "print(open(\"package.json\").read())"'
+assert_allowed "python3 read tsconfig.json"   'python3 -c "print(open(\"tsconfig.json\").read())"'
+assert_allowed "python3 read .ts file"        'python3 -c "print(open(\"config.ts\").read())"'
+assert_allowed "python3 .py not blocked"      'python3 migrate.py --replace src/app.py'
+assert_allowed "gh pr comment with .ts+replace"  'gh pr comment 252 --body "reading a .ts file and ide_replace_text_in_file"'
+
+echo ""
+echo "=== Pattern 6: mv on source files ==="
+assert_blocked "mv java file"                 'mv src/Old.java src/New.java'
+assert_blocked "mv kotlin file"               'mv src/Old.kt src/New.kt'
+assert_allowed "mv java to /tmp/"             'mv src/Backup.java /tmp/'
+assert_allowed "mv non-source"                'mv old.yml new.yml'
+
+echo ""
+echo "=== Pattern 7: cp on source files ==="
+assert_blocked "cp java file"                 'cp src/Foo.java src/FooCopy.java'
+assert_allowed "cp non-source"                'cp config.yml config.bak'
+
+echo ""
+echo "=== Pattern 8: rm on source files (warn, don't block) ==="
+assert_allowed "rm java file (warn only)"     'rm src/Foo.java'
+assert_allowed "rm kotlin file (warn only)"   'rm src/Bar.kt'
+
+echo ""
+echo "=== Safe commands that should never be blocked ==="
+assert_allowed "git status"                   'git status'
+assert_allowed "git log"                      'git log --oneline -5'
+assert_allowed "git diff"                     'git diff HEAD~1'
+assert_allowed "ls"                           'ls -la src/'
+assert_allowed "cat a java file"              'cat src/Foo.java'
+assert_allowed "pwd"                          'pwd'
+assert_allowed "gradlew test"                 './gradlew test --tests "*UnitTest*"'
+assert_allowed "gh pr list"                   'gh pr list --repo owner/repo'
+assert_allowed "python3 version"              'python3 --version'
+assert_allowed "python3 json one-liner"       "python3 -c 'import json; print(json.dumps({\"a\": 1}))'"
+
+echo ""
+echo "════════════════════════════"
+echo "  Passed: $PASS  Failed: $FAIL"
+echo "════════════════════════════"
+
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Agents bypass Edit/Write hooks by writing scripts to temp directories that manipulate source files directly via file I/O
- The previous hook had an explicit exception allowing temp script execution — this was the exact escape hatch agents exploited
- Now temp script execution is blocked with an error message naming the correct IDE tools
- Also adds a pattern catching inline Python commands that write to source files

## Why this matters

The hooks exist to enforce IDE MCP tool usage (ide_replace_text_in_file, ide_edit_member, etc.) so changes go through IntelliJ's Document/PSI layer. Temp scripts bypass VFS, PSI, indexing, and undo — the IDE doesn't see the changes until a manual sync.

## Test plan

- [x] Hook blocks temp script execution with actionable error message
- [x] Normal bash commands still work
- [x] Unit tests pass
