### PR TITLE
v5.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.3.0
+pluginVersion = 5.3.1
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary

Patch version bump `5.3.0` → `5.3.1` in `gradle.properties`, releasing the one fix currently sitting in `[Unreleased]`: `ide_find_references` resolving Java record components instead of the synthetic backing field in symbol-mode lookup (#297). A bug fix in an existing tool → patch bump per the SemVer table in CONTRIBUTING.md.

`CHANGELOG.md` is intentionally untouched: per the release flow in CONTRIBUTING.md, entries may stay in `[Unreleased]` — after the draft release for this version is published, the pipeline moves them under `## [5.3.1]` and opens the follow-up changelog PR (same sequence as v5.2.2 → #292).

## Checklist

Every PR must comply with [CONTRIBUTING.md](../CONTRIBUTING.md) — read it first.

- [x] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections) — no new entry needed: the release entry for this bump already lives in `[Unreleased]` (added by #297), and no version section is created here
- [ ] `./scripts/check-pr.sh` passes — not runnable in the sandbox this PR was authored from (network policy blocks the IntelliJ platform download); its static gates were applied manually and CI runs `./gradlew check` on this PR
- [ ] `./gradlew test` passes (full suite, not just `-Ptier=unit`) — same constraint; deferring to CI on a one-line version property change
- [x] New tools (if any): registered in `ToolNames`, `ToolRegistry`, and `McpSettings` (opt-in defaults), documented in all six doc locations, and the golden tool manifest regenerated with its diff reviewed — none added
- [x] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfcRfewEZpetxkiLsKUc3S

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfcRfewEZpetxkiLsKUc3S)_