### PR TITLE
fix: pre-check refactoring scope for read-only files (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ide_refactor_rename` and `ide_change_signature` no longer hang on the "read-only files" dialog** ([#310](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/310)) — when the refactoring scope contained read-only files (generated metamodel classes in `target/`, Flyway migration SQL, files from other content roots), the IntelliJ refactoring engine showed a modal read-only dialog that blocked the EDT until the MCP client timed out. Both tools now pre-check every file discovered by `findUsages()` before executing and return an actionable error listing the read-only files instead.
+
 ## [5.5.1] - 2026-08-12
 
 ### Fixed

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -315,6 +315,19 @@ class ChangeSignatureTool : AbstractMcpTool() {
                     .newInstance(project, changeInfo) as com.intellij.refactoring.BaseRefactoringProcessor
 
                 processor.setPreviewUsages(false)
+
+                // Pre-check the full refactoring scope for read-only files (issue #310):
+                // run() would route them through ReadonlyStatusHandler's modal dialog,
+                // blocking the EDT in headless MCP sessions. Fails open when
+                // findUsages() cannot be invoked reflectively.
+                val usages = RefactoringScopeGuard.findUsagesReflectively(processor)
+                val readOnlyInScope = usages
+                    ?.let { RefactoringScopeGuard.readOnlyFilesIn(project, it) }
+                    .orEmpty()
+                if (readOnlyInScope.isNotEmpty()) {
+                    throw Exception(RefactoringScopeGuard.blockedMessage(readOnlyInScope))
+                }
+
                 val hook = processorRunHook
                 if (hook != null) hook() else processor.run()
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringScopeGuard.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringScopeGuard.kt
@@ -1,0 +1,70 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.usageView.UsageInfo
+
+/**
+ * Pre-flight writability check for the *full* refactoring scope (issue #310).
+ *
+ * `BaseRefactoringProcessor.run()` routes read-only affected files through
+ * `ReadonlyStatusHandler`, which in a real IDE shows a modal "these files are
+ * read-only" dialog. A headless MCP call then blocks the EDT until the client
+ * times out. Checking every file discovered by `findUsages()` *before* running
+ * the processor turns that hang into an actionable error listing the files.
+ *
+ * The per-target `isWritable` checks in the individual tools still run first;
+ * this guard covers referencing files (generated sources, SQL migrations,
+ * files from other content roots).
+ */
+internal object RefactoringScopeGuard {
+    private val LOG = Logger.getInstance(RefactoringScopeGuard::class.java)
+
+    /** Relative paths of read-only files among the usages' containing files. */
+    fun readOnlyFilesIn(project: Project, usages: Array<UsageInfo>): List<String> =
+        usages.asSequence()
+            .mapNotNull { it.virtualFile }
+            .distinct()
+            .filterNot { it.isWritable }
+            .map { ProjectUtils.getToolFilePath(project, it) }
+            .distinct()
+            .sorted()
+            .toList()
+
+    /**
+     * Invokes the processor's `findUsages()` reflectively. `BaseRefactoringProcessor`
+     * declares it protected and some subclasses (e.g. `ChangeSignatureProcessorBase`)
+     * keep it that way. Returns null when reflection fails — callers fail open,
+     * keeping the tool functional at the cost of the pre-check.
+     */
+    fun findUsagesReflectively(processor: BaseRefactoringProcessor): Array<UsageInfo>? {
+        return try {
+            var cls: Class<*>? = processor.javaClass
+            while (cls != null) {
+                val method = try {
+                    cls.getDeclaredMethod("findUsages")
+                } catch (_: NoSuchMethodException) {
+                    cls = cls.superclass
+                    continue
+                }
+                method.isAccessible = true
+                @Suppress("UNCHECKED_CAST")
+                return method.invoke(processor) as? Array<UsageInfo>
+            }
+            null
+        } catch (e: Exception) {
+            LOG.warn("Read-only scope pre-check skipped — findUsages() reflection failed: ${e.message}")
+            null
+        }
+    }
+
+    /** Builds the error message for a scope blocked by [readOnlyFiles]. */
+    fun blockedMessage(readOnlyFiles: List<String>): String =
+        "Blocked by read-only files in the refactoring scope: " +
+            readOnlyFiles.joinToString(", ") +
+            ". Make these files writable, or remove them from the scope " +
+            "(for generated sources: run a clean build and ide_sync_files; " +
+            "or exclude the directory from the project's content roots), then retry."
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -707,6 +707,16 @@ class RenameSymbolTool : AbstractMcpTool() {
             .createSmartPsiElementPointer(targetElement)
         val targetNameBeforeRename = targetElement.name
 
+        // Pre-check the full refactoring scope for read-only files (issue #310):
+        // run() would route them through ReadonlyStatusHandler's modal dialog,
+        // blocking the EDT in headless MCP sessions. findUsages() is idempotent
+        // (it clears the internal renamer list on entry), so run() repeating the
+        // search is safe.
+        val readOnlyInScope = RefactoringScopeGuard.readOnlyFilesIn(project, renameProcessor.findUsages())
+        if (readOnlyInScope.isNotEmpty()) {
+            throw Exception(RefactoringScopeGuard.blockedMessage(readOnlyInScope))
+        }
+
         // RenameProcessor manages its own write actions and progress. Starting it inside
         // WriteCommandAction can deadlock in modern IDE builds.
         val hook = processorRunHook

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReadOnlyFileGuardBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReadOnlyFileGuardBehaviorTest.kt
@@ -110,6 +110,106 @@ class ReadOnlyFileGuardBehaviorTest : McpPlatformTestCase() {
         assertEquals("File must be unchanged", original, readProjectFileVfs("src/Locked.java"))
     }
 
+    // ── RenameSymbolTool — read-only file in scope, not the target (issue #310) ──
+
+    fun testRenameSymbolRejectsReadOnlyReferencingFile() = runBlocking {
+        registerSourceRoot("ro-scope-rename")
+        writeProjectFile(
+            "ro-scope-rename/roscope/Target.java", """
+            package roscope;
+
+            public class Target {
+                public String getDisplayName() {
+                    return "name";
+                }
+            }
+            """.trimIndent()
+        )
+        val callerOriginal = """
+            package roscope;
+
+            public class Caller {
+                public String describe(Target target) {
+                    return target.getDisplayName();
+                }
+            }
+        """.trimIndent()
+        writeProjectFile("ro-scope-rename/roscope/Caller.java", callerOriginal)
+        markReadOnly("ro-scope-rename/roscope/Caller.java")
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "ro-scope-rename/roscope/Target.java")
+            put("line", 4)
+            put("column", 19)
+            put("newName", "getFullName")
+        })
+
+        assertToolFailed("Should reject read-only referencing file", result)
+        assertTrue(
+            "Error should name the read-only scope, was: ${toolText(result)}",
+            toolText(result).contains("read-only files in the refactoring scope")
+        )
+        assertTrue(
+            "Error should list the read-only file, was: ${toolText(result)}",
+            toolText(result).contains("Caller.java")
+        )
+        assertEquals("Caller must be unchanged", callerOriginal, readProjectFileVfs("ro-scope-rename/roscope/Caller.java"))
+        assertFalse(
+            "Target must be unchanged",
+            readProjectFileVfs("ro-scope-rename/roscope/Target.java").contains("getFullName")
+        )
+    }
+
+    // ── ChangeSignatureTool — read-only file in scope, not the target (issue #310) ──
+
+    fun testChangeSignatureRejectsReadOnlyReferencingFile() = runBlocking {
+        registerSourceRoot("ro-scope-sig")
+        writeProjectFile(
+            "ro-scope-sig/rosig/Api.java", """
+            package rosig;
+
+            public class Api {
+                public int compute(int value) {
+                    return value;
+                }
+            }
+            """.trimIndent()
+        )
+        val clientOriginal = """
+            package rosig;
+
+            public class ApiClient {
+                public int use(Api api) {
+                    return api.compute(1);
+                }
+            }
+        """.trimIndent()
+        writeProjectFile("ro-scope-sig/rosig/ApiClient.java", clientOriginal)
+        markReadOnly("ro-scope-sig/rosig/ApiClient.java")
+
+        val result = ChangeSignatureTool().execute(project, buildJsonObject {
+            put("file", "ro-scope-sig/rosig/Api.java")
+            put("line", 4)
+            put("column", 16)
+            put("newName", "calculate")
+        })
+
+        assertToolFailed("Should reject read-only referencing file", result)
+        assertTrue(
+            "Error should name the read-only scope, was: ${toolText(result)}",
+            toolText(result).contains("read-only files in the refactoring scope")
+        )
+        assertTrue(
+            "Error should list the read-only file, was: ${toolText(result)}",
+            toolText(result).contains("ApiClient.java")
+        )
+        assertEquals("Client must be unchanged", clientOriginal, readProjectFileVfs("ro-scope-sig/rosig/ApiClient.java"))
+        assertFalse(
+            "Api must be unchanged",
+            readProjectFileVfs("ro-scope-sig/rosig/Api.java").contains("calculate")
+        )
+    }
+
     // ── SafeDeleteTool — symbol mode ──
 
     fun testSafeDeleteSymbolRejectsReadOnlyFile() = runBlocking {


### PR DESCRIPTION
Fixes #310.

## Problem

When `ide_refactor_rename` or `ide_change_signature` touched read-only files in the refactoring scope (generated metamodel classes in `target/`, Flyway migration SQL, files from other content roots), `BaseRefactoringProcessor.run()` routed them through `ReadonlyStatusHandler`, which shows a modal "these files are read-only" dialog. In headless MCP sessions this blocks the EDT until the client times out — the existing post-run `verifyRenameApplied` check never gets a chance to run because `run()` never returns. The existing `ensureWritable` pre-flight (#273) only checks the *target* file.

## Fix

New `RefactoringScopeGuard`: before running the processor, collect the files discovered by `findUsages()`, and if any is read-only, return an actionable error listing them plus a suggestion (clean build + `ide_sync_files`, or exclude the directory from content roots).

- `RenameSymbolTool`: uses the public `RenameProcessor.findUsages()` (idempotent — it clears its internal renamer list on entry, so `run()` repeating the search is safe).
- `ChangeSignatureTool`: `ChangeSignatureProcessorBase.findUsages()` is protected, so it is invoked reflectively; if reflection fails, the check fails open and the tool keeps working.
- `SafeDeleteTool` deletes PSI directly (no `BaseRefactoringProcessor.run()`), so it is not exposed to the dialog and is unchanged.

## Tests

Two new platform tests in `ReadOnlyFileGuardBehaviorTest` (read-only *referencing* file, writable target) assert the guard-specific error text, the listed file path, and that both files are unchanged. Without the fix these fail with the generic silent-abort error. Full suite + `./scripts/check-pr.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)