### PR TITLE
feat: include failure stack trace in ide_run_tests results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`ide_run_tests` results now include the failure stack trace** ([#316](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/316)) — each failed or errored test entry carries a new `stackTrace` field with the trace reported by the test framework, alongside the existing `errorMessage` (which only holds the exception message). Very long traces (e.g. deeply chained causes) are trimmed in the middle so both the throw site and the root cause survive.
+
 ## [5.5.2] - 2026-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Added
 
-- **`ide_run_tests` results now include the failure stack trace** ([#316](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/316)) — each failed or errored test entry carries a new `stackTrace` field with the trace reported by the test framework, alongside the existing `errorMessage` (which only holds the exception message). Very long traces (e.g. deeply chained causes) are trimmed in the middle so both the throw site and the root cause survive.
+- **`ide_run_tests` results now include the failure stack trace** ([#316](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/316)) — each failed or errored test entry carries a new `stackTrace` field with the trace reported by the test framework, alongside the existing `errorMessage` (which only holds the exception message). Very long traces (e.g. deeply chained causes) are trimmed in the middle so both the throw site and the root cause survive, and a per-run size budget keeps mass failures (hundreds of failing tests) from producing a response too large for MCP clients — earlier failures keep their traces, later entries fall back to `errorMessage` only.
+- **`ide_diagnostics` test-result stack traces now keep the root cause.** The test-results path previously truncated traces head-only at 500 chars, so chained exceptions lost their deepest `Caused by`. It now uses the same middle-trimming as `ide_run_tests` (same 500-char cap).
 
 ## [5.5.2] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 
 - **`ide_run_tests` results now include the failure stack trace** ([#316](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/316)) — each failed or errored test entry carries a new `stackTrace` field with the trace reported by the test framework, alongside the existing `errorMessage` (which only holds the exception message). Very long traces (e.g. deeply chained causes) are trimmed in the middle so both the throw site and the root cause survive, and a per-run size budget keeps mass failures (hundreds of failing tests) from producing a response too large for MCP clients — earlier failures keep their traces, later entries fall back to `errorMessage` only.
-- **`ide_diagnostics` test-result stack traces now keep the root cause.** The test-results path previously truncated traces head-only at 500 chars, so chained exceptions lost their deepest `Caused by`. It now uses the same middle-trimming as `ide_run_tests` (same 500-char cap).
+- **`ide_diagnostics` test-result stack traces now keep the innermost frames.** The test-results path previously truncated traces head-only at 500 chars, so for a chained exception you saw only the outermost frames. It now uses the same middle-trimming helper as `ide_run_tests` (unchanged 500-char cap), so the deepest frames — where the root cause was actually thrown — survive alongside the top of the trace.
 
 ## [5.5.2] - 2026-08-15
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1071,9 +1071,11 @@ Build the project using the IDE's build system (supports JPS, Gradle, Maven).
 
 > **Default**: Disabled - enable in Settings > Tools > Index MCP Server
 
-Run tests using the IDE's run configuration infrastructure. Returns structured pass/fail results with per-test error messages.
+Run tests using the IDE's run configuration infrastructure. Returns structured pass/fail results with per-test error messages and failure stack traces.
 
 Results are read directly from the IDE's test runner rather than from report files on disk, so they always reflect this run and work with any Service-Message-based framework (JUnit, TestNG, pytest, Jest, Go test, PHPUnit).
+
+Failed or errored tests carry a `stackTrace` alongside `errorMessage`. Very long traces are trimmed in the middle (keeping the throw site and the root cause of chained exceptions), and on mass failures a per-run size budget applies: earlier failures keep their traces, later entries carry `errorMessage` only.
 
 **Language support:** Passing an **existing run configuration name** works for any language/framework. Passing a **class or method FQN** (so the plugin creates the run config for you) is supported **only for Java/Kotlin** — for Python, JS/TS, Go, PHP, or Rust, create/select a run configuration in the IDE and pass its name.
 
@@ -1115,18 +1117,23 @@ Results are read directly from the IDE's test runner rather than from report fil
 
 ```json
 {
-  "success": true,
+  "success": false,
   "timedOut": false,
   "noTestsFound": false,
-  "exitCode": 0,
-  "passed": 3,
-  "failed": 0,
+  "exitCode": 1,
+  "passed": 2,
+  "failed": 1,
   "errors": 0,
   "total": 3,
   "tests": [
     { "name": "com.example.MyTest.testFoo", "status": "passed" },
     { "name": "com.example.MyTest.testBar", "status": "passed" },
-    { "name": "com.example.MyTest.testBaz", "status": "passed" }
+    {
+      "name": "com.example.MyTest.testBaz",
+      "status": "failed",
+      "errorMessage": "expected:<1> but was:<2>",
+      "stackTrace": "java.lang.AssertionError: expected:<1> but was:<2>\n\tat com.example.MyTest.testBaz(MyTest.java:42)"
+    }
   ]
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.5.2
+pluginVersion = 5.6.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
@@ -439,7 +439,8 @@ enum class TestStatus {
 data class TestRunEntry(
     val name: String,
     val status: TestStatus,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val stackTrace: String? = null
 )
 
 @Serializable

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -176,7 +176,9 @@ class RunTestsTool : AbstractMcpTool() {
         bounded by timeoutSeconds: once it expires the process is killed and the next poll reports
         timedOut: true.
 
-        Returns: success status, exit code, pass/fail/error counts, and per-test results.
+        Returns: success status, exit code, pass/fail/error counts, and per-test results. Failed or
+        errored tests include errorMessage and stackTrace (very long traces are trimmed in the
+        middle, keeping the throw site and the root cause).
         Results are read directly from the IDE's test runner, so they reflect this run (not stale report
         files) and work with any Service-Message-based framework (JUnit, TestNG, pytest, Jest, Go test, PHPUnit).
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -178,7 +178,8 @@ class RunTestsTool : AbstractMcpTool() {
 
         Returns: success status, exit code, pass/fail/error counts, and per-test results. Failed or
         errored tests include errorMessage and stackTrace (very long traces are trimmed in the
-        middle, keeping the throw site and the root cause).
+        middle, keeping the throw site and the root cause). On mass failures a per-run size budget
+        applies: earlier failures keep their traces, later entries carry errorMessage only.
         Results are read directly from the IDE's test runner, so they reflect this run (not stale report
         files) and work with any Service-Message-based framework (JUnit, TestNG, pytest, Jest, Go test, PHPUnit).
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollector.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollector.kt
@@ -103,8 +103,10 @@ object TestResultsCollector {
         if (trace.length <= maxLength) return trace
         var head = maxLength * 2 / 3
         var tailStart = trace.length - (maxLength - head)
-        if (trace[head - 1].isHighSurrogate()) head--
-        if (trace[tailStart].isLowSurrogate()) tailStart++
+        // Bounds-guarded: a degenerate cap collapses head to 0 / tailStart to the end, and this
+        // helper formats *error* output — crashing here would mask the real test failure.
+        if (head > 0 && trace[head - 1].isHighSurrogate()) head--
+        if (tailStart < trace.length && trace[tailStart].isLowSurrogate()) tailStart++
         return trace.substring(0, head) +
                 "\n... [${tailStart - head} chars truncated] ...\n" +
                 trace.substring(tailStart)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollector.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollector.kt
@@ -32,6 +32,14 @@ object TestResultsCollector {
      */
     internal const val MAX_RUN_ENTRY_STACKTRACE_LENGTH = 10_000
 
+    /**
+     * Aggregate stack-trace budget for one ide_run_tests result. A mass failure (broken shared
+     * fixture, hundreds of failed tests) must not become a multi-MB response that MCP clients
+     * truncate mid-JSON: earlier failures keep their traces, later ones fall back to
+     * errorMessage only once the budget is spent.
+     */
+    internal const val MAX_RUN_TOTAL_STACKTRACE_CHARS = 100_000
+
     fun collect(
         project: Project,
         testResultFilter: String,
@@ -57,36 +65,49 @@ object TestResultsCollector {
         )
     }
 
-    fun collectRunEntries(root: SMTestProxy.SMRootTestProxy): List<TestRunEntry> =
-        root.allTests
+    fun collectRunEntries(
+        root: SMTestProxy.SMRootTestProxy,
+        totalStackTraceBudget: Int = MAX_RUN_TOTAL_STACKTRACE_CHARS
+    ): List<TestRunEntry> {
+        var traceBudget = totalStackTraceBudget
+        return root.allTests
             .filter { it !== root && it.isLeaf && !it.isSuite && !it.isConfig }
             .mapNotNull { test ->
                 // TODO: Use `test.magnitudeInfo` once API is stable
-                magnitudeIndexToStatus(test.magnitude)?.let {
+                magnitudeIndexToStatus(test.magnitude)?.let { status ->
+                    // Budget check before the stacktrace read: once spent, the (possibly huge)
+                    // trace string is never materialized. Soft budget — the last attached trace
+                    // may overshoot by at most one per-test cap.
+                    val stackTrace = if (status.isFailure && traceBudget > 0) {
+                        test.stacktrace?.takeIf(String::isNotBlank)?.let(::truncateStackTrace)
+                            ?.also { traceBudget -= it.length }
+                    } else null
                     TestRunEntry(
                         name = composeName(test.name, test.parent?.name),
-                        status = it,
-                        errorMessage = if (it.isFailure) test.errorMessage else null,
-                        stackTrace = if (it.isFailure) {
-                            test.stacktrace?.takeIf(String::isNotBlank)?.let(::truncateStackTrace)
-                        } else null
+                        status = status,
+                        errorMessage = if (status.isFailure) test.errorMessage else null,
+                        stackTrace = stackTrace
                     )
                 }
             }
+    }
 
     /**
      * Head+tail truncation: for chained exceptions the root cause sits at the BOTTOM of the trace
      * (the issue #316 repro is 500 nested causes), so keeping only the head would drop exactly the
      * part that explains the failure. Two thirds head keeps the message and throw site, one third
-     * tail keeps the deepest causes.
+     * tail keeps the deepest causes. A cut point shifts by one char when it would split a
+     * surrogate pair, so the output never carries an unpaired surrogate.
      */
     internal fun truncateStackTrace(trace: String, maxLength: Int = MAX_RUN_ENTRY_STACKTRACE_LENGTH): String {
         if (trace.length <= maxLength) return trace
-        val head = maxLength * 2 / 3
-        val tail = maxLength - head
-        return trace.take(head) +
-                "\n... [${trace.length - head - tail} chars truncated] ...\n" +
-                trace.takeLast(tail)
+        var head = maxLength * 2 / 3
+        var tailStart = trace.length - (maxLength - head)
+        if (trace[head - 1].isHighSurrogate()) head--
+        if (trace[tailStart].isLowSurrogate()) tailStart++
+        return trace.substring(0, head) +
+                "\n... [${tailStart - head} chars truncated] ...\n" +
+                trace.substring(tailStart)
     }
 
     /** Composes a test display name from the test name and its optional parent (suite) name. */
@@ -184,9 +205,7 @@ object TestResultsCollector {
             else -> "FAILED"
         }
 
-        val stacktrace = test.stacktrace?.let {
-            if (it.length > MAX_STACKTRACE_LENGTH) it.substring(0, MAX_STACKTRACE_LENGTH) + "..." else it
-        }
+        val stacktrace = test.stacktrace?.let { truncateStackTrace(it, MAX_STACKTRACE_LENGTH) }
 
         var file: String? = null
         var line: Int? = null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollector.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollector.kt
@@ -26,6 +26,12 @@ object TestResultsCollector {
 
     private const val MAX_STACKTRACE_LENGTH = 500
 
+    /**
+     * Per-test cap for ide_run_tests stack traces (issue #316). Generous enough that real traces
+     * pass through untouched; only pathological ones (deeply chained causes) are trimmed.
+     */
+    internal const val MAX_RUN_ENTRY_STACKTRACE_LENGTH = 10_000
+
     fun collect(
         project: Project,
         testResultFilter: String,
@@ -60,10 +66,28 @@ object TestResultsCollector {
                     TestRunEntry(
                         name = composeName(test.name, test.parent?.name),
                         status = it,
-                        errorMessage = if (it.isFailure) test.errorMessage else null
+                        errorMessage = if (it.isFailure) test.errorMessage else null,
+                        stackTrace = if (it.isFailure) {
+                            test.stacktrace?.takeIf(String::isNotBlank)?.let(::truncateStackTrace)
+                        } else null
                     )
                 }
             }
+
+    /**
+     * Head+tail truncation: for chained exceptions the root cause sits at the BOTTOM of the trace
+     * (the issue #316 repro is 500 nested causes), so keeping only the head would drop exactly the
+     * part that explains the failure. Two thirds head keeps the message and throw site, one third
+     * tail keeps the deepest causes.
+     */
+    internal fun truncateStackTrace(trace: String, maxLength: Int = MAX_RUN_ENTRY_STACKTRACE_LENGTH): String {
+        if (trace.length <= maxLength) return trace
+        val head = maxLength * 2 / 3
+        val tail = maxLength - head
+        return trace.take(head) +
+                "\n... [${trace.length - head - tail} chars truncated] ...\n" +
+                trace.takeLast(tail)
+    }
 
     /** Composes a test display name from the test name and its optional parent (suite) name. */
     internal fun composeName(testName: String, parentName: String?): String {

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -579,7 +579,7 @@ Each call blocks at most `waitSeconds` (default 45) so the MCP client's own requ
 
 *Exactly one of `target` / `runId` is required.
 
-**Returns**: `{ success, timedOut, noTestsFound, exitCode, passed, failed, errors, total, tests: [{name, status, errorMessage?, stackTrace?}] }`, or while still executing: `{ status: "running", runId, configName, elapsedSeconds, timeoutSeconds, message }`. `stackTrace` is set for failed/errored tests; very long traces are trimmed in the middle, keeping the throw site and the root cause.
+**Returns**: `{ success, timedOut, noTestsFound, exitCode, passed, failed, errors, total, tests: [{name, status, errorMessage?, stackTrace?}] }`, or while still executing: `{ status: "running", runId, configName, elapsedSeconds, timeoutSeconds, message }`. `stackTrace` is set for failed/errored tests; very long traces are trimmed in the middle, keeping the throw site and the root cause. On mass failures a per-run size budget applies: earlier failures keep their traces, later entries carry `errorMessage` only.
 
 ### ide_reload_project (disabled by default)
 Force-reload the project build model (Maven, Gradle, or both). Use after changing build files so IntelliJ resolves updated dependencies before diagnostics or builds. The reload is asynchronous.

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -579,7 +579,7 @@ Each call blocks at most `waitSeconds` (default 45) so the MCP client's own requ
 
 *Exactly one of `target` / `runId` is required.
 
-**Returns**: `{ success, timedOut, noTestsFound, exitCode, passed, failed, errors, total, tests: [{name, status, errorMessage?}] }`, or while still executing: `{ status: "running", runId, configName, elapsedSeconds, timeoutSeconds, message }`
+**Returns**: `{ success, timedOut, noTestsFound, exitCode, passed, failed, errors, total, tests: [{name, status, errorMessage?, stackTrace?}] }`, or while still executing: `{ status: "running", runId, configName, elapsedSeconds, timeoutSeconds, message }`. `stackTrace` is set for failed/errored tests; very long traces are trimmed in the middle, keeping the throw site and the root cause.
 
 ### ide_reload_project (disabled by default)
 Force-reload the project build model (Maven, Gradle, or both). Use after changing build files so IntelliJ resolves updated dependencies before diagnostics or builds. The reload is asynchronous.

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ResultShapeContractUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ResultShapeContractUnitTest.kt
@@ -865,7 +865,9 @@ class ResultShapeContractUnitTest : TestCase() {
                 TestRunEntry(
                     name = "com.example.ServiceTest.testHandle",
                     status = TestStatus.FAILED,
-                    errorMessage = "expected:<1> but was:<2>"
+                    errorMessage = "expected:<1> but was:<2>",
+                    stackTrace = "java.lang.AssertionError: expected:<1> but was:<2>\n" +
+                            "\tat com.example.ServiceTest.testHandle(ServiceTest.java:21)"
                 )
             ),
             struct(

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorRunEntriesTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorRunEntriesTest.kt
@@ -1,0 +1,90 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.util
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TestStatus
+import com.intellij.execution.testframework.sm.runner.SMTestProxy
+
+/**
+ * Pins the ide_run_tests per-test output produced by [TestResultsCollector.collectRunEntries]
+ * from a real SMTestProxy tree — in particular that failed/errored tests carry the stack trace
+ * reported by the test framework (issue #316), and passed tests do not.
+ */
+class TestResultsCollectorRunEntriesTest : McpPlatformTestCase() {
+
+    private val stackTrace = """
+        java.lang.RuntimeException: depth 500
+        ${'\t'}at com.example.FooTest.recurse(FooTest.java:44)
+        ${'\t'}at com.example.FooTest.longStackTraceTest(FooTest.java:34)
+        Caused by: java.lang.RuntimeException: depth 0
+    """.trimIndent()
+
+    private fun buildRoot(configure: (SMTestProxy) -> Unit): SMTestProxy.SMRootTestProxy {
+        val root = SMTestProxy.SMRootTestProxy()
+        root.setStarted()
+        val suite = SMTestProxy("FooTest", true, null)
+        root.addChild(suite)
+        suite.setStarted()
+        val test = SMTestProxy("testX", false, null)
+        suite.addChild(test)
+        test.setStarted()
+        configure(test)
+        suite.setFinished()
+        root.setFinished()
+        return root
+    }
+
+    fun testFailedTestCarriesErrorMessageAndStackTrace() {
+        val root = buildRoot { it.setTestFailed("depth 500", stackTrace, false) }
+
+        val entries = TestResultsCollector.collectRunEntries(root)
+
+        assertEquals(1, entries.size)
+        val entry = entries.single()
+        assertEquals("FooTest.testX", entry.name)
+        assertEquals(TestStatus.FAILED, entry.status)
+        assertEquals("depth 500", entry.errorMessage)
+        assertEquals(stackTrace, entry.stackTrace)
+    }
+
+    fun testErroredTestCarriesStackTrace() {
+        val root = buildRoot { it.setTestFailed("depth 500", stackTrace, true) }
+
+        val entry = TestResultsCollector.collectRunEntries(root).single()
+        assertEquals(TestStatus.ERROR, entry.status)
+        assertEquals(stackTrace, entry.stackTrace)
+    }
+
+    fun testPassedTestHasNoStackTrace() {
+        val root = buildRoot { it.setFinished() }
+
+        val entry = TestResultsCollector.collectRunEntries(root).single()
+        assertEquals(TestStatus.PASSED, entry.status)
+        assertNull(entry.errorMessage)
+        assertNull(entry.stackTrace)
+    }
+
+    fun testBlankStackTraceBecomesNull() {
+        val root = buildRoot { it.setTestFailed("boom", "   \n", false) }
+
+        val entry = TestResultsCollector.collectRunEntries(root).single()
+        assertEquals(TestStatus.FAILED, entry.status)
+        assertNull("blank traces must not produce a whitespace-only field", entry.stackTrace)
+    }
+
+    fun testOversizedStackTraceIsTruncatedKeepingHeadAndTail() {
+        val monster = "java.lang.RuntimeException: depth 500\n" +
+                "\tat com.example.FooTest.recurse(FooTest.java:44)\n".repeat(5_000) +
+                "Caused by: java.lang.RuntimeException: depth 0"
+        val root = buildRoot { it.setTestFailed("depth 500", monster, false) }
+
+        val entry = TestResultsCollector.collectRunEntries(root).single()
+        val trace = entry.stackTrace!!
+        assertTrue(
+            "trace must be capped near MAX_RUN_ENTRY_STACKTRACE_LENGTH, was ${trace.length}",
+            trace.length < TestResultsCollector.MAX_RUN_ENTRY_STACKTRACE_LENGTH + 100
+        )
+        assertTrue("must keep the head", trace.startsWith("java.lang.RuntimeException: depth 500"))
+        assertTrue("must keep the tail (root cause)", trace.endsWith("Caused by: java.lang.RuntimeException: depth 0"))
+        assertTrue("must mark the elision", trace.contains("chars truncated"))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorRunEntriesTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorRunEntriesTest.kt
@@ -87,4 +87,51 @@ class TestResultsCollectorRunEntriesTest : McpPlatformTestCase() {
         assertTrue("must keep the tail (root cause)", trace.endsWith("Caused by: java.lang.RuntimeException: depth 0"))
         assertTrue("must mark the elision", trace.contains("chars truncated"))
     }
+
+    fun testAggregateBudgetDropsTracesOnceSpent() {
+        val root = SMTestProxy.SMRootTestProxy()
+        root.setStarted()
+        val suite = SMTestProxy("FooTest", true, null)
+        root.addChild(suite)
+        suite.setStarted()
+        repeat(3) { i ->
+            val test = SMTestProxy("test$i", false, null)
+            suite.addChild(test)
+            test.setStarted()
+            test.setTestFailed("boom $i", stackTrace, false)
+        }
+        suite.setFinished()
+        root.setFinished()
+
+        // Budget fits exactly one trace: the first failure keeps it, the rest fall back to
+        // errorMessage only — a mass failure must not produce an unbounded response.
+        val entries = TestResultsCollector.collectRunEntries(root, totalStackTraceBudget = stackTrace.length)
+
+        assertEquals(3, entries.size)
+        assertEquals(stackTrace, entries[0].stackTrace)
+        assertNull("budget spent — trace must be dropped", entries[1].stackTrace)
+        assertNull("budget spent — trace must be dropped", entries[2].stackTrace)
+        assertEquals("errorMessage survives the budget cut", "boom 1", entries[1].errorMessage)
+    }
+
+    fun testDiagnosticsPathTruncationKeepsRootCause() {
+        // ide_diagnostics shares the same truncation helper: its 500-char cap must also keep
+        // the root cause at the bottom of a chained trace, not just the head.
+        val monster = "java.lang.RuntimeException: depth 500\n" +
+                "\tat com.example.FooTest.recurse(FooTest.java:44)\n".repeat(50) +
+                "Caused by: java.lang.RuntimeException: depth 0"
+        val proxy = SMTestProxy("testX", false, null)
+        proxy.setStarted()
+        proxy.setTestFailed("depth 500", monster, false)
+
+        val info = TestResultsCollector.toTestResultInfo(proxy, project)
+
+        val trace = info.stacktrace!!
+        assertTrue("must keep the head", trace.startsWith("java.lang.RuntimeException: depth 500"))
+        assertTrue(
+            "diagnostics traces must keep the root cause",
+            trace.endsWith("Caused by: java.lang.RuntimeException: depth 0")
+        )
+        assertTrue("must mark the elision", trace.contains("chars truncated"))
+    }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorUnitTest.kt
@@ -110,4 +110,13 @@ class TestResultsCollectorUnitTest : TestCase() {
             }
         }
     }
+
+    fun testDegenerateCapDoesNotCrash() {
+        // The helper is shared by two call sites with different caps and formats *error* output:
+        // a crash here would replace a real test failure with an internal error.
+        for (cap in listOf(0, 1, 2, 3)) {
+            val out = TestResultsCollector.truncateStackTrace("abcdefghij", maxLength = cap)
+            assertTrue("cap=$cap must still mark the elision", out.contains("chars truncated"))
+        }
+    }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorUnitTest.kt
@@ -86,4 +86,28 @@ class TestResultsCollectorUnitTest : TestCase() {
         // 300 cap + the elision marker line — far below the original ~90KB
         assertTrue("must actually shrink the trace", truncated.length < 400)
     }
+
+    fun testTruncationNeverSplitsSurrogatePairs() {
+        // "😀" is a surrogate pair (2 chars). maxLength=101 puts the head cut mid-pair,
+        // maxLength=103 puts the tail cut mid-pair — both must shift instead of splitting.
+        val trace = "😀".repeat(400)
+        for (maxLength in listOf(101, 103)) {
+            val truncated = TestResultsCollector.truncateStackTrace(trace, maxLength = maxLength)
+            for (i in truncated.indices) {
+                val c = truncated[i]
+                if (c.isHighSurrogate()) {
+                    assertTrue(
+                        "unpaired high surrogate at $i (maxLength=$maxLength)",
+                        i + 1 < truncated.length && truncated[i + 1].isLowSurrogate()
+                    )
+                }
+                if (c.isLowSurrogate()) {
+                    assertTrue(
+                        "unpaired low surrogate at $i (maxLength=$maxLength)",
+                        i > 0 && truncated[i - 1].isHighSurrogate()
+                    )
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/TestResultsCollectorUnitTest.kt
@@ -58,4 +58,32 @@ class TestResultsCollectorUnitTest : TestCase() {
         // so value 1 is unambiguously PASSED at this layer.
         assertEquals(TestStatus.PASSED, TestResultsCollector.magnitudeIndexToStatus(1))
     }
+
+    // ── truncateStackTrace (issue #316) ───────────────────────────────────────
+
+    fun testShortStackTracePassesThroughUntouched() {
+        val trace = "java.lang.RuntimeException: boom\n\tat com.example.FooTest.test(FooTest.java:12)"
+        assertEquals(trace, TestResultsCollector.truncateStackTrace(trace))
+    }
+
+    fun testStackTraceAtExactCapPassesThroughUntouched() {
+        val trace = "x".repeat(100)
+        assertEquals(trace, TestResultsCollector.truncateStackTrace(trace, maxLength = 100))
+    }
+
+    fun testLongStackTraceKeepsHeadAndTail() {
+        // Chained exceptions put the root cause at the END of the trace — truncation must keep
+        // both the top (message + throw site) and the bottom (deepest causes).
+        val head = "java.lang.RuntimeException: depth 500\n"
+        val tail = "Caused by: java.lang.RuntimeException: depth 0\n"
+        val trace = head + "\tat com.example.FooTest.recurse(FooTest.java:44)\n".repeat(2000) + tail
+
+        val truncated = TestResultsCollector.truncateStackTrace(trace, maxLength = 300)
+
+        assertTrue("must keep the trace head", truncated.startsWith(head))
+        assertTrue("must keep the trace tail (root cause)", truncated.endsWith(tail))
+        assertTrue("must mark the elision", truncated.contains("chars truncated"))
+        // 300 cap + the elision marker line — far below the original ~90KB
+        assertTrue("must actually shrink the trace", truncated.length < 400)
+    }
 }

--- a/src/test/resources/contract/result-shapes.txt
+++ b/src/test/resources/contract/result-shapes.txt
@@ -473,6 +473,7 @@
 ## TestRunEntry
   errorMessage: string? (optional)
   name: string
+  stackTrace: string? (optional)
   status: string
 
 ## TestStatus (enum)

--- a/src/test/resources/contract/tool-manifest.json
+++ b/src/test/resources/contract/tool-manifest.json
@@ -2200,7 +2200,8 @@ description:
   
   Returns: success status, exit code, pass/fail/error counts, and per-test results. Failed or
   errored tests include errorMessage and stackTrace (very long traces are trimmed in the
-  middle, keeping the throw site and the root cause).
+  middle, keeping the throw site and the root cause). On mass failures a per-run size budget
+  applies: earlier failures keep their traces, later entries carry errorMessage only.
   Results are read directly from the IDE's test runner, so they reflect this run (not stale report
   files) and work with any Service-Message-based framework (JUnit, TestNG, pytest, Jest, Go test, PHPUnit).
   

--- a/src/test/resources/contract/tool-manifest.json
+++ b/src/test/resources/contract/tool-manifest.json
@@ -2198,7 +2198,9 @@ description:
   bounded by timeoutSeconds: once it expires the process is killed and the next poll reports
   timedOut: true.
   
-  Returns: success status, exit code, pass/fail/error counts, and per-test results.
+  Returns: success status, exit code, pass/fail/error counts, and per-test results. Failed or
+  errored tests include errorMessage and stackTrace (very long traces are trimmed in the
+  middle, keeping the throw site and the root cause).
   Results are read directly from the IDE's test runner, so they reflect this run (not stale report
   files) and work with any Service-Message-based framework (JUnit, TestNG, pytest, Jest, Go test, PHPUnit).
   


### PR DESCRIPTION
Closes #316

## What

`ide_run_tests` per-test entries for failed/errored tests now include a `stackTrace` field with the trace reported by the test framework, alongside the existing `errorMessage` (which only holds the exception message, e.g. `java.lang.RuntimeException: depth 500` with no location information).

```json
{"name": "FooTest.testX", "status": "failed",
 "errorMessage": "java.lang.RuntimeException: depth 500",
 "stackTrace": "java.lang.RuntimeException: depth 500\n\tat com.example.FooTest.recurse(FooTest.java:44)\n..."}
```

Also bumps `pluginVersion` to **5.6.0** (new feature → minor bump).

## How

- `TestRunEntry` gains `stackTrace: String? = null` (additive — omitted for passed/skipped tests, so existing clients are unaffected).
- `TestResultsCollector.collectRunEntries` fills it from `SMTestProxy.getStacktrace()` for failure statuses, the same source the `ide_diagnostics` test-results path already uses.
- **Truncation keeps head and tail**: very long traces are trimmed in the middle (10k char per-test cap, 2/3 head + 1/3 tail with an explicit elision marker). The issue's repro — 500 nested causes — produces a ~75KB trace whose root cause (`Caused by: ... depth 0`) sits at the *bottom*, so head-only truncation would drop exactly the part that explains the failure. Real-world traces pass through untouched.

## Hardening from self-review

- **Per-run aggregate budget (100k chars)**: a mass failure (hundreds of failed tests × 10KB traces) must not become a multi-MB response that MCP clients truncate mid-JSON. Earlier failures keep their traces; once the budget is spent, later entries fall back to `errorMessage` only and the trace string is not even read from the proxy.
- **`ide_diagnostics` unified**: its test-result traces now use the same middle-trimming helper (same 500-char cap) instead of head-only truncation, so chained exceptions keep their root cause on that path too.
- **Surrogate-safe cuts**: truncation cut points shift by one char when they would split a UTF-16 surrogate pair (emoji in JS test names, etc.), so responses never carry an unpaired surrogate.

Design notes: the wire key is `stackTrace` (camelCase, as requested in #316 and matching `errorMessage`/`durationMs` on the same entry); the pre-existing `TestResultInfo.stacktrace` spelling on the `ide_diagnostics` side is frozen contract and left as is. Passed entries serialize `"stackTrace": null` for consistency with the existing `"errorMessage": null` wire behavior (`encodeDefaults = true`). `errorMessage` itself remains uncapped (pre-existing behavior, deliberately untouched).

## Checklist

- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Contract goldens regenerated and diffs reviewed: `result-shapes.txt` gains `stackTrace: string? (optional)` on `TestRunEntry`; `tool-manifest.json` tracks the tool description
- [x] Docs updated: `references/tools-reference.md` result shape + `USAGE.md` section and example
- [x] Tests: platform tests drive `collectRunEntries`/`toTestResultInfo` over real `SMTestProxy` trees (failure carries trace, pass does not, blank → null, oversized → head+tail kept, budget exhaustion, diagnostics root cause); unit tests pin truncation incl. surrogate-pair safety
- [x] `./gradlew test` green (full suite, both tiers) and `./scripts/check-pr.sh` passes (16/16)
- [x] `pluginVersion` bumped to 5.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)