### PR TITLE
fix: auto-enable VFS sync on startup to prevent file-change dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-sync of external file changes is now enabled automatically.** The plugin sets `GeneralSettings.isSyncOnFrameActivation = true` on startup, preventing the "Load File System Changes" modal dialog that blocks headless MCP sessions when agents modify files externally.
+
 ## [5.5.1] - 2026-08-12
 
 ### Fixed

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
@@ -103,6 +103,7 @@ class McpServerService(
         val startServer = shouldStartServer()
         if (startServer) {
             EdtHeartbeatService.getInstance()
+            ensureAutoSyncEnabled()
             val settings = McpSettings.getInstance()
             val port = settings.serverPort
             val host = settings.serverHost
@@ -110,6 +111,14 @@ class McpServerService(
             LOG.info("MCP Server Service initialized with Ktor CIO server")
         } else {
             LOG.info("Initialized MCP tool metadata without starting server in unit test mode")
+        }
+    }
+
+    private fun ensureAutoSyncEnabled() {
+        val gs = com.intellij.ide.GeneralSettings.getInstance()
+        if (!gs.isSyncOnFrameActivation) {
+            gs.isSyncOnFrameActivation = true
+            LOG.info("Enabled auto-sync of external file changes for MCP operation")
         }
     }
 


### PR DESCRIPTION
## Summary

When `GeneralSettings.isSyncOnFrameActivation` (aka `autoSyncFiles` in `ide.general.xml`) is `false`, every external file modification triggers a modal "Load File System Changes" dialog. In headless MCP sessions this blocks the EDT indefinitely — the agent never gets a response.

The fix: `McpServerService.initialize()` now enables auto-sync on startup. This is a one-line change that ensures the IDE automatically picks up external file changes without prompting, which is essential for MCP agents that modify files via `Write`, `Edit`, and other external tools.

The setting is only enabled, never disabled — if a user has it on already (the default), nothing changes. If they disabled it manually, the MCP plugin re-enables it because headless operation requires it.

## Test plan

- [x] Compiles clean
- [x] Full test suite passes (`./gradlew clean test --no-build-cache`)
- [x] Verified manually: with `autoSyncFiles=false` in `ide.general.xml`, restarting with the plugin re-enables it and the dialog no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)