### PR TITLE
fix: resolve record component instead of backing field in symbol lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ide_find_references` now finds usages of Java record component accessors.** Symbol-mode lookup (`language`+`symbol`) for a record member (e.g. `com.example.Point#x`) resolved to the backing field instead of the record component, causing `ReferencesSearch` to return 0 results. The resolver now prefers the `PsiRecordComponent` over the synthetic field for record classes.
+
 ## [5.3.0] - 2026-08-05
 
 ### Fixed

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaHandlers.kt
@@ -3,10 +3,10 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.java
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.toArgumentFailure
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.*
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureKind
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureNode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiSourcePosition
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.openapi.diagnostic.logger
@@ -1710,6 +1710,12 @@ class JavaSymbolReferenceHandler : BaseJavaHandler<PsiNamedElement>(), SymbolRef
         classFqn: String,
         memberName: String
     ): Result<PsiNamedElement> {
+        // For records, first go over the component over the backing field (ReferencesSearch finds 0 on fields).
+        if (psiClass.isRecord) {
+            val component = psiClass.recordComponents.firstOrNull { it.name == memberName }
+            if (component != null) return Result.success(component)
+        }
+
         // Try field/enum constant first (true = search supertypes)
         val field = psiClass.findFieldByName(memberName, true)
         if (field != null && isInheritedBy(field, psiClass)) {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesRecordComponentBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesRecordComponentBehaviorTest.kt
@@ -1,0 +1,81 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindUsagesResult
+import com.intellij.platform.ide.progress.ModalTaskOwner.project
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class FindUsagesRecordComponentBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        LanguageHandlerRegistry.registerHandlers()
+    }
+
+    private fun writeRecordFixture() {
+        registerSourceRoot("record-src")
+        writeProjectFile(
+            "record-src/example/Config.java",
+            //language=java
+            """
+            package example;
+
+            public record Config(String name, int timeout) {}
+            """.trimIndent()
+        )
+        writeProjectFile(
+            "record-src/example/Service.java",
+            //language=java
+            """
+            package example;
+
+            public class Service {
+                public void run(Config config) {
+                    config.name();
+                    config.name();
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    fun testRecordComponentPositionBasedFindsAccessorCallSites() =
+        // Column 29 lands on `name` in `public record Config(String name, int timeout) {}`
+        testRecordComponentSymbol(buildJsonObject {
+            put("file", "record-src/example/Config.java")
+            put("line", 3)
+            put("column", 29)
+        })
+
+    fun testRecordComponentSymbolBasedFindsAccessorCallSites() =
+        testRecordComponentSymbol(buildJsonObject {
+            put("language", "Java")
+            put("symbol", "example.Config#name")
+        })
+
+    private fun testRecordComponentSymbol(args: JsonObject) = runBlocking {
+        writeRecordFixture()
+
+        val result = FindUsagesTool().execute(project, args)
+        assertToolSucceeded("find_references (symbol) on Java record component", result)
+        val parsed = json.decodeFromString<FindUsagesResult>(toolText(result))
+
+        assertEquals(
+            "Accessor call sites must be returned; got: ${parsed.usages}",
+            2, parsed.totalCount
+        )
+        assertEquals(
+            "kind must be record component for symbol-based lookup after fix",
+            "record component",
+            parsed.resolvedSymbol?.kind
+        )
+        assertTrue(parsed.usages.all { it.file.endsWith("Service.java") })
+    }
+}


### PR DESCRIPTION
## Summary

`ide_find_references` (and other tools that resolve members by symbol name) returned 0 results for Java record component accessors. The symbol-mode lookup for e.g. `com.example.Point#x` resolved to the synthetic backing field rather than the `PsiRecordComponent`, and `ReferencesSearch` finds nothing on synthetic fields.

The fix: when resolving a member by name on a record class, check `recordComponents` first and return the matching component before falling through to `findFieldByName`.

## Why
IntelliJ did does find usages for a record:

<img width="2348" height="332" alt="image" src="https://github.com/user-attachments/assets/f0cbe0c7-c6f8-4f40-86e3-bb264cb85559" />

where the MCP tool does not:

```
Tool: ide_find_references
Status: SUCCESS
Timestamp: 2026-08-06T07: 51:17.890806Z
Duration: 16ms

Parameters:
{
"language": "Java",
"symbol": "package.name.SomeProperties#workflowFlowId",
"project_path": "<project-path>"
}

Result:
{
  "usages": [],
  "totalCount": 0,
  "truncated": false,
  "nextCursor": null,
  "hasMore": false,
  "totalCollected": 0,
  "offset": 0,
  "pageSize": 0,
  "stale": false,
  "resolvedSymbol": {
    "name": "workflowFlowId",
    "kind": "field",
    "container": "SomeProperties",
    "file": "path/to/SomeProperties.java",
    "line": 16
  },
  "totalIsExact": true
}
```

## Test
A `FindUsagesRecordComponentBehaviorTest` is included to guard this behavior.