### PR TITLE
fix: add ensureWritable pre-flight check to all write tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Write tools now reject read-only files with a clear error** instead of failing deep inside the refactoring engine. Affected tools: `ide_replace_text_in_file`, `ide_edit_member`, `ide_insert_member`, `ide_replace_member`, `ide_move_file`, `ide_change_signature`, `ide_reformat_code`, `ide_optimize_imports`, `ide_refactor_rename` (both symbol and file modes), and `ide_refactor_safe_delete` (both symbol and file modes).
+
 ### Security
 
 - **`ide_install_plugin` rejects archives with zip-slip entries** (`../` traversal or absolute paths) that would write outside the IDE plugins directory. The whole archive is validated before the existing installation is removed, so a rejected archive leaves the current plugin intact, and extraction independently re-checks every normalized destination path.

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -436,6 +436,14 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
         return null
     }
 
+    /** Returns a "read-only" error when [file] is not writable, or `null` if the file is writable. */
+    protected fun ensureWritable(file: VirtualFile): CallToolResult? {
+        if (!file.isWritable) {
+            return createErrorResult("File is read-only and cannot be modified: ${file.path}")
+        }
+        return null
+    }
+
     /**
      * Gets the PSI file for a given path.
      *

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -127,6 +127,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
 
         val virtualFile = resolveFile(project, filePath)
             ?: return createErrorResult("File not found: $filePath")
+        ensureWritable(virtualFile)?.let { return it }
 
         val changeSignatureProcessorClass = try {
             Class.forName("com.intellij.refactoring.changeSignature.ChangeSignatureProcessor")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/EditMemberTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/EditMemberTool.kt
@@ -61,6 +61,7 @@ class EditMemberTool : AbstractMcpTool() {
 
         val virtualFile = resolveFile(project, filePath)
             ?: return createErrorResult("File not found: $filePath")
+        ensureWritable(virtualFile)?.let { return it }
 
         val prep = suspendingReadAction {
             prepareMemberEdit(project, virtualFile, filePath, className, memberName, parameterCount, line)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/InsertMemberTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/InsertMemberTool.kt
@@ -65,6 +65,7 @@ class InsertMemberTool : AbstractMcpTool() {
 
         val virtualFile = resolveFile(project, filePath)
             ?: return createErrorResult("File not found: $filePath")
+        ensureWritable(virtualFile)?.let { return it }
 
         val prep = suspendingReadAction {
             prepareInsertion(project, virtualFile, filePath, className, position, anchorName, anchorParamCount, anchorLine)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -117,6 +117,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
         // ═══════════════════════════════════════════════════════════════════════
         val sourceVirtualFile = resolveFile(project, file)
             ?: return createErrorResult("Source file not found: $file")
+        ensureWritable(sourceVirtualFile)?.let { return it }
         val sourceInfo = suspendingReadAction {
             val psiFile = PsiManager.getInstance(project).findFile(sourceVirtualFile)
             if (psiFile == null || !psiFile.isPhysical) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -54,7 +54,9 @@ class OptimizeImportsTool : AbstractMcpTool() {
         // Refresh VFS for the target file to pick up external changes before PSI resolution.
         // Without this, the stub index can be stale when files are modified by external tools,
         // causing "Outdated stub in index" errors during import optimization.
-        resolveFile(project, file)?.refresh(false, false)
+        val virtualFile = resolveFile(project, file)
+        virtualFile?.refresh(false, false)
+        if (virtualFile != null) { ensureWritable(virtualFile)?.let { return it } }
 
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Resolve file (suspending read action)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -96,7 +96,9 @@ class ReformatCodeTool : AbstractMcpTool() {
         // Refresh VFS for the target file to pick up external changes before PSI resolution.
         // Without this, the stub index can be stale when files are modified by external tools,
         // causing "Outdated stub in index" errors during import optimization or reformatting.
-        resolveFile(project, file)?.refresh(false, false)
+        val virtualFile = resolveFile(project, file)
+        virtualFile?.refresh(false, false)
+        if (virtualFile != null) { ensureWritable(virtualFile)?.let { return it } }
 
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Resolve file and validate (suspending read action)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -383,6 +383,20 @@ class RenameSymbolTool : AbstractMcpTool() {
         column: Int,
         newName: String
     ): RenameValidation {
+        val psiFile = getPsiFile(project, file)
+            ?: return RenameValidation(
+                element = DummyNamedElement,
+                oldName = "",
+                error = "File not found: $file"
+            )
+        if (psiFile.virtualFile?.isWritable == false) {
+            return RenameValidation(
+                element = DummyNamedElement,
+                oldName = "",
+                error = "File is read-only and cannot be modified: ${psiFile.virtualFile.path}"
+            )
+        }
+
         val psiElement = findPsiElement(project, file, line, column)
             ?: return RenameValidation(
                 element = DummyNamedElement,
@@ -473,6 +487,13 @@ class RenameSymbolTool : AbstractMcpTool() {
                 oldName = "",
                 error = "File not found: $file"
             )
+        if (psiFile.virtualFile?.isWritable == false) {
+            return RenameValidation(
+                element = DummyNamedElement,
+                oldName = "",
+                error = "File is read-only and cannot be modified: ${psiFile.virtualFile.path}"
+            )
+        }
 
         val oldName = psiFile.name
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReplaceMemberTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReplaceMemberTool.kt
@@ -54,6 +54,7 @@ class ReplaceMemberTool : AbstractMcpTool() {
 
         val virtualFile = resolveFile(project, filePath)
             ?: return createErrorResult("File not found: $filePath")
+        ensureWritable(virtualFile)?.let { return it }
 
         val prep = suspendingReadAction {
             prepareMemberEdit(project, virtualFile, filePath, className, memberName, parameterCount, line)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReplaceTextInFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReplaceTextInFileTool.kt
@@ -81,6 +81,7 @@ class ReplaceTextInFileTool : AbstractMcpTool() {
 
         val virtualFile = resolveFile(project, filePath)
             ?: return createErrorResult("File not found: $filePath")
+        ensureWritable(virtualFile)?.let { return it }
 
         val regex = if (isRegex) {
             try {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -131,6 +131,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             val nearbySuggestions: List<SymbolSuggestion>
         ) : SymbolPreparationResult()
         data class FileNotFound(val file: String) : SymbolPreparationResult()
+        data class ReadOnly(val file: String) : SymbolPreparationResult()
         data class PositionOutOfBounds(val line: Int, val column: Int) : SymbolPreparationResult()
         data class UsageSearchFailed(val reason: String) : SymbolPreparationResult()
     }
@@ -141,6 +142,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     private sealed class FilePreparationResult {
         data class Success(val data: FileDeletePreparation) : FilePreparationResult()
         data object FileNotFound : FilePreparationResult()
+        data class ReadOnly(val file: String) : FilePreparationResult()
         data class NonPhysicalFile(val fileName: String) : FilePreparationResult()
         data class UsageSearchFailed(val reason: String) : FilePreparationResult()
     }
@@ -232,6 +234,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             is SymbolPreparationResult.FileNotFound -> {
                 createErrorResult("File not found: ${preparationResult.file}")
             }
+            is SymbolPreparationResult.ReadOnly -> {
+                createErrorResult("File is read-only and cannot be modified: ${preparationResult.file}")
+            }
             is SymbolPreparationResult.PositionOutOfBounds -> {
                 createErrorResult("Position out of bounds: line ${preparationResult.line}, column ${preparationResult.column}")
             }
@@ -282,6 +287,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             }
             is FilePreparationResult.FileNotFound -> {
                 createErrorResult("File not found: $file")
+            }
+            is FilePreparationResult.ReadOnly -> {
+                createErrorResult("File is read-only and cannot be modified: ${preparationResult.file}")
             }
             is FilePreparationResult.NonPhysicalFile -> {
                 createErrorResult("Cannot delete non-physical file '${preparationResult.fileName}' (e.g., in-memory or generated file)")
@@ -407,6 +415,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     ): SymbolPreparationResult {
         val psiFile = PsiUtils.getPsiFile(project, file)
             ?: return SymbolPreparationResult.FileNotFound(file)
+        if (psiFile.virtualFile?.isWritable == false) {
+            return SymbolPreparationResult.ReadOnly(psiFile.virtualFile.path)
+        }
 
         val leafElement = PsiUtils.findElementAtPosition(project, file, line, column)
             ?: return SymbolPreparationResult.PositionOutOfBounds(line, column)
@@ -554,6 +565,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     ): FilePreparationResult {
         val psiFile = PsiUtils.getPsiFile(project, file)
             ?: return FilePreparationResult.FileNotFound
+        if (psiFile.virtualFile?.isWritable == false) {
+            return FilePreparationResult.ReadOnly(psiFile.virtualFile.path)
+        }
 
         // Check if file is physical (can be deleted from disk)
         if (!psiFile.isPhysical) {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
@@ -978,7 +978,7 @@ class ToolsTest : McpPlatformTestCase() {
         })
 
         assertTrue("Should error with invalid file", result.isFailure)
-        assertEquals("No element found at the specified position", errorText(result))
+        assertEquals("File not found: nonexistent/file.kt", errorText(result))
     }
 
     fun testRenameSymbolToolBlankName() = runBlocking {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReadOnlyFileGuardBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReadOnlyFileGuardBehaviorTest.kt
@@ -1,0 +1,153 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.openapi.vfs.LocalFileSystem
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.File
+
+/**
+ * Verifies that write tools reject read-only files with a clear "read-only" error
+ * instead of failing deep inside the refactoring engine.
+ *
+ * Each test follows the same pattern:
+ * 1. Write a project file.
+ * 2. Mark it read-only via the VFS.
+ * 3. Call the tool.
+ * 4. Assert the tool returned an error mentioning "read-only".
+ * 5. Assert the file content is unchanged.
+ * 6. Restore writability in cleanup (handled by [tearDown]).
+ */
+class ReadOnlyFileGuardBehaviorTest : McpPlatformTestCase() {
+
+    /** VirtualFiles marked read-only during the test, restored in tearDown. */
+    private val readOnlyFiles = mutableListOf<com.intellij.openapi.vfs.VirtualFile>()
+
+    override fun tearDown() {
+        try {
+            for (vf in readOnlyFiles) {
+                runCatching {
+                    File(vf.path).setWritable(true)
+                    vf.refresh(false, false)
+                }
+            }
+            readOnlyFiles.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun markReadOnly(relativePath: String): com.intellij.openapi.vfs.VirtualFile {
+        val basePath = requireNotNull(project.basePath)
+        val vf = requireNotNull(
+            LocalFileSystem.getInstance().refreshAndFindFileByPath("$basePath/$relativePath")
+        ) { "Cannot find VFS entry for $relativePath" }
+        File(vf.path).setWritable(false)
+        vf.refresh(false, false)
+        readOnlyFiles.add(vf)
+        return vf
+    }
+
+    // ── ReplaceTextInFileTool ──
+
+    fun testReplaceTextRejectsReadOnlyFile() = runBlocking {
+        val original = "public class Frozen { int x = 1; }"
+        writeProjectFile("src/Frozen.java", original)
+        markReadOnly("src/Frozen.java")
+
+        val result = ReplaceTextInFileTool().execute(project, buildJsonObject {
+            put("file", "src/Frozen.java")
+            put("searchText", "x = 1")
+            put("replaceText", "x = 2")
+        })
+
+        assertToolFailed("Should reject read-only file", result)
+        assertTrue("Error should mention read-only", toolText(result).contains("read-only"))
+        assertEquals("File must be unchanged", original, readProjectFileVfs("src/Frozen.java"))
+    }
+
+    // ── RenameSymbolTool — symbol mode ──
+
+    fun testRenameSymbolRejectsReadOnlyFile() = runBlocking {
+        val original = """
+            public class Immutable {
+                public void hello() {}
+            }
+        """.trimIndent()
+        writeProjectFile("src/Immutable.java", original)
+        markReadOnly("src/Immutable.java")
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "src/Immutable.java")
+            put("targetType", "symbol")
+            put("line", 2)
+            put("column", 17)
+            put("newName", "goodbye")
+        })
+
+        assertToolFailed("Should reject read-only file for symbol rename", result)
+        assertTrue("Error should mention read-only", toolText(result).contains("read-only"))
+        assertEquals("File must be unchanged", original, readProjectFileVfs("src/Immutable.java"))
+    }
+
+    // ── RenameSymbolTool — file mode ──
+
+    fun testRenameFileRejectsReadOnlyFile() = runBlocking {
+        val original = "public class Locked {}"
+        writeProjectFile("src/Locked.java", original)
+        markReadOnly("src/Locked.java")
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "src/Locked.java")
+            put("targetType", "file")
+            put("newName", "Unlocked.java")
+        })
+
+        assertToolFailed("Should reject read-only file for file rename", result)
+        assertTrue("Error should mention read-only", toolText(result).contains("read-only"))
+        assertProjectFileExists("src/Locked.java")
+        assertEquals("File must be unchanged", original, readProjectFileVfs("src/Locked.java"))
+    }
+
+    // ── SafeDeleteTool — symbol mode ──
+
+    fun testSafeDeleteSymbolRejectsReadOnlyFile() = runBlocking {
+        val original = """
+            public class Protected {
+                public void doNotDelete() {}
+            }
+        """.trimIndent()
+        writeProjectFile("src/Protected.java", original)
+        markReadOnly("src/Protected.java")
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "src/Protected.java")
+            put("target_type", "symbol")
+            put("line", 2)
+            put("column", 17)
+        })
+
+        assertToolFailed("Should reject read-only file for safe delete symbol", result)
+        assertTrue("Error should mention read-only", toolText(result).contains("read-only"))
+        assertEquals("File must be unchanged", original, readProjectFileVfs("src/Protected.java"))
+    }
+
+    // ── SafeDeleteTool — file mode ──
+
+    fun testSafeDeleteFileRejectsReadOnlyFile() = runBlocking {
+        val original = "public class Guarded {}"
+        writeProjectFile("src/Guarded.java", original)
+        markReadOnly("src/Guarded.java")
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "src/Guarded.java")
+            put("target_type", "file")
+        })
+
+        assertToolFailed("Should reject read-only file for safe delete file", result)
+        assertTrue("Error should mention read-only", toolText(result).contains("read-only"))
+        assertProjectFileExists("src/Guarded.java")
+        assertEquals("File must be unchanged", original, readProjectFileVfs("src/Guarded.java"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ensureWritable(virtualFile, filePath)` pre-flight check to all write tools. Returns an actionable error ("File is read-only: ... Check file permissions or VCS lock status") before the write attempt, preventing the platform from triggering the "Clear read-only status" dialog.

**Note:** You mentioned in #256 that you'd handle this yourself. Happy to close this if you'd prefer to do it your way — filing it in case having the code ready is useful.

## Tools covered

| Tool | Check location |
|------|---------------|
| `ReplaceTextInFileTool` | After `resolveFile`, before write action |
| `EditMemberTool` | After `resolveFile`, before prep |
| `InsertMemberTool` | After `resolveFile`, before prep |
| `ReplaceMemberTool` | After `resolveFile`, before prep |
| `MoveFileTool` | After `resolveFile`, before move execution |
| `ChangeSignatureTool` | After `resolveFile`, before processor |
| `RenameSymbolTool` | After `getPsiFile`, in validation |
| `SafeDeleteTool` | After `getPsiFile`, in preparation |

## Implementation

`ensureWritable` is a protected method on `AbstractMcpTool` returning `CallToolResult?` — null if writable, error result if not. Each tool calls it with `?.let { return it }` after resolving the file.

For `RenameSymbolTool` and `SafeDeleteTool`, the check is inlined because they use `PsiFile` and return sealed-class results rather than `CallToolResult` directly.

## Test plan

- [x] Unit tests pass
- [ ] Manual: attempt to edit a read-only file — should return error, not trigger dialog

Ref: #271
