### PR TITLE
v5.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.5.0
+pluginVersion = 5.5.1
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary

Version bump `5.5.0` → `5.5.1` for release.

Patch bump per the CONTRIBUTING SemVer table — this release ships one bug fix: **lifecycle ghost-entry pruning** (#306, #307). Managed lifecycle entries whose project directory was deleted from disk (temporary worktrees, ephemeral checkouts) are now pruned on startup instead of accumulating forever and triggering reopen attempts on nonexistent paths.

Changelog entry is already under `[Unreleased]` (added in #307); the versioned section is created by the release workflow as usual.

## Test plan

- [x] `./scripts/check-pr.sh` — 16/16 checks pass, full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)