### PR TITLE
feat: add ide_create_module — generic module creation for any directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+### Added
+- **`ide_create_module`** — add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions (e.g., `node_modules`, `dist`). For Maven projects, use `ide_import_modules` instead. *(disabled by default)*
 
 ## [5.1.0] - 2026-07-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ Three tiers, selected by class-name suffix:
      schema into `src/test/resources/contract/tool-manifest.json`. This is the regression net
      for large refactors: one assertion covers every registered tool × every schema property, so
      a dropped `register(...)` call or a mutated parameter type fails here instead of shipping.
-     Scope: 47 of the 50 tools in `ToolNames.ALL` (the three needing the Kotlin or Maven plugin
+     Scope: 48 of the 51 tools in `ToolNames.ALL` (the three needing the Kotlin or Maven plugin
      are covered by set-equality instead), and **inputs only**.
    - `ResultShapeContractUnitTest` snapshots the other half of the client contract — the response
      side — into `src/test/resources/contract/result-shapes.txt`: the wire key set, JSON value
@@ -491,6 +491,7 @@ Tools are organized by IDE availability.
 - `ide_open_file` - Open a file in the editor with optional line/column navigation (disabled by default)
 - `ide_set_power_save_mode` - Enable/disable IDE Power Save Mode (IDE-wide). Suspends background inspections and code analysis while keeping the index and code intelligence operational (disabled by default)
 - `ide_close_project` - Close an open project window and free its memory. Non-blocking; refuses to close the last open project so the MCP server keeps a JSON-RPC context (disabled by default)
+- `ide_create_module` - Add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions. For Maven projects, use `ide_import_modules` instead. (disabled by default)
 - `ide_open_project` - Open a project by absolute path and wait until indexing completes (`timeoutSeconds`, default 600). Idempotent for already-open projects (disabled by default)
 - `ide_install_plugin` - Install a plugin zip into the IDE, replacing any existing version; auto-detects `build/distributions/*.zip` when no path is given (disabled by default)
 - `ide_restart` - Restart the IDE; terminates the MCP connection. Call after `ide_install_plugin` (disabled by default)

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Each JetBrains IDE has a unique default port and server name to allow running mu
 
 ## Available Tools
 
-The plugin provides **50 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
+The plugin provides **51 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
 
 ### Universal Tools
 
@@ -285,6 +285,7 @@ These tools work in all supported JetBrains IDEs.
 | `ide_open_file` | Open a file in the editor with optional line/column navigation *(disabled by default)* |
 | `ide_set_power_save_mode` | Enable or disable IDE Power Save Mode — suspends background inspections while keeping the index and all code intelligence operational *(disabled by default)* |
 | `ide_close_project` | Close an open project window and free its memory — refuses to close the last open project *(disabled by default)* |
+| `ide_create_module` | Add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.) *(disabled by default)* |
 | `ide_open_project` | Open a project by absolute path and wait until indexing completes (configurable timeout); returns immediately if already open *(disabled by default)* |
 | `ide_install_plugin` | Install a plugin zip into the IDE, replacing any existing version — auto-detects `build/distributions/*.zip` when no path is given *(disabled by default)* |
 | `ide_restart` | Restart the IDE — terminates the MCP connection; call after `ide_install_plugin` *(disabled by default)* |

--- a/USAGE.md
+++ b/USAGE.md
@@ -24,6 +24,7 @@ These tools work in every supported JetBrains IDE:
 | `ide_reload_project` | Reload linked Maven/Gradle build models | Disabled |
 | `ide_import_modules` | Import external Maven projects as modules | Disabled |
 | `ide_open_workspace` | Scan root directory for Maven projects, or open an explicit module list, in one window | Disabled |
+| `ide_create_module` | Add a directory as an IntelliJ module content root for non-Maven projects | Disabled |
 | `ide_build_project` | Build project with structured errors | Disabled |
 | `ide_run_tests` | Run tests via run configs; structured pass/fail results from the IDE's test runner (any framework). FQN class/method targeting is Java/Kotlin-only; other languages pass an existing run-config name | Disabled |
 | `ide_read_file` | Read file content by path or qualified name | Disabled |
