### PR TITLE
v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ide_create_file`** — `project_path` outside every known project root or content root now returns a clear error instead of silently falling through to `basePath` and creating the file in the wrong location. Traversal paths (`../..`) are also rejected.
+
 ## [5.2.0] - 2026-07-31
 
 ### Added
 
 - **`ide_create_module`** — add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions (e.g., `node_modules`, `dist`). For Maven projects, use `ide_import_modules` instead. *(disabled by default)*
-
-### Fixed
-
-- **`ide_create_file`** — `project_path` outside every known project root or content root now returns a clear error instead of silently falling through to `basePath` and creating the file in the wrong location. Traversal paths (`../..`) are also rejected.
 
 ## [5.1.0] - 2026-07-30
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.2.0
+pluginVersion = 5.2.1
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Bumps `pluginVersion` 5.2.0 → 5.2.1. Patch, per the SemVer table in CONTRIBUTING.md: the only user-visible change since 5.2.0 is a bug fix.

## Changes since 5.2.0

| PR | Change | Changelog |
|----|--------|-----------|
| #248 | `ide_create_file` rejects `project_path` outside known roots | Yes — `Fixed` |
| #274 | `chore(deps)`: bump qodana-action | No — CI only |

## Changelog correction

The `ide_create_file` entry is moved from `## [5.2.0]` back to `## [Unreleased]`.

#248 was branched while that entry was still under `[Unreleased]`, but merged after the `Changelog update - 5.2.0` PR (#280) had renamed the heading — so git placed it textually inside an already-released section. 5.2.0 shipped on 2026-07-31 without the fix, and [its published release notes](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/releases/tag/5.2.0) list only `ide_create_module`. The changelog was claiming a fix that release does not contain.

This is exactly the "already-released entries bleeding across a rebase" case CONTRIBUTING.md warns about, in the opposite direction.

## Verification

- `./gradlew getChangelog --unreleased` returns the entry, so the release pipeline will move it under 5.2.1 rather than silently dropping it (the failure mode #275 hit).
- `./scripts/check-pr.sh` — 16 passed, 0 failed, full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)