### PR TITLE
v5.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.3.1
+pluginVersion = 5.4.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary

Version bump `5.3.1` → `5.4.0` for release.

Minor bump per the CONTRIBUTING SemVer table — this release ships a new feature: the **EDT heartbeat fail-fast gate** (#300, #301). When the IDE's UI thread is frozen, tool calls now return an immediate actionable error instead of hanging into the MCP client timeout.

Changelog entry is already under `[Unreleased]` (added in #301); the versioned section is created by the release workflow as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)