### PR TITLE
docs: document the local server's trust model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **`ide_install_plugin` rejects archives with zip-slip entries** (`../` traversal or absolute paths) that would write outside the IDE plugins directory. The whole archive is validated before the existing installation is removed, so a rejected archive leaves the current plugin intact, and extraction independently re-checks every normalized destination path.
 - **`ide_read_file` no longer reads local files outside the project.** Plain filesystem paths (including `~`-expanded ones) are now checked against the project's content roots and registered libraries; jar/library-source reads are unaffected.
+- **The local server's trust model is now documented** in the README (and therefore the Marketplace description) and in `SECURITY.md`: the server binds to `127.0.0.1` with no authentication, so any process on the machine can call its tools with the IDE user's file access.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Unlike simple text-based code analysis, this plugin gives AI assistants access t
 - **Safe refactoring operations** with automatic reference updates and undo support
 
 Perfect for AI-assisted development workflows where accuracy and safety matter.
+
+### Security
+
+The server binds to `127.0.0.1` with no authentication — any local process can call its
+tools with your IDE's file access. On a single-user dev machine that's the same trust
+boundary your shell already has; on a shared machine, it's worth weighing before you
+enable the write tools.
 <!-- Plugin description end -->
 
 ## Table of Contents

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,10 @@ before publishing details.
   (localhost) only. It is never exposed to the network by design.
 - Loopback Origin/Host validation is in place to mitigate DNS-rebinding
   attacks against the local server.
+- There is no authentication on the local server: any process on the machine
+  can call the tools with the IDE user's file access. This is a deliberate
+  trade-off for one-line client setup — keeping the machine free of untrusted
+  local processes is the user's call. Reports based on local unauthenticated
+  access, or on privilege escalation derived from it, are out of scope.
 - Reports that require the user to have deliberately reconfigured the server
   to a non-loopback bind are out of scope.


### PR DESCRIPTION
Following a private security report: the MCP server binds to `127.0.0.1` with no authentication, so any process on the machine can call its tools with the IDE user's file access. Token auth is not being added — it would break one-line client setup for a boundary most single-user dev machines already accept — so the trust model gets written down instead.

- **README** — a short `### Security` section inside the plugin-description markers, so [build.gradle.kts](build.gradle.kts) carries it into the Marketplace listing on the next release.
- **SECURITY.md** — the same statement in the scope notes, which also sets expectations for future reports of local unauthenticated access.
- **CHANGELOG** — one bullet under the existing `[Unreleased] / Security` section.

Docs only, no behavior change. `./scripts/check-pr.sh` passes 16/16 (full test suite included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)