### PR TITLE
v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@
 ### Fixed
 
 - **Write tools now reject read-only files with a clear error** instead of failing deep inside the refactoring engine. Affected tools: `ide_replace_text_in_file`, `ide_edit_member`, `ide_insert_member`, `ide_replace_member`, `ide_move_file`, `ide_change_signature`, `ide_reformat_code`, `ide_optimize_imports`, `ide_refactor_rename` (both symbol and file modes), and `ide_refactor_safe_delete` (both symbol and file modes).
-
-### Security
-
-- **`ide_install_plugin` rejects archives with zip-slip entries** (`../` traversal or absolute paths) that would write outside the IDE plugins directory. The whole archive is validated before the existing installation is removed, so a rejected archive leaves the current plugin intact, and extraction independently re-checks every normalized destination path.
-- **`ide_read_file` no longer reads local files outside the project.** Plain filesystem paths (including `~`-expanded ones) are now checked against the project's content roots and registered libraries; jar/library-source reads are unaffected.
-- **The local server's trust model is now documented** in the README (and therefore the Marketplace description) and in `SECURITY.md`: the server binds to `127.0.0.1` with no authentication, so any process on the machine can call its tools with the IDE user's file access.
-
-### Fixed
-
 - **`ide_open_project`** — pre-trusts the target directory before opening, preventing the modal "Trust and Open Project?" dialog from freezing headless MCP sessions. The project is trusted per-path, not blanket.
 - **The settings page now appears under Settings → Tools → Index MCP Server**, where all documentation always said it was — it was previously registered as a top-level settings entry.
 - **Documentation corrections across README, USAGE, CLAUDE.md and the bundled skill**: the license is MIT (README claimed Apache 2.0), the minimum IDE version is 2025.3 (docs claimed 2025.1), lifecycle management is documented as opt-in (its master toggle defaults to off), stale tool counts/parameters were reconciled with the real tool schemas, and the pre-5.0 custom JSON-RPC error-code tables were replaced with the current `isError: true` behavior.
@@ -38,6 +29,12 @@
 - **`ide_close_project` re-checks the last-open-project guard on the EDT at close time**, so concurrent close requests can no longer leave the IDE with zero open projects and an unreachable MCP server.
 - **The MCP tool window panel is disposed with its content**, releasing the application-level server-status and command-history listeners (previously leaked the Project after closing it), and its Refresh button actually refreshes again (was a silent no-op).
 - **Settings can be applied while the configured port is occupied by another process** as long as host/port are unchanged, and applying with Enter while the Server Host field has focus no longer fails with a perpetual "Validating server host" error.
+
+### Security
+
+- **`ide_install_plugin` rejects archives with zip-slip entries** (`../` traversal or absolute paths) that would write outside the IDE plugins directory. The whole archive is validated before the existing installation is removed, so a rejected archive leaves the current plugin intact, and extraction independently re-checks every normalized destination path.
+- **`ide_read_file` no longer reads local files outside the project.** Plain filesystem paths (including `~`-expanded ones) are now checked against the project's content roots and registered libraries; jar/library-source reads are unaffected.
+- **The local server's trust model is now documented** in the README (and therefore the Marketplace description) and in `SECURITY.md`: the server binds to `127.0.0.1` with no authentication, so any process on the machine can call its tools with the IDE user's file access.
 
 ## [5.0.1] - 2026-07-27
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.0.2
+pluginVersion = 5.1.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Version-bump PR for the next release. Branched off `main` at 38158c8.

## Version

`pluginVersion` 5.0.2 → **5.1.0**.

`5.0.2` was set by #265 but never published — its GitHub Release is still a draft, so the version was never consumed. The Build workflow deletes stale drafts, so merging this replaces the 5.0.2 draft with a 5.1.0 one.

## Merged PRs in this release (since the `5.0.1` tag)

| PR | Title | Changelog |
|----|-------|-----------|
| #265 | fix: resolve 28 adversarially-verified bugs | ✅ |
| #266 | chore: audit and correct docs, scripts, and CI | ✅ |
| #270 | docs: document the local server's trust model | ✅ Security |
| #252 | fix: block temp script hook bypass in claude-code-hooks | n/a — `docs/claude-code-hooks.md` + `tests/hook-tests.sh` only, no plugin change |
| #273 | fix: add ensureWritable pre-flight check to all write tools | ✅ (was being dropped — see below) |
| #272 | fix: pre-trust projects before opening | ✅ |

## CHANGELOG fix

`[Unreleased]` had **two `### Fixed` headings** — one added by #273 above `### Security`, the pre-existing one below it. gradle-changelog-plugin keeps only the *last* block of a given group per version, so the first one was being discarded:

```
$ ./gradlew getChangelog --unreleased --no-header
# before: 26 entries in CHANGELOG.md → 25 in generated notes
#         missing: "Write tools now reject read-only files with a clear error" (#273)
# after:  26 → 26
```

That entry would have vanished from the draft release notes *and* from the `## [5.1.0]` section `patchChangelog` writes at release time. The two blocks are now merged, ordered Fixed → Security per Keep a Changelog (which is also the order the plugin emits).

No entries were reworded, added, or removed — only regrouped.

## Verification

- `./scripts/check-pr.sh` — 16 passed, 0 failed (includes the full `./gradlew test` suite, platform tier included)
- `./gradlew properties --property version` → `5.1.0`
- `getChangelog --unreleased` output diffed against the source entry list: identical, 26/26

## Note on the bump size

Per the CONTRIBUTING SemVer table this release is Fixed + Security only, which maps to a patch bump. Minor was requested, and there is a case for it: `ide_read_file` no longer reads outside the project and `ide_open_project` now auto-trusts its target — user-visible behavior changes rather than pure fixes.

Changelog entries are left in `[Unreleased]`; the release pipeline moves them under `## [5.1.0]` and opens the follow-up `Changelog update - 5.1.0` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)