### PR TITLE
chore: bump pluginVersion to 5.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.7.0
+pluginVersion = 5.8.0
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
Minor bump for the two features merged since 5.7.0. Both are additive:

| Change | Issue | Notes |
| --- | --- | --- |
| New `ide_symbol_info` tool | [#327](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/327) | Resolved signature + documentation at a position. Disabled by default. |
| `paths` scoping on `ide_search_text`, `ide_find_references`, `ide_structural_search_replace` | [#328](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/328) | Optional parameter; omitting it keeps existing behaviour exactly. |

No breaking changes, hence minor rather than major.

## What's in the diff

One line — `pluginVersion` in `gradle.properties`.

Per [CONTRIBUTING.md](CONTRIBUTING.md) the changelog entries stay under `[Unreleased]`; the release pipeline moves them under the new version and opens the `Changelog update - 5.8.0` PR. No `## [5.8.0]` section is added here.

## Docs

Checked, nothing needed. Both features were already documented in all six required locations (`README.md`, `USAGE.md`, `CLAUDE.md`, `SKILL.md`, `tools-reference.md`, `ToolNames.ALL`) by their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)