@@ -116,6 +117,7 @@ see [Claude Code Hooks](docs/claude-code-hooks.md) for ready-to-use `PreToolUse`
 - [Project Window Management](#project-window-management)
   - [ide_set_power_save_mode](#ide_set_power_save_mode)
   - [ide_close_project](#ide_close_project)
+  - [ide_create_module](#ide_create_module)
   - [ide_open_project](#ide_open_project)
 - [Refactoring Tools](#refactoring-tools)
   - [ide_refactor_rename](#ide_refactor_rename)
@@ -1432,6 +1434,61 @@ Non-blocking: the tool returns as soon as the close is scheduled. Refuses to clo
 
 ```
 Project 'myproject' is closing.
+```
+
+---
+
+### ide_create_module
+
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+
+Add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions. For Maven projects, use `ide_import_modules` instead.
+
+**Side effects:** Creates a `<name>.iml` file in the target directory and registers the module in `.idea/modules.xml`. To undo: Project Structure (Cmd+;) → Modules → select → minus button. Indexing of the new content root is async — call `ide_index_status` if subsequent tools hit dumb mode.
+
+**Use when:**
+- Adding a non-Maven project directory for IDE indexing and code intelligence
+- Enabling search, navigation, and diagnostics for TypeScript or plain directories
+- Excluding directories like `node_modules` or `dist` from indexing
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Absolute directory path to add as a module content root |
+| `name` | string | No | Module name. Defaults to the directory name |
+| `excludes` | string[] | No | Relative paths to exclude from indexing (e.g., `["node_modules", "dist"]`) |
+| `project_path` | string | No | Target project when multiple projects are open |
+
+**Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_create_module",
+    "arguments": {
+      "path": "/Users/dev/my-frontend",
+      "excludes": ["node_modules", "dist"]
+    }
+  }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Module 'my-frontend' created with content root: /Users/dev/my-frontend
+Module file: /Users/dev/my-frontend/my-frontend.iml
+Excluded 2 directories
+Note: indexing is async — call ide_index_status if subsequent tools hit dumb mode."
+    }
+  ]
+}
 ```
 
 ---
@@ -3117,6 +3174,24 @@ Use this for tail -f monitoring or post-mortem analysis when no MCP connection i
 
 ```
 Lifecycle log file enabled. Events are being written to: /Users/you/Library/Logs/JetBrains/IntelliJIdea2026.1/mcp-lifecycle.log
+```
+
+---
+
+### ide_create_module
+
+Add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). For Maven projects, use `ide_import_modules` instead.
+
+**Side effects:** Creates a `<name>.iml` file in the target directory and registers the module in `.idea/modules.xml`. To undo: Project Structure (Cmd+;) → Modules → select → minus button. Indexing of the new content root is async — call `ide_index_status` if subsequent tools hit dumb mode.
+
+**Parameters:**
+- `path` (required): absolute directory path to add as a module content root
+- `name` (optional): module name (defaults to directory name)
+- `excludes` (optional): relative paths to exclude from indexing (e.g., `["node_modules", "dist"]`)
+- `project_path` (optional)
+
+```json
+{ "name": "ide_create_module", "arguments": { "path": "/Users/dev/my-frontend", "excludes": ["node_modules", "dist"] } }
 ```
 
 ---

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ToolNames.kt
@@ -22,6 +22,7 @@ object ToolNames {
     const val INDEX_STATUS = "ide_index_status"
     const val SYNC_FILES = "ide_sync_files"
     const val BUILD_PROJECT = "ide_build_project"
+    const val CREATE_MODULE = "ide_create_module"
     const val IMPORT_MODULES = "ide_import_modules"
     const val RELOAD_PROJECT = "ide_reload_project"
     const val LIST_TESTS = "ide_list_tests"
@@ -81,6 +82,7 @@ object ToolNames {
         CLOSE_PROJECT,
         CONVERT_JAVA_TO_KOTLIN,
         CREATE_FILE,
+        CREATE_MODULE,
         DIAGNOSTICS,
         EDIT_MEMBER,
         ENROLL_ALL_PROJECTS,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettings.kt
@@ -9,11 +9,12 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 
 private object ToolSettingsDefaults {
-    const val CURRENT_SCHEMA_VERSION = 5
+    const val CURRENT_SCHEMA_VERSION = 6
 
     val DEFAULT_DISABLED_TOOLS: Set<String> = setOf(
         ToolNames.BUILD_PROJECT,
         ToolNames.CLOSE_PROJECT,
+        ToolNames.CREATE_MODULE,
         ToolNames.IMPORT_MODULES,
         ToolNames.LIST_TESTS,
         ToolNames.RELOAD_PROJECT,
@@ -55,7 +56,8 @@ private object ToolSettingsDefaults {
         2 to setOf(ToolNames.OPEN_WORKSPACE),
         3 to setOf(ToolNames.CHANGE_SIGNATURE, ToolNames.CREATE_FILE, ToolNames.REPLACE_TEXT_IN_FILE, ToolNames.STRUCTURAL_SEARCH_REPLACE),
         4 to setOf(ToolNames.LIST_TESTS, ToolNames.RUN_TESTS),
-        5 to setOf(ToolNames.EDIT_MEMBER, ToolNames.INSERT_MEMBER, ToolNames.REPLACE_MEMBER)
+        5 to setOf(ToolNames.EDIT_MEMBER, ToolNames.INSERT_MEMBER, ToolNames.REPLACE_MEMBER),
+        6 to setOf(ToolNames.CREATE_MODULE)
     )
 }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -27,6 +27,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.BuildProject
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.ReloadProjectTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.RunTestsTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CloseProjectTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CreateModuleTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.GetIndexStatusTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.ImportModulesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.InstallPluginTool
@@ -255,6 +256,7 @@ class ToolRegistry {
         register(BuildProjectTool())
         register(ReloadProjectTool())
         register(RunTestsTool())
+        register(CreateModuleTool())
         if (PluginDetectors.maven.isAvailable) {
             register(ImportModulesTool())
             register(OpenWorkspaceTool())

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/CreateModuleTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/CreateModuleTool.kt
@@ -1,0 +1,172 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import java.io.File
+
+class CreateModuleTool : AbstractMcpTool() {
+
+    companion object {
+        private const val MODULE_TYPE_WEB = "WEB_MODULE"
+    }
+
+    override val requiresPsiSync = false
+    override val participatesInLifecycle = false
+
+    override val name = "ide_create_module"
+
+    override val description = """
+        Add a directory as an IntelliJ module with a content root, enabling code intelligence
+        for non-Maven projects (TypeScript, plain directories, etc.).
+
+        Use this when ide_import_modules (Maven-only) does not apply. After adding a module,
+        ide_find_references, ide_diagnostics, and other tools will cover files in that directory.
+
+        For Maven projects, prefer ide_import_modules which sets up the full reactor relationship.
+        For Gradle projects, use ide_open_project to open the Gradle project directly.
+
+        Parameters:
+        - path (required): absolute directory path to add as a module content root
+        - name (optional): module name, defaults to the directory name
+        - excludes (optional): array of relative directory paths to mark as excluded
+          (e.g. ["node_modules", "dist", ".next"])
+        - project_path (optional): selects which project window to add the module to
+
+        Example: {"path": "/Users/dev/my-app", "excludes": ["node_modules", "dist"]}
+    """.trimIndent()
+
+    override val inputSchema: ToolSchema = SchemaBuilder.tool()
+        .stringProperty("path",
+            "Absolute directory path to add as a module content root.", required = true)
+        .stringProperty("name",
+            "Module name. Defaults to the directory name if omitted.")
+        .property("excludes", kotlinx.serialization.json.buildJsonObject {
+            put("type", kotlinx.serialization.json.JsonPrimitive("array"))
+            put("description", kotlinx.serialization.json.JsonPrimitive(
+                "Relative directory paths within the module to mark as excluded " +
+                "(e.g. [\"node_modules\", \"dist\"]). Excluded directories are " +
+                "ignored by indexing and code intelligence."
+            ))
+            put("items", kotlinx.serialization.json.buildJsonObject {
+                put("type", kotlinx.serialization.json.JsonPrimitive("string"))
+            })
+        })
+        .projectPath()
+        .build()
+
+    override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
+        val path = requiredStringArg(arguments, "path").getOrElse {
+            return createErrorResult(it.message ?: "Missing required parameter: path")
+        }
+
+        if (!File(path).isAbsolute) {
+            return createErrorResult("path must be an absolute path, got: $path")
+        }
+        val dir = File(path).canonicalFile
+        if (!dir.exists()) return createErrorResult("Path does not exist: $path")
+        if (!dir.isDirectory) return createErrorResult("Path is not a directory: $path")
+
+        if (File(dir, "pom.xml").exists() && com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors.maven.isAvailable) {
+            return createErrorResult(
+                "Directory contains pom.xml — use ide_import_modules instead, " +
+                "which sets up the full Maven reactor relationship."
+            )
+        }
+
+        val moduleName = optionalStringArg(arguments, "name") ?: dir.name
+        if (moduleName.isBlank() || moduleName.contains("..") || moduleName.contains("/") || moduleName.contains("\\")) {
+            return createErrorResult("Invalid module name: '$moduleName'. Must not be blank or contain path separators.")
+        }
+        val excludes = arguments["excludes"]?.jsonArray
+            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            ?: emptyList()
+
+        for (exclude in excludes) {
+            if (exclude.isBlank()) {
+                return createErrorResult("Exclude path must not be blank.")
+            }
+            if (exclude.contains("..")) {
+                return createErrorResult("Exclude path must not contain '..': $exclude")
+            }
+        }
+
+        val existingRoots = ProjectUtils.getModuleContentRoots(project)
+            .map { ProjectUtils.canonicalNormalizedPath(it) }.toSet()
+        val canonicalPath = ProjectUtils.canonicalNormalizedPath(dir.absolutePath)
+        if (canonicalPath in existingRoots) {
+            return createSuccessResult("Directory already registered as a module content root: $path")
+        }
+
+        if (ModuleManager.getInstance(project).findModuleByName(moduleName) != null) {
+            return createErrorResult(
+                "A module named '$moduleName' already exists in this project. " +
+                "Pass a different 'name' to create a module for this directory."
+            )
+        }
+
+        val dirVf = LocalFileSystem.getInstance().refreshAndFindFileByPath(dir.absolutePath)
+            ?: return createErrorResult("Could not resolve directory in VFS: $path")
+
+        val imlPath = File(dir, "$moduleName.iml").absolutePath
+        val excludedCount = edtAction {
+            WriteAction.compute<Int, Exception> {
+                createModule(project, moduleName, imlPath, dirVf, dir, excludes)
+            }
+        }
+
+        val msg = buildString {
+            append("Module '$moduleName' created with content root: $path")
+            append("\nModule file: $imlPath")
+            if (excludedCount > 0) {
+                append("\nExcluded $excludedCount director${if (excludedCount == 1) "y" else "ies"}")
+            }
+            append("\nNote: indexing is async — call ide_index_status if subsequent tools hit dumb mode.")
+        }
+        return createSuccessResult(msg)
+    }
+
+    private fun createModule(
+        project: Project,
+        moduleName: String,
+        imlPath: String,
+        dirVf: VirtualFile,
+        dir: File,
+        excludes: List<String>
+    ): Int {
+        val moduleManager = ModuleManager.getInstance(project)
+        val module = moduleManager.newModule(imlPath, MODULE_TYPE_WEB)
+
+        val rootModel = ModuleRootManager.getInstance(module).modifiableModel
+        try {
+            val contentEntry = rootModel.addContentEntry(dirVf)
+
+            var excludedCount = 0
+            for (exclude in excludes) {
+                val excludeUrl = com.intellij.openapi.vfs.VfsUtilCore.pathToUrl(
+                    File(dir, exclude).absolutePath
+                )
+                contentEntry.addExcludeFolder(excludeUrl)
+                excludedCount++
+            }
+
+            rootModel.commit()
+            return excludedCount
+        } catch (e: Exception) {
+            rootModel.dispose()
+            throw e
+        }
+    }
+}

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: >
   ide_find_implementations, ide_find_symbol, ide_find_super_methods, ide_file_structure,
   ide_refactor_safe_delete, ide_reformat_code, ide_reload_project, ide_import_modules,
   ide_build_project, ide_read_file, ide_structural_search_replace, ide_change_signature,
-  ide_create_file, ide_get_active_file, ide_open_file, ide_list_tests, or ide_run_tests are available — especially when a second
+  ide_create_file, ide_create_module, ide_get_active_file, ide_open_file, ide_list_tests, or ide_run_tests are available — especially when a second
   IntelliJ MCP (mcp__intellij__*) is also present. The two servers are NOT
   interchangeable: this plugin (mcp__intellij-index__*) supports auto-opening projects
   via project_path; the built-in server cannot. Always use mcp__intellij-index__ for code
@@ -173,7 +173,7 @@ All lifecycle action tools are disabled by default:
 
 These tools exist but are disabled by default. They are omitted from `tools/list`, and direct `tools/call` requests are rejected until the user enables them in IDE settings (Settings > Tools > Index MCP Server):
 
-`ide_build_project`, `ide_change_signature`, `ide_close_project`, `ide_convert_java_to_kotlin`, `ide_create_file`, `ide_edit_member`, `ide_enroll_all_projects`, `ide_file_structure`, `ide_find_symbol`, `ide_get_active_file`, `ide_get_project_modes`, `ide_import_modules`, `ide_insert_member`, `ide_install_plugin`, `ide_lifecycle_log`, `ide_list_tests`, `ide_open_file`, `ide_open_project`, `ide_open_workspace`, `ide_optimize_imports`, `ide_read_file`, `ide_reformat_code`, `ide_release_all_projects`, `ide_release_project`, `ide_reload_project`, `ide_replace_member`, `ide_replace_text_in_file`, `ide_restart`, `ide_run_tests`, `ide_set_all_project_modes`, `ide_set_lifecycle_log_file`, `ide_set_power_save_mode`, `ide_set_project_mode`, `ide_structural_search_replace`
+`ide_build_project`, `ide_change_signature`, `ide_close_project`, `ide_convert_java_to_kotlin`, `ide_create_file`, `ide_create_module`, `ide_edit_member`, `ide_enroll_all_projects`, `ide_file_structure`, `ide_find_symbol`, `ide_get_active_file`, `ide_get_project_modes`, `ide_import_modules`, `ide_insert_member`, `ide_install_plugin`, `ide_lifecycle_log`, `ide_list_tests`, `ide_open_file`, `ide_open_project`, `ide_open_workspace`, `ide_optimize_imports`, `ide_read_file`, `ide_reformat_code`, `ide_release_all_projects`, `ide_release_project`, `ide_reload_project`, `ide_replace_member`, `ide_replace_text_in_file`, `ide_restart`, `ide_run_tests`, `ide_set_all_project_modes`, `ide_set_lifecycle_log_file`, `ide_set_power_save_mode`, `ide_set_project_mode`, `ide_structural_search_replace`
 
 Note: `ide_restart` terminates the MCP connection — reconnect your client after calling it.
 Note: `ide_close_project` refuses to close the last open project; `ide_open_project` requires an absolute path and may take up to `timeoutSeconds` (default 600) while the project indexes.

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -603,6 +603,18 @@ Close an open project window and free its memory. Non-blocking; returns once the
 
 **Returns**: text confirmation, e.g. `Project 'name' is closing.`
 
+### ide_create_module (disabled by default)
+Add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions. For Maven projects, use `ide_import_modules` instead.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | yes | Absolute directory path to add as a module content root |
+| `name` | string | no | Module name (defaults to directory name) |
+| `excludes` | string[] | no | Relative paths to exclude from indexing (e.g., `["node_modules", "dist"]`) |
+| `project_path` | string | no | Target project when multiple are open |
+
+**Returns**: text confirmation with module name, content root path, module file path, count of excluded directories, and an async-indexing note.
+
 ### ide_open_project (disabled by default)
 Open a project by absolute path and wait until indexing completes. Idempotent: returns immediately if the project is already open. May require a human to answer the IDE's "Trust project?" dialog for first-time projects.
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ConstantsUnitTest.kt
@@ -32,6 +32,7 @@ class ConstantsUnitTest : TestCase() {
             ToolNames.INDEX_STATUS,
             ToolNames.SYNC_FILES,
             ToolNames.BUILD_PROJECT,
+            ToolNames.CREATE_MODULE,
             ToolNames.IMPORT_MODULES,
             ToolNames.CHANGE_SIGNATURE,
             ToolNames.CREATE_FILE,

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ToolManifestContractUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ToolManifestContractUnitTest.kt
@@ -21,7 +21,7 @@ import java.io.File
  * fail here rather than silently shipping.
  *
  * Two limits worth knowing before trusting it:
- * - It covers the tools that register headlessly — currently 47 of the 50 in [ToolNames.ALL].
+ * - It covers the tools that register headlessly — currently 48 of the 51 in [ToolNames.ALL].
  *   The three in [NOT_REGISTRABLE_HEADLESS] are guarded by set-equality in
  *   [testEveryDeclaredToolNameIsRegistered] instead, so they cannot vanish unnoticed, but their
  *   schemas are not snapshotted.

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/integration/ToolExecutionIntegrationTest.kt
@@ -548,6 +548,7 @@ class ToolExecutionIntegrationTest : McpPlatformTestCase() {
             ToolNames.DIAGNOSTICS,
             // Project tools
             ToolNames.BUILD_PROJECT,
+            ToolNames.CREATE_MODULE,
             ToolNames.INDEX_STATUS,
             ToolNames.SYNC_FILES,
             ToolNames.RUN_TESTS,

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsUnitTest.kt
@@ -173,7 +173,7 @@ class McpSettingsUnitTest : TestCase() {
         settings.setToolEnabled(ToolNames.IMPORT_MODULES, true)
 
         assertTrue(settings.isToolEnabled(ToolNames.IMPORT_MODULES))
-        assertEquals(5, settings.state.settingsSchemaVersion)
+        assertEquals(6, settings.state.settingsSchemaVersion)
     }
 
     fun testUpdateToolEnabledStatesPreservesHiddenDisabledTools() {
@@ -191,7 +191,7 @@ class McpSettingsUnitTest : TestCase() {
         assertFalse("Hidden disabled tool must stay disabled", settings.isToolEnabled(ToolNames.IMPORT_MODULES))
         assertFalse("Visible disabled checkbox must disable the tool", settings.isToolEnabled(ToolNames.INDEX_STATUS))
         assertTrue("Visible enabled checkbox must enable the tool", settings.isToolEnabled(ToolNames.RELOAD_PROJECT))
-        assertEquals(5, settings.state.settingsSchemaVersion)
+        assertEquals(6, settings.state.settingsSchemaVersion)
     }
 
     fun testMcpSettingsGetStateReturnsCurrentState() {
@@ -233,6 +233,18 @@ class McpSettingsUnitTest : TestCase() {
 
         assertEquals(McpSettings.ResponseFormat.TOON, settings.responseFormat)
         assertEquals(McpSettings.ResponseFormat.TOON, settings.state.responseFormat)
+    }
+
+    fun testSchemaVersion5MigrationKeepsCreateModuleDisabled() {
+        val settings = McpSettings()
+        val disabled = (McpSettings.DEFAULT_DISABLED_TOOLS - ToolNames.CREATE_MODULE).toMutableSet()
+
+        settings.loadState(McpSettings.State(disabledTools = disabled, settingsSchemaVersion = 5))
+
+        assertFalse(
+            "${ToolNames.CREATE_MODULE} should be disabled after v5→v6 migration",
+            settings.isToolEnabled(ToolNames.CREATE_MODULE)
+        )
     }
 
     // Edge case tests

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -13,6 +13,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindImple
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindSymbolTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsagesTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CreateModuleTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
@@ -245,5 +246,31 @@ class ToolsUnitTest : TestCase() {
         assertTrue("ide_edit_member should be disabled by default", ToolNames.EDIT_MEMBER in defaultDisabled)
         assertTrue("ide_insert_member should be disabled by default", ToolNames.INSERT_MEMBER in defaultDisabled)
         assertTrue("ide_replace_member should be disabled by default", ToolNames.REPLACE_MEMBER in defaultDisabled)
+    }
+
+
+    // ── ide_create_module tests ────────────────────────────────────────────────
+
+    fun testCreateModuleToolSchema() {
+        val tool = CreateModuleTool()
+        assertEquals(ToolNames.CREATE_MODULE, tool.name)
+        assertNotNull(tool.description)
+
+        val schema = tool.inputSchema
+        assertEquals(SchemaConstants.TYPE_OBJECT, schema[SchemaConstants.TYPE]?.jsonPrimitive?.content)
+
+        val properties = schema[SchemaConstants.PROPERTIES]?.jsonObject
+        assertNotNull(properties)
+        assertNotNull("Should have path property", properties?.get("path"))
+        assertNotNull("Should have name property", properties?.get("name"))
+        assertNotNull("Should have excludes property", properties?.get("excludes"))
+        assertNotNull("Should have project_path property", properties?.get(ParamNames.PROJECT_PATH))
+
+        val required = schema["required"]?.jsonArray?.map { it.jsonPrimitive.content }
+        assertTrue("path should be required", required?.contains("path") == true)
+    }
+
+    fun testCreateModuleToolIsDisabledByDefault() {
+        assertTrue(ToolNames.CREATE_MODULE in McpSettings.DEFAULT_DISABLED_TOOLS)
     }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/CreateModuleBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/CreateModuleBehaviorTest.kt
@@ -1,0 +1,243 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.isFailure
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.text
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetector
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.LoggedErrorProcessor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.File
+
+/**
+ * Behavior coverage for `ide_create_module`.
+ *
+ * Extends [HeavyPlatformTestCase] instead of `McpPlatformTestCase` because module creation is
+ * explicitly blocked by the light test infrastructure (`LightPlatformTestCase` fails with
+ * "Adding modules is not permitted in light tests").
+ */
+class CreateModuleBehaviorTest : HeavyPlatformTestCase() {
+
+    private val tool = CreateModuleTool()
+
+    private val createdDirs = mutableListOf<File>()
+
+    override fun tearDown() {
+        try {
+            createdDirs.asReversed().forEach { it.deleteRecursively() }
+            createdDirs.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun createTestDir(name: String): File {
+        val basePath = requireNotNull(myProject.basePath)
+        val dir = File(basePath, name)
+        dir.mkdirs()
+        createdDirs.add(dir)
+        return dir
+    }
+
+    /**
+     * Suppresses a `NoSuchMethodError` in `WorkspaceModelImpl.logErrorOnEventHandling` that fires
+     * when a module is added in the test environment due to a Kotlin version mismatch between the
+     * test classpath and the bundled platform. The error is harmless — the module is still created.
+     */
+    private fun suppressWorkspaceModelErrors(action: () -> Unit) {
+        val token = LoggedErrorProcessor.executeWith(
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    t: Throwable?
+                ): MutableSet<Action> {
+                    if (t is NoSuchMethodError || message.contains("Workspace Model event handling")) {
+                        return Action.NONE
+                    }
+                    return Action.ALL
+                }
+            }
+        )
+        try {
+            action()
+        } finally {
+            token.finish()
+        }
+    }
+
+    fun testHappyPath_createsModuleWithContentRootAndExcludes() = suppressWorkspaceModelErrors {
+        val dir = createTestDir("test-module-happy")
+        val result = runBlocking {
+            tool.execute(myProject, buildJsonObject {
+                put("path", dir.absolutePath)
+                put("name", "happy-module")
+                put("excludes", buildJsonArray {
+                    add(JsonPrimitive("node_modules"))
+                    add(JsonPrimitive("dist"))
+                })
+            })
+        }
+
+        assertFalse("Module creation should succeed: ${result.text}", result.isFailure)
+        val text = result.text
+        assertTrue("Response should include module name: $text", text.contains("happy-module"))
+        assertTrue("Response should include content root path: $text", text.contains(dir.absolutePath))
+        assertTrue("Response should include module file path: $text", text.contains(".iml"))
+        assertTrue("Response should include excluded count: $text", text.contains("Excluded 2"))
+        assertTrue("Response should include async note: $text", text.contains("indexing is async"))
+
+        val module = ModuleManager.getInstance(myProject).findModuleByName("happy-module")
+        assertNotNull("Module should be registered in ModuleManager", module)
+        val roots = ModuleRootManager.getInstance(module!!).contentRoots
+        assertTrue(
+            "Content root should include the target directory",
+            roots.any { it.path == dir.absolutePath }
+        )
+
+        val contentEntries = ModuleRootManager.getInstance(module).contentEntries
+        val excludeUrls = contentEntries.flatMap { it.excludeFolderUrls }
+        assertTrue(
+            "node_modules should be excluded: $excludeUrls",
+            excludeUrls.any { it.contains("node_modules") }
+        )
+        assertTrue(
+            "dist should be excluded: $excludeUrls",
+            excludeUrls.any { it.contains("dist") }
+        )
+    }
+
+    fun testIdempotent_secondCallOnSamePathReturnsSuccess() = suppressWorkspaceModelErrors {
+        val dir = createTestDir("test-module-idempotent")
+
+        val first = runBlocking {
+            tool.execute(myProject, buildJsonObject {
+                put("path", dir.absolutePath)
+                put("name", "idempotent-module")
+            })
+        }
+        assertFalse("First call should succeed: ${first.text}", first.isFailure)
+
+        val second = runBlocking {
+            tool.execute(myProject, buildJsonObject {
+                put("path", dir.absolutePath)
+                put("name", "idempotent-module-2")
+            })
+        }
+        assertFalse("Second call on same path should succeed (idempotent): ${second.text}", second.isFailure)
+        assertTrue(
+            "Should indicate already registered: ${second.text}",
+            second.text.contains("already registered")
+        )
+    }
+
+    fun testNameCollision_secondModuleWithSameNameReturnsError() = suppressWorkspaceModelErrors {
+        val dir1 = createTestDir("test-module-collision-a")
+        val dir2 = createTestDir("test-module-collision-b")
+
+        val first = runBlocking {
+            tool.execute(myProject, buildJsonObject {
+                put("path", dir1.absolutePath)
+                put("name", "collision-module")
+            })
+        }
+        assertFalse("First module creation should succeed: ${first.text}", first.isFailure)
+
+        val second = runBlocking {
+            tool.execute(myProject, buildJsonObject {
+                put("path", dir2.absolutePath)
+                put("name", "collision-module")
+            })
+        }
+        assertTrue("Second module with same name should fail: ${second.text}", second.isFailure)
+        assertTrue(
+            "Error should mention existing module name: ${second.text}",
+            second.text.contains("already exists")
+        )
+    }
+
+    fun testInvalidName_dotDotInNameReturnsError() = runBlocking {
+        val dir = createTestDir("test-module-invalid-name")
+
+        val result = tool.execute(myProject, buildJsonObject {
+            put("path", dir.absolutePath)
+            put("name", "bad..name")
+        })
+
+        assertTrue("Name with '..' should be rejected: ${result.text}", result.isFailure)
+        assertTrue(
+            "Error should mention invalid name: ${result.text}",
+            result.text.contains("Invalid module name")
+        )
+    }
+
+    fun testInvalidExclude_dotDotInExcludeReturnsError() = runBlocking {
+        val dir = createTestDir("test-module-invalid-exclude")
+
+        val result = tool.execute(myProject, buildJsonObject {
+            put("path", dir.absolutePath)
+            put("name", "valid-module")
+            put("excludes", buildJsonArray {
+                add(JsonPrimitive("../escape"))
+            })
+        })
+
+        assertTrue("Exclude with '..' should be rejected: ${result.text}", result.isFailure)
+        assertTrue(
+            "Error should mention '..': ${result.text}",
+            result.text.contains("..")
+        )
+    }
+
+    fun testInvalidExclude_blankExcludeReturnsError() = runBlocking {
+        val dir = createTestDir("test-module-blank-exclude")
+
+        val result = tool.execute(myProject, buildJsonObject {
+            put("path", dir.absolutePath)
+            put("name", "valid-module-2")
+            put("excludes", buildJsonArray {
+                add(JsonPrimitive("  "))
+            })
+        })
+
+        assertTrue("Blank exclude should be rejected: ${result.text}", result.isFailure)
+        assertTrue(
+            "Error should mention blank: ${result.text}",
+            result.text.contains("blank")
+        )
+    }
+
+    fun testPomXmlGuard_directoryWithPomAndMavenAvailableReturnsError() = runBlocking {
+        val dir = createTestDir("test-module-pom")
+        File(dir, "pom.xml").writeText("<project/>")
+
+        val mockMaven = mockk<PluginDetector>()
+        every { mockMaven.isAvailable } returns true
+        mockkObject(PluginDetectors)
+        every { PluginDetectors.maven } returns mockMaven
+        try {
+            val result = tool.execute(myProject, buildJsonObject {
+                put("path", dir.absolutePath)
+            })
+
+            assertTrue("pom.xml + Maven available should block creation: ${result.text}", result.isFailure)
+            assertTrue(
+                "Error should suggest ide_import_modules: ${result.text}",
+                result.text.contains("ide_import_modules")
+            )
+        } finally {
+            unmockkObject(PluginDetectors)
+        }
+    }
+}

--- a/src/test/resources/contract/tool-manifest.json
+++ b/src/test/resources/contract/tool-manifest.json
@@ -1,6 +1,6 @@
 # MCP tool manifest — golden snapshot
 # Regenerate: ./gradlew test -Ptier=unit --tests "*ToolManifestContractUnitTest" -Dcontract.update=true
-# tools: 47
+# tools: 48
 
 ## ide_build_project
 description:
@@ -286,6 +286,61 @@ schema:
     [
       "file",
       "content"
+    ],
+    "type": "object"
+  }
+
+## ide_create_module
+description:
+  Add a directory as an IntelliJ module with a content root, enabling code intelligence
+  for non-Maven projects (TypeScript, plain directories, etc.).
+  
+  Use this when ide_import_modules (Maven-only) does not apply. After adding a module,
+  ide_find_references, ide_diagnostics, and other tools will cover files in that directory.
+  
+  For Maven projects, prefer ide_import_modules which sets up the full reactor relationship.
+  For Gradle projects, use ide_open_project to open the Gradle project directly.
+  
+  Parameters:
+  - path (required): absolute directory path to add as a module content root
+  - name (optional): module name, defaults to the directory name
+  - excludes (optional): array of relative directory paths to mark as excluded
+    (e.g. ["node_modules", "dist", ".next"])
+  - project_path (optional): selects which project window to add the module to
+  
+  Example: {"path": "/Users/dev/my-app", "excludes": ["node_modules", "dist"]}
+schema:
+  {
+    "properties":
+    {
+      "excludes":
+      {
+        "description": "Relative directory paths within the module to mark as excluded (e.g. [\"node_modules\", \"dist\"]). Excluded directories are ignored by indexing and code intelligence.",
+        "items":
+        {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "name":
+      {
+        "description": "Module name. Defaults to the directory name if omitted.",
+        "type": "string"
+      },
+      "path":
+      {
+        "description": "Absolute directory path to add as a module content root.",
+        "type": "string"
+      },
+      "project_path":
+      {
+        "description": "Absolute path to the project root. Required when multiple projects are open. For workspace projects, use the sub-project path.",
+        "type": "string"
+      }
+    },
+    "required":
+    [
+      "path"
     ],
     "type": "object"
   }


### PR DESCRIPTION
## Summary

- Adds `ide_create_module` — registers a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, git worktrees)
- Complements `ide_import_modules` (Maven-only) and `ide_open_workspace` (Maven workspace aggregator)
- Supports optional directory exclusions (e.g., `node_modules`, `dist`, `.next`)

## Why

When agents work in git worktrees or non-Maven projects, IntelliJ tools like `ide_find_references` and `ide_diagnostics` don't cover the files because the directory isn't registered as a content root. This tool fills that gap without requiring Maven.

## Implementation

- `CreateModuleTool.kt`: creates a `WEB_MODULE` with a content root and optional excluded directories
- Module creation runs inside `WriteAction` on EDT (required for `ModuleManager.newModule` and `rootModel.commit`)
- Guards: non-absolute path, non-existent directory, pom.xml present (directs to `ide_import_modules`), `..` in excludes, already-registered content root (idempotent)
- Disabled by default (schema version 6 migration)
- Updated for MCP Kotlin SDK migration (CallToolResult, ToolSchema)

Supersedes #254 (closed due to stale fork state).

## Checklist

- [x] All 6 doc locations (README, USAGE, CLAUDE.md, SKILL.md, tools-reference.md, CHANGELOG)
- [x] ToolNames constant + ALL list (alphabetical)
- [x] McpSettings: DEFAULT_DISABLED_TOOLS + schema v6 migration
- [x] ToolRegistry registration
- [x] Unit tests: schema, disabled-by-default, migration from v2
- [x] CONTRIBUTING.md code correctness checklist: threading, error handling, sibling consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)