### PR TITLE
v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 # IDE Index MCP Server Changelog
 
 ## [Unreleased]
+
 ### Added
+
 - **`ide_create_module`** — add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions (e.g., `node_modules`, `dist`). For Maven projects, use `ide_import_modules` instead. *(disabled by default)*
 
 ## [5.1.0] - 2026-07-30

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.1.0
+pluginVersion = 5.2.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Bumps `pluginVersion` 5.1.0 → 5.2.0.

**Minor**, per the SemVer table in [CONTRIBUTING.md](CONTRIBUTING.md#version-bumps): the only change since 5.1.0 is a new tool, [`ide_create_module`](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/268).

### Changelog

The `[Unreleased]` entry stays where it is — the release pipeline moves it under the new version when the draft release is published. Verified it survives the move:

```
$ ./gradlew getChangelog --unreleased --no-header
### Added

- **`ide_create_module`** — add a directory as an IntelliJ module with a content root, …
```

This is the check that mattered last release: 5.1.0 shipped a fix for a duplicate `### Fixed` heading that made `getChangelog --unreleased` silently drop an entry from the generated release notes.

Also restores the blank lines around `### Added`, the convention every other section in the file follows.

### Docs audit

No doc changes needed — #268 already updated all six required locations, and the counts still line up:

| Location | State |
|---|---|
| `README.md` | tool row present; "provides **51 MCP tools**" matches `ToolNames.ALL.size` = 51 |
| `USAGE.md` | summary row, TOC entry, full section, quick-reference entry |
| `CLAUDE.md` | inventory entry; "48 of the 51 tools" matches the manifest scope |
| `SKILL.md` | trigger list + disabled-tools section |
| `tools-reference.md` | parameter/return reference |
| `ToolNames.kt` / `McpSettings.kt` / `ToolRegistry.kt` | constant, `DEFAULT_DISABLED_TOOLS`, registration |

`docs/mcp-kotlin-sdk-migration.md` still says "50 tools" — that is a historical record of the 5.0.0 migration and correct in context, so it is left alone.

### Verification

`./scripts/check-pr.sh` — **16/16 passed**, including `./gradlew test --rerun-tasks` (full suite, platform tier included, no cached results).

Per CONTRIBUTING, the smoke test is skipped: version-bump change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)