### PR TITLE
v4.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Changed
 - **`ide_search_text`** — plain-text queries now use `FindInProjectUtil` (same engine as IDE's Find in Files), enabling true substring matching. Previously, whole-word token matching caused queries like `"a_word"` to miss results in identifiers like `"a_word_and_another_word"`. A new `wholeWord` boolean parameter (default `false`) restores whole-word matching when needed.
 
+### Fixed
+- **`ide_optimize_imports` / `ide_reformat_code`** — refresh the file from disk before resolving PSI, preventing "Outdated stub in index" errors when files were modified by external tools.
+
 ## [4.30.0] - 2026-07-19
 ### Added
 - **`ide_edit_member`** — replace an entire class member declaration (signature + body) by structural name, not text match. Targets by file, class, and member name with optional overload disambiguation. Auto-reformats after editing. Supports Java and Kotlin. *(disabled by default)*

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 4.30.0
+pluginVersion = 4.31.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Release 4.31.0 — first release through the new CD pipeline (#250).

**Included changes** (staying under `[Unreleased]` — the pipeline moves them at publish time):
- `ide_search_text` true substring matching via `FindInProjectUtil`, with new `wholeWord` parameter (#249)
- VFS refresh before `ide_optimize_imports` / `ide_reformat_code` to prevent "Outdated stub in index" errors (#253) — changelog entry added here, it was missing

**After merging:** wait for Build on `main` to go green, then press **Publish release** on the `4.31.0` draft. The Release workflow signs and publishes to the Marketplace and opens a `Changelog update - 4.31.0` PR — merge that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)