### PR TITLE
fix: prune managed lifecycle entries for deleted directories on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Lifecycle manager no longer accumulates ghost entries for deleted project directories.** Temporary projects (worktrees, slots, ephemeral checkouts) that were opened and later deleted from disk remained in the managed projects registry forever. On startup, `loadState` now prunes any managed path whose directory no longer exists, preventing unbounded growth of the persisted state.
+
 ## [5.5.0] - 2026-08-09
 
 ### Added

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeService.kt
@@ -51,9 +51,22 @@ class ProjectModeService : PersistentStateComponent<ProjectModeService.State>, D
     override fun loadState(state: State) {
         // IntelliJ collapses real paths to macros (e.g. $USER_HOME$) when persisting but does
         // not expand them back automatically for plain Set<String> fields — expand explicitly.
+        val expandedClosed = state.closedProjectPaths.mapTo(ConcurrentHashMap.newKeySet(), ::expandMacros)
+        val expandedManaged = state.managedProjectPaths.mapTo(ConcurrentHashMap.newKeySet(), ::expandMacros)
+
+        val ghostPaths = expandedManaged.filter { !java.io.File(it).isDirectory }
+        if (ghostPaths.isNotEmpty()) {
+            LOG.info("Pruning ${ghostPaths.size} managed project(s) whose path no longer exists on disk")
+            ghostPaths.forEach { path ->
+                expandedManaged.remove(path)
+                expandedClosed.remove(path)
+                LOG.info("  pruned: $path")
+            }
+        }
+
         persistedState = State(
-            closedProjectPaths = state.closedProjectPaths.mapTo(ConcurrentHashMap.newKeySet(), ::expandMacros),
-            managedProjectPaths = state.managedProjectPaths.mapTo(ConcurrentHashMap.newKeySet(), ::expandMacros)
+            closedProjectPaths = expandedClosed,
+            managedProjectPaths = expandedManaged
         )
         persistedState.closedProjectPaths.forEach { modes[it] = ProjectMode.CLOSED }
     }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeServicePruneTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeServicePruneTest.kt
