### PR TITLE
fix: refresh VFS before optimize-imports and reformat

### DIFF
--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Optimizes imports in a file without reformatting code.
@@ -50,6 +49,11 @@ class OptimizeImportsTool : AbstractMcpTool() {
         val file = requiredStringArg(arguments, ParamNames.FILE).getOrElse {
             return createErrorResult(it.message ?: "Missing required parameter: file")
         }
+
+        // Refresh VFS for the target file to pick up external changes before PSI resolution.
+        // Without this, the stub index can be stale when files are modified by external tools,
+        // causing "Outdated stub in index" errors during import optimization.
+        resolveFile(project, file)?.refresh(false, false)
 
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Resolve file (suspending read action)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -10,7 +10,6 @@ import com.intellij.codeInsight.actions.AbstractLayoutCodeProcessor
 import com.intellij.codeInsight.actions.OptimizeImportsProcessor
 import com.intellij.codeInsight.actions.RearrangeCodeProcessor
 import com.intellij.codeInsight.actions.ReformatCodeProcessor
-import com.intellij.openapi.application.EDT
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
@@ -92,6 +91,11 @@ class ReformatCodeTool : AbstractMcpTool() {
             if (startLine < 1) return createErrorResult("startLine must be >= 1")
             if (endLine < startLine) return createErrorResult("endLine must be >= startLine")
         }
+
+        // Refresh VFS for the target file to pick up external changes before PSI resolution.
+        // Without this, the stub index can be stale when files are modified by external tools,
+        // causing "Outdated stub in index" errors during import optimization or reformatting.
+        resolveFile(project, file)?.refresh(false, false)
 
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Resolve file and validate (suspending read action)


### PR DESCRIPTION
## Summary

- `ide_optimize_imports` and `ide_reformat_code` can throw "Outdated stub in index" when files were modified externally (by AI agents using Write/Edit)
- Fix: refresh VFS for the target file before PSI resolution, picking up external changes
- Same defensive pattern used by other tools that read externally-modified files

## Changes

- `OptimizeImportsTool.kt`: add `resolveFile(project, file)?.refresh(false, false)` before PSI phase
- `ReformatCodeTool.kt`: same fix
- Removed unused imports (`jsonPrimitive`, `EDT`)

## Test plan

- [x] Unit tests pass
- [x] `check-pr.sh` passes all 13 checks
- [ ] Manual verification: externally modify a file, then call `ide_reformat_code` — should not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)
