### PR TITLE
v5.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.0.0
+pluginVersion = 5.0.1
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Bumps `pluginVersion` to **5.0.1** for the patch release carrying the tool-honesty fixes from #263 (now merged).

One commit, one file: `serverInfo.version` is stamped from `pluginVersion` at build time, and the changelog version section is created by release CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)