@@ -1,0 +1,55 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.lifecycle
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import java.util.concurrent.ConcurrentHashMap
+
+class ProjectModeServicePruneTest : McpPlatformTestCase() {
+
+    fun testLoadStatePrunesNonExistentPaths() {
+        val service = ProjectModeService()
+        val existingPath = System.getProperty("user.home")
+        val ghostPath = "/tmp/does-not-exist-lifecycle-test-${System.nanoTime()}"
+
+        val state = ProjectModeService.State(
+            closedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply {
+                add(existingPath)
+                add(ghostPath)
+            },
+            managedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply {
+                add(existingPath)
+                add(ghostPath)
+            }
+        )
+
+        service.loadState(state)
+
+        assertTrue("Existing path should be kept in managedProjectPaths",
+            service.isManaged(existingPath))
+        assertFalse("Ghost path should be pruned from managedProjectPaths",
+            service.isManaged(ghostPath))
+        assertFalse("Ghost path should be pruned from closedProjectPaths",
+            service.wasClosedByUs(ghostPath))
+    }
+
+    fun testLoadStateKeepsAllExistingPaths() {
+        val service = ProjectModeService()
+        val path1 = System.getProperty("user.home")
+        val path2 = System.getProperty("java.io.tmpdir").trimEnd('/')
+
+        val state = ProjectModeService.State(
+            closedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply {
+                add(path1)
+                add(path2)
+            },
+            managedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply {
+                add(path1)
+                add(path2)
+            }
+        )
+
+        service.loadState(state)
+
+        assertTrue("path1 should be kept", service.isManaged(path1))
+        assertTrue("path2 should be kept", service.isManaged(path2))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeServiceTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/lifecycle/ProjectModeServiceTest.kt
@@ -84,23 +84,29 @@ class ProjectModeServiceTest : BasePlatformTestCase() {
     }
 
     fun testClosedProjectRegistryRoundTrip() {
-        // Simulates what happens across an IDE restart: state is persisted and reloaded
-        val path = "/persisted/project"
-        service.markClosed(path)
+        // Simulates what happens across an IDE restart: state is persisted and reloaded.
+        // Uses a real temp directory — loadState prunes non-existent paths on startup.
+        val dir = java.io.File.createTempFile("lifecycle-roundtrip-", "").apply { delete(); mkdirs() }
+        try {
+            val path = dir.absolutePath
+            service.markClosed(path)
 
-        val persistedState = service.getState()
-        assertTrue(persistedState.closedProjectPaths.contains(path))
+            val persistedState = service.getState()
+            assertTrue(persistedState.closedProjectPaths.contains(path))
 
-        // Simulate restart: create fresh service, load persisted state
-        val fresh = ProjectModeService()
-        fresh.loadState(persistedState)
+            // Simulate restart: create fresh service, load persisted state
+            val fresh = ProjectModeService()
+            fresh.loadState(persistedState)
 
-        assertTrue("Closed path must survive state round-trip", fresh.wasClosedByUs(path))
-        assertEquals(
-            "Mode must be CLOSED after loading state with closed path",
-            ProjectMode.CLOSED,
-            fresh.getMode(path)
-        )
+            assertTrue("Closed path must survive state round-trip", fresh.wasClosedByUs(path))
+            assertEquals(
+                "Mode must be CLOSED after loading state with closed path",
+                ProjectMode.CLOSED,
+                fresh.getMode(path)
+            )
+        } finally {
+            dir.deleteRecursively()
+        }
     }
 
     // ── Mode queries ─────────────────────────────────────────────────────────

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ProjectStatusToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/lifecycle/ProjectStatusToolBehaviorTest.kt
@@ -63,27 +63,31 @@ class ProjectStatusToolBehaviorTest : McpPlatformTestCase() {
      * `0 == 0` for any predicate you write when there is only one row.
      */
     private fun withSyntheticManagedProjects(
-        vararg managedPaths: String,
-        closedPaths: Set<String> = managedPaths.toSet(),
+        count: Int,
+        closedCount: Int = count,
         lifecycleEnabled: Boolean = true,
-        body: () -> Unit
+        body: (paths: List<String>) -> Unit
     ) {
         val settings = McpSettings.getInstance()
         val service = ProjectModeService.getInstance()
         val previousLifecycle = settings.lifecycleEnabled
         val previousState = service.getAllManagedModes().keys.toSet()
+        val tempDirs = (1..count).map { java.nio.file.Files.createTempDirectory("aaa-lifecycle-synth-$it") }
+        val paths = tempDirs.map { it.toAbsolutePath().toString() }
+        val closedPaths = paths.take(closedCount).toSet()
         try {
             settings.lifecycleEnabled = lifecycleEnabled
             service.loadState(
                 ProjectModeService.State(
                     closedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply { addAll(closedPaths) },
-                    managedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply { addAll(managedPaths) }
+                    managedProjectPaths = ConcurrentHashMap.newKeySet<String>().apply { addAll(paths) }
                 )
             )
-            body()
+            body(paths)
         } finally {
             service.loadState(ProjectModeService.State())
             settings.lifecycleEnabled = previousLifecycle
+            tempDirs.forEach { it.toFile().deleteRecursively() }
             assertTrue(
                 "Lifecycle state must be restored so later tests are unaffected",
                 service.getAllManagedModes().keys.none { it !in previousState }
@@ -92,13 +96,13 @@ class ProjectStatusToolBehaviorTest : McpPlatformTestCase() {
     }
 
     fun testManagedButClosedProjectIsReportedWithItsMode() = runBlocking {
-        withSyntheticManagedProjects("/synthetic/closed-project") {
+        withSyntheticManagedProjects(1) { paths ->
             val result = runBlocking { ProjectStatusTool().execute(project, buildJsonObject { }) }
             assertToolSucceeded("project_status should succeed", result)
 
             val projects = json.parseToJsonElement(toolText(result)).jsonObject["projects"]!!
                 .jsonArray.map { it.jsonObject }
-            val closed = projects.singleOrNull { it["path"]?.jsonPrimitive?.content == "/synthetic/closed-project" }
+            val closed = projects.singleOrNull { it["path"]?.jsonPrimitive?.content == paths[0] }
             assertNotNull("A managed-but-closed project must still be reported", closed)
             assertFalse("It is not open", closed!!["open"]!!.jsonPrimitive.boolean)
             assertTrue("It is managed", closed["managed"]!!.jsonPrimitive.boolean)
@@ -107,12 +111,16 @@ class ProjectStatusToolBehaviorTest : McpPlatformTestCase() {
                 "closed",
                 closed["mode"]?.jsonPrimitive?.content
             )
-            assertEquals("Name falls back to the last path segment", "closed-project", closed["name"]!!.jsonPrimitive.content)
+            assertEquals(
+                "Name falls back to the last path segment",
+                paths[0].substringAfterLast("/"),
+                closed["name"]!!.jsonPrimitive.content
+            )
         }
     }
 
     fun testSummaryCountsAgreeWithTheProjectRows() = runBlocking {
-        withSyntheticManagedProjects("/synthetic/closed-a", "/synthetic/closed-b") {
+        withSyntheticManagedProjects(2) { _ ->
             val result = runBlocking { ProjectStatusTool().execute(project, buildJsonObject { }) }
             val payload = json.parseToJsonElement(toolText(result)).jsonObject
             val projects = payload["projects"]!!.jsonArray.map { it.jsonObject }
@@ -163,17 +171,17 @@ class ProjectStatusToolBehaviorTest : McpPlatformTestCase() {
      */
     fun testManagedProjectsAreReportedEvenWhenLifecycleAutomationIsDisabled() = runBlocking {
         withSyntheticManagedProjects(
-            "/synthetic/enrolled-elsewhere",
-            closedPaths = emptySet(),
+            1,
+            closedCount = 0,
             lifecycleEnabled = false
-        ) {
+        ) { paths ->
             val result = runBlocking { ProjectStatusTool().execute(project, buildJsonObject { }) }
             assertToolSucceeded("project_status should succeed", result)
 
             val payload = json.parseToJsonElement(toolText(result)).jsonObject
             val projects = payload["projects"]!!.jsonArray.map { it.jsonObject }
             val enrolled = projects.singleOrNull {
-                it["path"]?.jsonPrimitive?.content == "/synthetic/enrolled-elsewhere"
+                it["path"]?.jsonPrimitive?.content == paths[0]
             }
             assertNotNull("An enrolled project must be reported even while automation is paused", enrolled)
             assertTrue(
@@ -214,14 +222,15 @@ class ProjectStatusToolBehaviorTest : McpPlatformTestCase() {
     }
 
     fun testOpenProjectsAreListedBeforeClosedOnes() = runBlocking {
-        withSyntheticManagedProjects("/synthetic/aaa-closed-sorts-first-alphabetically") {
+        // The synthetic path prefix "aaa-" sorts before the fixture project by name, so a
+        // name-only sort would put the closed row first. Only the open-first ordering yields
+        // [true, false].
+        withSyntheticManagedProjects(1) { _ ->
             val result = runBlocking { ProjectStatusTool().execute(project, buildJsonObject { }) }
 
             val openFlags = json.parseToJsonElement(toolText(result)).jsonObject["projects"]!!
                 .jsonArray.map { it.jsonObject["open"]!!.jsonPrimitive.boolean }
 
-            // The synthetic path sorts before the fixture project by name, so a name-only sort
-            // would put the closed row first. Only the open-first ordering yields [true, false].
             assertEquals(
                 "Open projects must sort ahead of closed ones so the useful rows come first",
                 listOf(true, false),


### PR DESCRIPTION
## Summary

Closes #306.

Temporary projects (worktrees, slots, ephemeral checkouts) opened via `ide_open_project` and later deleted from disk remained in the managed projects registry forever. In practice this accumulated 79+ ghost entries out of 185 managed projects. Calling `ide_release_project` on them triggered `resolveOrOpen` which tried to reopen each path, spawning dozens of windows simultaneously.

- **`loadState` now prunes non-existent paths** — on startup, any managed/closed path where `File.isDirectory()` returns false is removed before the state is applied. Pruned entries are logged at INFO.
- **New test** — `ProjectModeServicePruneTest` verifies ghost paths are pruned and existing paths survive.
- **Existing test fixes** — `ProjectModeServiceTest.testClosedProjectRegistryRoundTrip` and `ProjectStatusToolBehaviorTest.withSyntheticManagedProjects` used fake paths that don't exist on disk. Updated to use real temp directories so they work with the new pruning.

## Test plan

- [x] `ProjectModeServicePruneTest` — 2 tests: ghost path pruned, existing paths kept
- [x] `ProjectModeServiceTest` — round-trip test updated to use real temp directory
- [x] `ProjectStatusToolBehaviorTest` — all 5 tests updated to use real temp directories
- [x] Full test suite passes (`./gradlew clean test --no-build-cache`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)