### PR TITLE
fix: ide_refactor_rename pre-checks usage scope for read-only files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ide_refactor_rename` no longer blocks on modal dialogs in headless MCP sessions.** ([#310](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/310)) Two dialog-blocking paths fixed: (1) when the rename scope includes read-only files, the tool now pre-checks all usage files for writability and returns an actionable error listing the blocking files; (2) when the language processor forces a refactoring preview, `HeadlessRenameProcessor` now suppresses it instead of opening the preview tool window.
+
 ## [5.5.1] - 2026-08-12
 
 ### Fixed

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/HeadlessRenameProcessor.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/HeadlessRenameProcessor.kt
@@ -27,6 +27,8 @@ internal class HeadlessRenameProcessor(
      */
     val capturedConflicts = mutableListOf<String>()
 
+    override fun isPreviewUsages(usages: Array<out UsageInfo>): Boolean = false
+
     override fun showAutomaticRenamingDialog(automaticVariableRenamer: AutomaticRenamer): Boolean {
         for (element in automaticVariableRenamer.elements) {
             val suggestedName = automaticVariableRenamer.getNewName(element) ?: continue

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -696,6 +696,24 @@ class RenameSymbolTool : AbstractMcpTool() {
         // Disable preview dialog for headless operation
         renameProcessor.setPreviewUsages(false)
 
+        // Pre-check: find all files that the rename would touch and verify they're writable.
+        // Without this, the platform shows a modal "read-only files" dialog that blocks the
+        // EDT indefinitely in headless MCP sessions.
+        val usages = renameProcessor.findUsages()
+        val readOnlyUsageFiles = usages
+            .mapNotNull { it.virtualFile }
+            .filter { !it.isWritable }
+            .map { ProjectUtils.getRelativePath(project, it.path) }
+            .distinct()
+        if (readOnlyUsageFiles.isNotEmpty()) {
+            throw Exception(
+                "Rename blocked by read-only files in rename scope: " +
+                    readOnlyUsageFiles.joinToString(", ") +
+                    ". Remove generated sources (mvn clean + ide_sync_files) or " +
+                    "exclude immutable files from the project's content roots."
+            )
+        }
+
         // Collected partial-success data from JS/TS import retargeting.
         val retargetWarnings = mutableListOf<String>()
         val unretargetedImporters = mutableListOf<String>()

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameReadOnlyScopeBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameReadOnlyScopeBehaviorTest.kt
@@ -1,0 +1,84 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.openapi.vfs.LocalFileSystem
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.File
+
+/**
+ * When a rename's usage scope includes read-only files (generated metamodel classes,
+ * Flyway migrations, files from other content roots), the tool must return an error
+ * listing the blocking files instead of showing a modal dialog that hangs headless
+ * MCP sessions.
+ */
+class RenameReadOnlyScopeBehaviorTest : McpPlatformTestCase() {
+
+    private val readOnlyFiles = mutableListOf<com.intellij.openapi.vfs.VirtualFile>()
+
+    override fun setUp() {
+        super.setUp()
+        registerSourceRoot("src")
+    }
+
+    override fun tearDown() {
+        try {
+            for (vf in readOnlyFiles) {
+                runCatching {
+                    File(vf.path).setWritable(true)
+                    vf.refresh(false, false)
+                }
+            }
+            readOnlyFiles.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun markReadOnly(relativePath: String): com.intellij.openapi.vfs.VirtualFile {
+        val basePath = requireNotNull(project.basePath)
+        val vf = requireNotNull(
+            LocalFileSystem.getInstance().refreshAndFindFileByPath("$basePath/$relativePath")
+        ) { "Cannot find VFS entry for $relativePath" }
+        File(vf.path).setWritable(false)
+        vf.refresh(false, false)
+        readOnlyFiles.add(vf)
+        return vf
+    }
+
+    fun testRenameFailsWithReadOnlyUsageSiteInsteadOfShowingDialog() = runBlocking {
+        writeProjectFile("src/Api.java", """
+            public class Api {
+                public String greet() { return "hello"; }
+            }
+        """.trimIndent())
+
+        writeProjectFile("src/Caller.java", """
+            public class Caller {
+                String s = new Api().greet();
+            }
+        """.trimIndent())
+
+        markReadOnly("src/Caller.java")
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "src/Api.java")
+            put("line", 2)
+            put("column", 19)
+            put("newName", "sayHello")
+        })
+
+        assertToolFailed("Rename should fail when usage sites are read-only", result)
+        val text = toolText(result)
+        assertTrue(
+            "Error must mention read-only usage files (pre-check), was: $text",
+            text.contains("read-only files in rename scope", ignoreCase = true)
+        )
+        assertTrue(
+            "Error must list the specific blocking file, was: $text",
+            text.contains("Caller.java")
+        )
+        assertFileContains("src/Api.java", "public String greet()")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #310.

When `ide_refactor_rename` encounters read-only files in the refactoring scope (generated metamodel classes in `target/`, Flyway migrations, files from other content roots), the platform shows a modal "read-only files" dialog. In headless MCP sessions this blocks the EDT indefinitely — the agent gets a client timeout with no explanation.

The fix adds a pre-check between processor configuration and `run()`:
1. Calls `renameProcessor.findUsages()` to discover all affected files
2. Filters for non-writable virtual files
3. If any are found, throws with an actionable error listing the blocking files and suggesting `mvn clean` + `ide_sync_files`

The existing single-file writability check (line 392) only covers the declaration file. This new check covers the entire usage scope.

## Test plan

- [x] `RenameReadOnlyScopeBehaviorTest` — writable declaration + read-only call-site: tool returns error listing the read-only file with "read-only files in rename scope" message, declaration file unchanged
- [x] Existing `RenameSymbolToolBehaviorTest` — all passing (no regression on normal renames)
- [x] Full test suite green (`./gradlew clean test --no-build-cache`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)