### PR TITLE
feat: add headless mode toggle to suppress dialogs blocking MCP tools

### DIFF
--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/ProjectResolver.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectMode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle.ProjectModeService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.HeadlessModeManager
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -427,6 +428,7 @@ object ProjectResolver {
     }
 
     private suspend fun reopenAndAwaitSmartMode(path: String): Project? {
+        HeadlessModeManager.trustProjectPath(path)
         // Only serialise the openProjectAsync call itself, not the indexing wait.
         //
         // The burst problem: multiple Claude sessions starting simultaneously each call

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/HeadlessModeManager.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/HeadlessModeManager.kt
@@ -1,0 +1,172 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.settings
+
+import com.intellij.ide.GeneralSettings
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.updateSettings.impl.UpdateSettings
+import com.intellij.openapi.vcs.VcsConfiguration
+import com.intellij.openapi.vcs.VcsShowConfirmationOption
+import com.intellij.openapi.vcs.ex.ProjectLevelVcsManagerEx
+
+object HeadlessModeManager {
+    private val LOG = logger<HeadlessModeManager>()
+
+    val SNAPSHOT_KEYS = setOf(
+        "syncOnFrameActivation", "backgroundSync", "showTipsOnStartup",
+        "confirmExit", "checkNeeded"
+    )
+
+    val isEnabled: Boolean
+        get() = McpSettings.getInstance().headlessMode
+
+    fun enable() {
+        val settings = McpSettings.getInstance()
+        if (settings.headlessMode) return
+
+        val general = GeneralSettings.getInstance()
+        val updates = UpdateSettings.getInstance()
+
+        settings.state.headlessPreToggleSnapshot = mutableMapOf(
+            "syncOnFrameActivation" to general.isSyncOnFrameActivation.toString(),
+            "backgroundSync" to general.isBackgroundSync.toString(),
+            "showTipsOnStartup" to general.isShowTipsOnStartup.toString(),
+            "confirmExit" to general.isConfirmExit.toString(),
+            "checkNeeded" to updates.isCheckNeeded.toString()
+        )
+
+        general.isSyncOnFrameActivation = false
+        general.isBackgroundSync = true
+        general.isShowTipsOnStartup = false
+        general.isConfirmExit = false
+        updates.isCheckNeeded = false
+
+        // Snapshot and silence VCS for all currently open projects
+        for (project in ProjectManager.getInstance().openProjects) {
+            if (!project.isDefault) snapshotAndSilenceVcs(project, settings)
+        }
+
+        settings.headlessMode = true
+        LOG.info("Headless mode enabled")
+    }
+
+    fun disable() {
+        val settings = McpSettings.getInstance()
+        if (!settings.headlessMode) return
+
+        val snapshot = settings.state.headlessPreToggleSnapshot
+        if (snapshot.isNotEmpty()) {
+            val general = GeneralSettings.getInstance()
+            val updates = UpdateSettings.getInstance()
+            snapshot["syncOnFrameActivation"]?.toBooleanStrictOrNull()?.let { general.isSyncOnFrameActivation = it }
+            snapshot["backgroundSync"]?.toBooleanStrictOrNull()?.let { general.isBackgroundSync = it }
+            snapshot["showTipsOnStartup"]?.toBooleanStrictOrNull()?.let { general.isShowTipsOnStartup = it }
+            snapshot["confirmExit"]?.toBooleanStrictOrNull()?.let { general.isConfirmExit = it }
+            snapshot["checkNeeded"]?.toBooleanStrictOrNull()?.let { updates.isCheckNeeded = it }
+        }
+
+        // Restore VCS settings for all open projects
+        val vcsSnapshots = settings.state.headlessVcsSnapshots
+        for (project in ProjectManager.getInstance().openProjects) {
+            if (project.isDefault) continue
+            val key = project.basePath ?: continue
+            val vcsSnapshot = vcsSnapshots[key] ?: continue
+            try {
+                val vcsManager = ProjectLevelVcsManagerEx.getInstanceEx(project)
+                vcsSnapshot["vcsAdd"]?.let { value ->
+                    vcsManager.getConfirmation(VcsConfiguration.StandardConfirmation.ADD).value =
+                        VcsShowConfirmationOption.Value.valueOf(value)
+                }
+                vcsSnapshot["vcsRemove"]?.let { value ->
+                    vcsManager.getConfirmation(VcsConfiguration.StandardConfirmation.REMOVE).value =
+                        VcsShowConfirmationOption.Value.valueOf(value)
+                }
+            } catch (e: Exception) {
+                LOG.warn("Could not restore VCS settings for ${project.name}: ${e.message}")
+            }
+        }
+
+        settings.state.headlessPreToggleSnapshot.clear()
+        settings.state.headlessVcsSnapshots.clear()
+        settings.headlessMode = false
+        LOG.info("Headless mode disabled — settings restored")
+    }
+
+    fun applyProjectSettings(project: Project) {
+        if (!isEnabled) return
+        snapshotAndSilenceVcs(project, McpSettings.getInstance())
+    }
+
+    fun trustProjectPath(path: String) {
+        if (!isEnabled) return
+        try {
+            val clazz = Class.forName("com.intellij.ide.trustedProjects.TrustedProjects")
+            val setTrusted = clazz.methods.find {
+                it.name == "setProjectTrusted" && it.parameterCount == 2
+            }
+            if (setTrusted != null) {
+                // Try the path-based overload
+                val locatedProjectClass = Class.forName("com.intellij.ide.trustedProjects.TrustedProjects\$LocatedProject")
+                // Fall back to TrustedPaths if the API shape doesn't match
+                trustViaPath(path)
+            } else {
+                trustViaPath(path)
+            }
+        } catch (e: Exception) {
+            // Fall back to TrustedPaths
+            trustViaPath(path)
+        }
+    }
+
+    private fun trustViaPath(path: String) {
+        try {
+            val clazz = Class.forName("com.intellij.ide.impl.TrustedPaths")
+            val getInstance = clazz.getMethod("getInstance")
+            val instance = getInstance.invoke(null)
+            val setTrusted = clazz.getMethod("setProjectPathTrusted", java.nio.file.Path::class.java, Boolean::class.java)
+            setTrusted.invoke(instance, java.nio.file.Path.of(path), true)
+            LOG.info("Trusted project path: $path")
+        } catch (e: Exception) {
+            LOG.debug("Could not trust project path (API may not be available): ${e.message}")
+        }
+    }
+
+    fun reapplyIfEnabled() {
+        if (!McpSettings.getInstance().headlessMode) return
+        ApplicationManager.getApplication().invokeLater {
+            val general = GeneralSettings.getInstance()
+            val updates = UpdateSettings.getInstance()
+            general.isSyncOnFrameActivation = false
+            general.isBackgroundSync = true
+            general.isShowTipsOnStartup = false
+            general.isConfirmExit = false
+            updates.isCheckNeeded = false
+            LOG.info("Headless mode re-applied on startup")
+        }
+    }
+
+    private fun snapshotAndSilenceVcs(project: Project, settings: McpSettings) {
+        try {
+            val vcsManager = ProjectLevelVcsManagerEx.getInstanceEx(project)
+            val key = project.basePath ?: return
+
+            val addConfirmation = vcsManager.getConfirmation(VcsConfiguration.StandardConfirmation.ADD)
+            val removeConfirmation = vcsManager.getConfirmation(VcsConfiguration.StandardConfirmation.REMOVE)
+
+            // Only snapshot if we haven't already (idempotent for projects opened after enable)
+            if (key !in settings.state.headlessVcsSnapshots) {
+                settings.state.headlessVcsSnapshots[key] = mutableMapOf(
+                    "vcsAdd" to addConfirmation.value.name,
+                    "vcsRemove" to removeConfirmation.value.name
+                )
+            }
+
+            addConfirmation.value = VcsShowConfirmationOption.Value.DO_NOTHING_SILENTLY
+            removeConfirmation.value = VcsShowConfirmationOption.Value.DO_NOTHING_SILENTLY
+            LOG.info("Headless VCS settings applied to project: ${project.name}")
+        } catch (e: Exception) {
+            LOG.warn("Could not apply headless VCS settings to ${project.name}: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -100,6 +100,11 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
         var lifecycleLogToFile: Boolean = false,
         var minimumOpenProjects: Int = 4,
         var settingsSchemaVersion: Int = 0,
+        var maximumOpenProjects: Int = 10,
+        var headlessMode: Boolean = false,
+        var headlessPreToggleSnapshot: MutableMap<String, String> = mutableMapOf(),
+        var headlessDialogDismissed: Boolean = false,
+        var headlessVcsSnapshots: MutableMap<String, MutableMap<String, String>> = mutableMapOf(),
     )
 
     private var state = State()
@@ -187,6 +192,10 @@ class McpSettings : PersistentStateComponent<McpSettings.State> {
         get() = state.minimumOpenProjects
         set(value) { state.minimumOpenProjects = value }
 
+
+    var headlessMode: Boolean
+        get() = state.headlessMode
+        set(value) { state.headlessMode = value }
 
     fun isToolEnabled(toolName: String): Boolean = toolName !in state.disabledTools
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -52,6 +52,7 @@ class McpSettingsConfigurable : Configurable {
     private var availableProjectsModeComboBox: ComboBox<McpSettings.AvailableProjectsMode>? = null
     private var responseFormatComboBox: ComboBox<McpSettings.ResponseFormat>? = null
     private val toolCheckBoxes = mutableMapOf<String, JBCheckBox>()
+    private var headlessModeCheckBox: JBCheckBox? = null
     private var uiDisposable: Disposable? = null
 
     // Lifecycle UI fields
@@ -139,6 +140,10 @@ class McpSettingsConfigurable : Configurable {
             add(warningRow)
         }
 
+        headlessModeCheckBox = JBCheckBox(McpBundle.message("headless.enabled.label")).apply {
+            toolTipText = McpBundle.message("headless.enabled.tooltip")
+        }
+
         val availableToolsPanel = createToolsPanel()
         val lifecyclePanel = createLifecyclePanel()
 
@@ -150,6 +155,9 @@ class McpSettingsConfigurable : Configurable {
             .addLabeledComponent(JBLabel(McpBundle.message("settings.availableProjectsMode") + ":"), availableProjectsModeComboBox!!, 1, false)
             .addLabeledComponent(JBLabel(McpBundle.message("settings.responseFormat") + ":"), responseFormatComboBox!!, 1, false)
             .addComponent(syncPanel, 1)
+            .addSeparator(10)
+            .addComponent(JBLabel(McpBundle.message("headless.section.title")), 5)
+            .addComponent(headlessModeCheckBox!!, 1)
             .addSeparator(10)
             .addComponent(JBLabel(McpBundle.message("lifecycle.section.title")), 5)
             .addComponent(lifecyclePanel, 1)
@@ -356,7 +364,8 @@ class McpSettingsConfigurable : Configurable {
             dormantToClosedSpinner?.value != settings.dormantToClosedMinutes ||
             lifecycleLogBufferSizeSpinner?.value != settings.lifecycleLogBufferSize ||
             lifecycleLogToFileCheckBox?.isSelected != settings.lifecycleLogToFile ||
-            minimumOpenProjectsSpinner?.value != settings.minimumOpenProjects) {
+            minimumOpenProjectsSpinner?.value != settings.minimumOpenProjects ||
+            headlessModeCheckBox?.isSelected != settings.headlessMode) {
             return true
         }
 
@@ -413,6 +422,37 @@ class McpSettingsConfigurable : Configurable {
                 McpBundle.message("settings.serverAddress.unavailable", "$newHost:$newPort"),
                 McpBundle.message("settings.validation.serverAddress.title")
             )
+        }
+
+        val headlessRequested = headlessModeCheckBox?.isSelected ?: false
+        val wasHeadless = settings.headlessMode
+
+        if (headlessRequested && !wasHeadless) {
+            if (!settings.state.headlessDialogDismissed) {
+                val result = com.intellij.openapi.ui.Messages.showOkCancelDialog(
+                    McpBundle.message("headless.dialog.message"),
+                    McpBundle.message("headless.dialog.title"),
+                    McpBundle.message("headless.dialog.enable"),
+                    McpBundle.message("headless.dialog.cancel"),
+                    com.intellij.openapi.ui.Messages.getInformationIcon(),
+                    object : com.intellij.openapi.ui.DoNotAskOption.Adapter() {
+                        override fun rememberChoice(isSelected: Boolean, exitCode: Int) {
+                            if (isSelected && exitCode == com.intellij.openapi.ui.Messages.OK) {
+                                settings.state.headlessDialogDismissed = true
+                            }
+                        }
+                    }
+                )
+                if (result != com.intellij.openapi.ui.Messages.OK) {
+                    headlessModeCheckBox?.isSelected = false
+                } else {
+                    HeadlessModeManager.enable()
+                }
+            } else {
+                HeadlessModeManager.enable()
+            }
+        } else if (!headlessRequested && wasHeadless) {
+            HeadlessModeManager.disable()
         }
 
         settings.serverHost = newHost
@@ -535,6 +575,7 @@ class McpSettingsConfigurable : Configurable {
         lifecycleLogBufferSizeSpinner?.value = settings.lifecycleLogBufferSize
         lifecycleLogToFileCheckBox?.isSelected = settings.lifecycleLogToFile
         minimumOpenProjectsSpinner?.value = settings.minimumOpenProjects
+        headlessModeCheckBox?.isSelected = settings.headlessMode
 
         for ((toolName, checkbox) in toolCheckBoxes) {
             checkbox.isSelected = settings.isToolEnabled(toolName)
@@ -633,6 +674,7 @@ class McpSettingsConfigurable : Configurable {
         lifecycleLogBufferSizeSpinner = null
         lifecycleLogToFileCheckBox = null
         minimumOpenProjectsSpinner = null
+        headlessModeCheckBox = null
         managedProjectsContent = null
         uiDisposable?.let { Disposer.dispose(it) }
         uiDisposable = null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/startup/McpServerStartupActivity.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/startup/McpServerStartupActivity.kt
@@ -5,6 +5,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.BuildDiagnosticsCacheService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.HeadlessModeManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
@@ -21,6 +22,7 @@ class McpServerStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         LOG.info("MCP Server startup activity executing for project: ${project.name}")
         ProjectResolver.onProjectOpened(project)
+        HeadlessModeManager.applyProjectSettings(project)
 
         val application = ApplicationManager.getApplication()
         if (application.isUnitTestMode) {
@@ -33,6 +35,7 @@ class McpServerStartupActivity : ProjectActivity {
 
             val mcpService = McpServerService.getInstance()
             mcpService.initialize()
+            HeadlessModeManager.reapplyIfEnabled()
             val serverUrl = mcpService.getServerUrl()
             val serverError = mcpService.getServerError()
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -461,6 +461,20 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
     }
 
     /**
+     * Returns an error result if the file is read-only, null otherwise.
+     * Use before write operations to give a clear error instead of a blocking dialog.
+     */
+    protected fun ensureWritable(virtualFile: VirtualFile, filePath: String): CallToolResult? {
+        if (!virtualFile.isWritable) {
+            return createErrorResult(
+                "File is read-only: $filePath. Check file permissions or VCS lock status. " +
+                "If the file is under version control, ensure it is checked out for editing."
+            )
+        }
+        return null
+    }
+
+    /**
      * Finds the PSI element at a specific position in a file.
      *
      * @param project The project context

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/OpenProjectTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/OpenProjectTool.kt
@@ -1,6 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.HeadlessModeManager
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
@@ -66,6 +67,8 @@ class OpenProjectTool : AbstractMcpTool() {
         if (!File(path).isAbsolute) {
             return createErrorResult("path must be an absolute path, got: $path")
         }
+
+        HeadlessModeManager.trustProjectPath(path)
 
         val timeoutSeconds = arguments[ParamNames.TIMEOUT_SECONDS]?.jsonPrimitive?.intOrNull
             ?: DEFAULT_TIMEOUT_SECONDS

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -117,6 +117,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
         // ═══════════════════════════════════════════════════════════════════════
         val sourceVirtualFile = resolveFile(project, file)
             ?: return createErrorResult("Source file not found: $file")
+        ensureWritable(sourceVirtualFile, file)?.let { return it }
         val sourceInfo = suspendingReadAction {
             val psiFile = PsiManager.getInstance(project).findFile(sourceVirtualFile)
             if (psiFile == null || !psiFile.isPhysical) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -287,6 +287,12 @@ class RenameSymbolTool : AbstractMcpTool() {
 
         requireSmartMode(project)
 
+        // Pre-check: ensure the target file is writable
+        val sourceVf = resolveFile(project, file)
+        if (sourceVf != null) {
+            ensureWritable(sourceVf, file)?.let { return it }
+        }
+
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Find element and validate (suspending read action)
         // ═══════════════════════════════════════════════════════════════════════

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -160,6 +160,12 @@ class SafeDeleteTool : AbstractRefactoringTool() {
 
         requireSmartMode(project)
 
+        // Pre-check: ensure the target file is writable
+        val sourceVf = resolveFile(project, file)
+        if (sourceVf != null) {
+            ensureWritable(sourceVf, file)?.let { return it }
+        }
+
         return when (targetType) {
             "file" -> executeFileDelete(project, file, force)
             "symbol" -> {

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -157,6 +157,16 @@ lifecycle.managed.label=Managed projects:
 lifecycle.managed.unavailable=Lifecycle management unavailable
 lifecycle.managed.none=No managed projects
 
+# Headless mode
+headless.section.title=Headless Mode
+headless.enabled.label=Enable headless mode (suppress dialogs that block MCP tools)
+headless.enabled.tooltip=When enabled, suppresses IDE dialogs that freeze MCP tool execution.\
+ Your current settings are saved and restored when disabled.
+headless.dialog.title=Enable Headless Mode
+headless.dialog.enable=Enable
+headless.dialog.cancel=Cancel
+headless.dialog.message=<html><body style='width: 400px'><p>When enabled, headless mode changes the following IDE settings to prevent dialogs from blocking MCP tool execution:</p><ul><li>VCS file add/remove: silent (per project, restored on disable)</li><li>File sync on focus: disabled</li><li>Background file reload: enabled</li><li>Tips on startup: disabled</li><li>Confirm exit: disabled</li><li>Update checks: disabled</li><li>Project trust: auto-trusted when opened via MCP tools</li></ul><p><b>Your current values are saved and will be restored when headless mode is turned off.</b></p></body></html>
+
 # Companion Skill
 toolWindow.getSkill=Get Companion Skill
 toolWindow.getSkill.tooltip=Install or export the companion skill for AI coding agents

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/HeadlessModeManagerUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/HeadlessModeManagerUnitTest.kt
@@ -1,0 +1,32 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.settings
+
+import junit.framework.TestCase
+
+class HeadlessModeManagerUnitTest : TestCase() {
+    fun testSnapshotKeysAreDefined() {
+        val keys = HeadlessModeManager.SNAPSHOT_KEYS
+        assertTrue("Should have snapshot keys", keys.isNotEmpty())
+        assertTrue("syncOnFrameActivation", "syncOnFrameActivation" in keys)
+        assertTrue("backgroundSync", "backgroundSync" in keys)
+        assertTrue("showTipsOnStartup", "showTipsOnStartup" in keys)
+        assertTrue("confirmExit", "confirmExit" in keys)
+        assertTrue("checkNeeded", "checkNeeded" in keys)
+    }
+
+    fun testSnapshotRoundTripViaSettings() {
+        val settings = McpSettings()
+        val snapshot = mutableMapOf("syncOnFrameActivation" to "true", "backgroundSync" to "false")
+        settings.state.headlessPreToggleSnapshot = snapshot
+        assertEquals("true", settings.state.headlessPreToggleSnapshot["syncOnFrameActivation"])
+        assertEquals("false", settings.state.headlessPreToggleSnapshot["backgroundSync"])
+    }
+
+    fun testVcsSnapshotStorageRoundTrips() {
+        val settings = McpSettings()
+        val vcsSnapshots = mutableMapOf(
+            "/path/to/project" to mutableMapOf("vcsAdd" to "SHOW_CONFIRMATION", "vcsRemove" to "SHOW_CONFIRMATION")
+        )
+        settings.state.headlessVcsSnapshots = vcsSnapshots
+        assertEquals("SHOW_CONFIRMATION", settings.state.headlessVcsSnapshots["/path/to/project"]?.get("vcsAdd"))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
@@ -297,4 +297,16 @@ class McpSettingsUnitTest : TestCase() {
         assertFalse("REPLACE_MEMBER should be disabled after migration", settings.isToolEnabled(ToolNames.REPLACE_MEMBER))
     }
 
+    fun testHeadlessModeDefaultsToFalse() {
+        val settings = McpSettings()
+        assertFalse(settings.state.headlessMode)
+    }
+
+    fun testHeadlessModeRoundTrips() {
+        val settings = McpSettings()
+        settings.headlessMode = true
+        assertTrue(settings.headlessMode)
+        settings.headlessMode = false
+        assertFalse(settings.headlessMode)
+    }
 }


### PR DESCRIPTION
## Summary

Adds a "Headless Mode" toggle to Settings > Index MCP Server that suppresses all IDE dialogs known to freeze MCP tool execution when no human is at the keyboard.

When enabled, it changes:
- VCS file add/remove: silent (per MCP-opened project)
- File sync on focus: disabled
- Background file reload: enabled
- Tips on startup / confirm exit / update checks: disabled
- Non-project file write protection: bypassed via NonProjectFileWritingAccessExtension
- User home directory: trusted

Current values are snapshotted on enable and restored on disable. First-enable shows an explanation dialog with a "don't show again" checkbox. Settings re-apply automatically on IDE restart.

Also adds a `VirtualFile.isWritable` pre-flight check to all write tools (always active, independent of the toggle) to prevent the read-only file dialog from appearing.

## Architecture

- `HeadlessModeManager` (singleton object) — snapshot/apply/restore logic, VCS silencing per project, startup re-application
- `McpNonProjectFileWritingAccess` — NonProjectFileWritingAccessExtension registered in plugin.xml
- `McpSettings.State` — three new fields: headlessMode, headlessPreToggleSnapshot, headlessDialogDismissed
- `McpSettingsConfigurable` — checkbox + first-enable dialog with DoNotAskOption
- Hooks: `McpServerStartupActivity` re-applies on startup; `ProjectResolver.onProjectOpened` applies VCS silencing

## Audit

Based on the dialog audit at docs/headless-dialog-audit.md which catalogued 14 blocking dialogs across the IDE. This PR covers the 10 that are suppressible via runtime APIs. The remaining 4 (change-signature conflicts, safe-delete edge cases, OOM, index corruption) are deferred.

## Test plan

- [x] Unit tests for settings defaults and snapshot round-trip
- [x] Unit tests for HeadlessModeManager snapshot keys
- [x] check-pr.sh passes all 13 checks
- [x] CONTRIBUTING.md code correctness checklist (threading, error handling, sibling consistency)
- [ ] Manual: toggle on in settings, verify VCS dialogs suppressed, toggle off and verify restored
