### PR TITLE
chore: bump pluginVersion to 5.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - **New `ide_link_build_system` tool** ([#319](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/319)) — links an unlinked Maven or Gradle project using the platform's `ExternalSystemUnlinkedProjectAware` EP, the same code path the IDE's own "Load Maven/Gradle Project" notification uses. Detects the build system automatically from build files. Use when `ide_reload_project` reports "build file found but project is not linked". *(disabled by default)*
 - **`ide_open_project` gains an optional `autoLink` parameter** ([#319](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/319)) — when `true`, automatically links an unlinked Maven/Gradle build system after opening. Default: `false`. `ide_reload_project`'s "not linked" message now points at `ide_link_build_system` instead of telling agents to click IDE UI they can't reach.
 
+### Fixed
+
+- **Kotlin property FQNs no longer resolve to the light backing field.** `ide_find_references` (and every other tool taking a `language`+`symbol` argument) resolved `com.example.Subject#probeName` to the private light field Kotlin generates for a property, on which `ReferencesSearch` finds nothing - so the call returned `0 usages` with `totalIsExact: true`. Non-Java fields now resolve to their navigation element (the `KtProperty`), which returns the real usages.
+
 ## [5.6.0] - 2026-08-16
 
 ### Added
@@ -26,7 +30,6 @@
 
 ### Fixed
 
-- **Kotlin property FQNs no longer resolve to the light backing field.** `ide_find_references` (and every other tool taking a `language`+`symbol` argument) resolved `com.example.Subject#probeName` to the private light field Kotlin generates for a property, on which `ReferencesSearch` finds nothing - so the call returned `0 usages` with `totalIsExact: true`. Non-Java fields now resolve to their navigation element (the `KtProperty`), which returns the real usages.
 - **Lifecycle manager no longer accumulates ghost entries for deleted project directories.** Temporary projects (worktrees, slots, ephemeral checkouts) that were opened and later deleted from disk remained in the managed projects registry forever. On startup, `loadState` now prunes any managed path whose directory no longer exists, preventing unbounded growth of the persisted state.
 
 ## [5.5.0] - 2026-08-09

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.6.0
+pluginVersion = 5.7.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Release bump for the changes on `main` since [5.6.0](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/releases/tag/5.6.0).

## Why 5.7.0 (minor)

| Commit | Change | Bump |
|---|---|---|
| [#320](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/320) | new `ide_link_build_system` tool + `autoLink` on `ide_open_project` | minor |
| [#323](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/323) | Kotlin property FQNs resolve to the declaration, not the light backing field | patch |
| [#321](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/321) | docs: recommended IDE settings | — |

A new tool is a feature, so minor. No breaking changes: `autoLink` defaults to `false`, `ide_link_build_system` is disabled by default, and the #323 fix leaves Java resolution untouched.

## Changelog correction

The #323 entry had landed inside the already-released `## [5.5.1]` section — the branch predated the CI changelog PR that created that section, so the rebase folded it in there. 5.5.1 shipped on 2026-08-12, well before the fix, so the entry moves to `[Unreleased]` under `### Fixed` where it belongs.

Otherwise `[Unreleased]` is left as-is for the CI changelog job to move into a `## [5.7.0]` section after publish, following the usual flow.

## Docs

No doc changes needed — #320 already registered `ide_link_build_system` in all six required locations (`README.md`, `USAGE.md`, `CLAUDE.md`, `SKILL.md`, `references/tools-reference.md`, `ToolNames.ALL`), verified.

`./scripts/check-pr.sh` 16/16, full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)