### PR TITLE
fix: make safe-delete file mode actually enumerate the file's declarations (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ide_refactor_safe_delete` in `target_type: "file"` mode no longer deletes files whose declarations it never enumerated** ([#336](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/336)) — file mode looks for external usages in three layers, and for an ordinary source file only the third one fires: search every top-level declaration in the file. That enumeration walked `psiFile.children` and stopped there, so any language that nests its top-level declarations one node below the file produced *zero* declarations to search — the scan found nothing, `externalUsages` stayed empty, and the tool deleted a still-referenced file while reporting success. Scala hits this whenever the file has a `package` clause (every definition then lives inside an `ScPackaging` node), and so do `export const X = …` in JS/TS (the name is on the `JSVariable` inside a `JSVarStatement`), `type Foo struct{}` in Go, and Python module-level constants. The walk now descends through unnamed wrapper nodes — stopping at the first named element on each path, so it never walks into a class or function body — and unions in `PsiClassOwner.getClasses()`, the language's own authoritative answer for Java, Kotlin, Scala and Groovy. Symbol mode was never affected.
+- **A missing `Document` no longer empties that same usage scan.** Line and column are display-only, but the collection read the document *first* and returned an empty symbol list when there was none, producing a complete-looking "no usages" result — exactly what the tool's `UsageSearchException` handling exists to prevent ("an incomplete search must never be reported as 'no usages'"). Positions now degrade to `0` instead of the symbol list degrading to empty.
+- **A file delete that had nothing to check now says so.** Deleting a file with no top-level declarations previously reported `contained 0 symbol(s) with no external usages`, which reads like a completed safety check. It now reports that no top-level declarations were found and only direct references to the file itself were checked.
+
 ## [5.8.1] - 2026-08-22
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.8.1
+pluginVersion = 5.8.2
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -7,12 +7,14 @@ import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiClassOwner
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -40,6 +42,16 @@ import org.jetbrains.annotations.TestOnly
  * 2. **EDT Phase**: Apply deletion quickly (in write action)
  */
 class SafeDeleteTool : AbstractRefactoringTool() {
+
+    private companion object {
+        /**
+         * How far below the file [collectDeclarationsInto] may descend through *unnamed* wrapper
+         * nodes before giving up. Three is what the deepest known wrapper chain needs
+         * (`ES6ExportDeclaration` > `JSVarStatement` > `JSVariable`), and keeping it small is
+         * what stops the walk from wandering into statement bodies in script-style files.
+         */
+        const val MAX_WRAPPER_DEPTH = 3
+    }
 
     /**
      * Test hook invoked between the usage check (phase 1) and the deletion write action
@@ -390,10 +402,15 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                     success = true,
                     affectedFiles = listOf(preparation.filePath),
                     changesCount = 1,
-                    message = if (force && preparation.externalUsages.isNotEmpty()) {
-                        "Force-deleted file '${preparation.fileName}' (had ${preparation.externalUsages.size} external usage(s) that may now be broken)"
-                    } else {
-                        "Successfully deleted file '${preparation.fileName}' (contained ${preparation.symbols.size} symbol(s) with no external usages)"
+                    message = when {
+                        force && preparation.externalUsages.isNotEmpty() ->
+                            "Force-deleted file '${preparation.fileName}' (had ${preparation.externalUsages.size} external usage(s) that may now be broken)"
+                        // No declarations to scan means layer 3 never ran. Saying "0 symbol(s)
+                        // with no external usages" reads like a completed check; it is not one.
+                        preparation.symbols.isEmpty() ->
+                            "Successfully deleted file '${preparation.fileName}' (no top-level declarations found in it — only direct references to the file itself were checked)"
+                        else ->
+                            "Successfully deleted file '${preparation.fileName}' (contained ${preparation.symbols.size} symbol(s) with no external usages)"
                     }
                 )
             )
@@ -555,8 +572,10 @@ class SafeDeleteTool : AbstractRefactoringTool() {
      *    `RenamePsiElementProcessor.prepareRenaming()` to detect this substitution, then
      *    search for usages of the resource element. This catches `@xml/`, `@drawable/`, etc.
      *    references in XML files.
-     * 3. **Top-level symbol references** — Checks top-level declarations (classes, functions)
-     *    for external usages. Internal call chains don't block deletion.
+     * 3. **Top-level symbol references** — Checks the file's top-level declarations (see
+     *    [collectTopLevelDeclarations]) for external usages. Internal call chains don't block
+     *    deletion. This is the only layer that fires for an ordinary source file, so an
+     *    enumeration that comes back empty leaves the file effectively unchecked.
      */
     private fun prepareFileDelete(
         project: Project,
@@ -672,57 +691,99 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     }
 
     /**
-     * Collects only top-level declarations (classes, interfaces, top-level functions/properties).
-     * This is more efficient than collecting all named elements for file deletion checks.
+     * Collects the file's top-level declarations — the symbols whose *external* references are
+     * what make a file unsafe to delete.
+     *
+     * Two properties this deliberately has, both of them bug fixes (issue #336):
+     *
+     * 1. **The document does not gate the collection.** Line and column are display-only, but
+     *    reading the document *first* and bailing out on `null` made the entire layer-3 usage
+     *    scan collapse to a no-op — `prepareFileDelete` then reported a complete-looking empty
+     *    result and deleted the file. That is precisely the failure [UsageSearchException]
+     *    exists to prevent: an incomplete check must never be reported as "no usages". A missing
+     *    document now degrades the *positions* to 0, not the symbol list to empty.
+     *
+     * 2. **The walk does not stop at the file's direct children.** Several languages nest their
+     *    top-level declarations one or two nodes down, and a direct-children scan silently finds
+     *    nothing at all in those files:
+     *    - Scala wraps every definition in an `ScPackaging` node as soon as the file has a
+     *      `package` clause, so its classes are grandchildren of the file.
+     *    - `export const API_URL = "…"` in JS/TS names the `JSVariable` *inside* a
+     *      `JSVarStatement`.
+     *    - Go's `type Foo struct{}` names the `GoTypeSpec` inside a `GoTypeDeclaration`.
+     *    - Python module-level constants name the `PyTargetExpression` inside a
+     *      `PyAssignmentStatement`.
+     *
+     * The walk therefore descends through *unnamed* wrapper nodes, and stops at the first named
+     * element on each path so it never walks into a class or function body — the members inside
+     * a top-level declaration cannot outlive it, and searching each of them would turn one file
+     * delete into hundreds of index queries.
+     *
+     * [PsiClassOwner.getClasses] is unioned on top of the walk. For the class-owning languages
+     * (Java, Kotlin, Scala, Groovy) it is the language's own authoritative answer to "what does
+     * this file declare", and it unwraps package nesting whatever shape that language chose.
      */
     private fun collectTopLevelDeclarations(
         project: Project,
         psiFile: PsiFile
     ): List<Triple<PsiNamedElement, Int, Int>> {
-        val document = PsiDocumentManager.getInstance(project).getDocument(psiFile)
-            ?: return emptyList()
+        val declarations = mutableListOf<PsiNamedElement>()
+        val seenTargets = HashSet<PsiElement>()
 
-        val results = mutableListOf<Triple<PsiNamedElement, Int, Int>>()
-
-        // Only process direct children of the file (top-level declarations)
-        for (child in psiFile.children) {
-            if (child is PsiNamedElement && child.name != null) {
-                val line = document.getLineNumber(child.textOffset) + 1
-                val lineStart = document.getLineStartOffset(line - 1)
-                val column = child.textOffset - lineStart + 1
-                results.add(Triple(child, line, column))
+        val record: (PsiNamedElement) -> Unit = { element ->
+            if (element !is PsiFile && element.name != null) {
+                // A light class (Kotlin) and the source declaration it wraps share a navigation
+                // element, so this keeps the structural walk and getClasses() from both landing
+                // the same declaration and doubling the reported usage count.
+                if (seenTargets.add(element.navigationElement)) {
+                    declarations.add(element)
+                }
             }
         }
 
-        return results
+        collectDeclarationsInto(psiFile, MAX_WRAPPER_DEPTH, record)
+        (psiFile as? PsiClassOwner)?.classes?.forEach(record)
+
+        // Display-only, and legitimately absent for binary files — never a reason to drop symbols.
+        val document = PsiDocumentManager.getInstance(project).getDocument(psiFile)
+        return declarations.map { element ->
+            val (line, column) = positionOf(document, element.textOffset)
+            Triple(element, line, column)
+        }
     }
 
     /**
-     * Collects all named elements in a file with their line and column positions.
-     * Shared helper used by both findNearbySymbols and prepareFileDelete.
-     *
-     * @return List of triples: (element, line, column)
+     * Records every named child of [parent], descending through unnamed wrapper nodes until
+     * [depthBudget] is spent. Named elements terminate their branch: their members are deleted
+     * with them and cannot be broken independently.
      */
-    private fun collectNamedElementsWithPositions(
-        project: Project,
-        psiFile: PsiFile
-    ): List<Triple<PsiNamedElement, Int, Int>> {
-        val document = PsiDocumentManager.getInstance(project).getDocument(psiFile)
-            ?: return emptyList()
-
-        val results = mutableListOf<Triple<PsiNamedElement, Int, Int>>()
-
-        PsiTreeUtil.processElements(psiFile) { element ->
-            if (element is PsiNamedElement && element !is PsiFile && element.name != null) {
-                val line = document.getLineNumber(element.textOffset) + 1
-                val lineStart = document.getLineStartOffset(line - 1)
-                val column = element.textOffset - lineStart + 1
-                results.add(Triple(element, line, column))
+    private fun collectDeclarationsInto(
+        parent: PsiElement,
+        depthBudget: Int,
+        record: (PsiNamedElement) -> Unit
+    ) {
+        for (child in parent.children) {
+            ProgressManager.checkCanceled()
+            if (child is PsiWhiteSpace || child is PsiComment) continue
+            if (child is PsiNamedElement && child !is PsiFile && child.name != null) {
+                record(child)
+                continue
             }
-            true // continue processing
+            if (depthBudget > 0) {
+                collectDeclarationsInto(child, depthBudget - 1, record)
+            }
         }
+    }
 
-        return results
+    /**
+     * 1-based (line, column) for [offset], or `(0, 0)` when it cannot be resolved — no document
+     * for the file, or an offset no longer inside it. `(0, 0)` is the "position unknown"
+     * encoding this tool has always reported for usages in documentless files.
+     */
+    private fun positionOf(document: Document?, offset: Int): Pair<Int, Int> {
+        if (document == null || offset < 0 || offset > document.textLength) return 0 to 0
+        val line = document.getLineNumber(offset) + 1
+        return line to (offset - document.getLineStartOffset(line - 1) + 1)
     }
 
     /**
@@ -819,13 +880,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
 
                 if (refFile != null) {
                     val document = PsiDocumentManager.getInstance(project).getDocument(refElement.containingFile)
-                    val lineNumber = document?.getLineNumber(refElement.textOffset)?.plus(1) ?: 0
-                    val columnNumber = if (document != null && lineNumber > 0) {
-                        val lineStart = document.getLineStartOffset(lineNumber - 1)
-                        refElement.textOffset - lineStart + 1
-                    } else {
-                        0
-                    }
+                    val (lineNumber, columnNumber) = positionOf(document, refElement.textOffset)
 
                     usages.add(
                         UsageInfo(
@@ -853,7 +908,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         return cause?.message ?: cause?.javaClass?.simpleName ?: "unknown error"
     }
 
-    private fun getContextLine(document: com.intellij.openapi.editor.Document?, line: Int): String {
+    private fun getContextLine(document: Document?, line: Int): String {
         if (document == null || line < 1 || line > document.lineCount) return ""
         val lineIndex = line - 1
         val startOffset = document.getLineStartOffset(lineIndex)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
@@ -659,6 +659,19 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
     // layer 1 blocked the delete and layer 3 was never exercised. It now lives below as
     // `testModuleImportingTheFileByPathRefusesFileDelete`, labelled for the layer it covers.
     // Keep fixtures here free of module imports, or they stop testing this fix.
+    //
+    // What is deliberately NOT here is an end-to-end "nested declaration is used from another
+    // file, so the delete is refused" case. It cannot run in this harness: a cross-file search
+    // for a JS/TS *symbol* reaches the platform's polySymbols module, which dies with
+    //   NoSuchMethodError: kotlin.sequences.SequencesKt.sequenceOf(java.lang.Object)
+    //   at com.intellij.polySymbols.patterns.impl.SymbolReferencePattern.getStaticPrefixes
+    // — an older kotlin-stdlib on the test classpath than polySymbols was compiled against.
+    // The plugin ships no kotlin-stdlib of its own (kotlin.stdlib.default.dependency = false),
+    // so a real IDE supplies a matching one and this does not arise there. The existing Java
+    // fixtures cover "non-empty enumeration ⇒ layer 3 blocks the delete"; what the tests below
+    // add is the other half, that the enumeration is non-empty for a nested declaration.
+    // Note the failure mode if it ever did arise in production: findUsages wraps it in
+    // UsageSearchException and the tool refuses the delete. It fails closed.
 
     fun testTypeScriptModuleConstantIsCountedAsATopLevelDeclaration() = runBlocking {
         Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
@@ -690,55 +703,6 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
             payload.message
         )
         assertProjectFileAbsent("sd-tsdecl-src/settings.ts")
-    }
-
-    /**
-     * The end-to-end half: a nested declaration that something else uses must block the delete.
-     *
-     * The fixture is deliberately **global-script JS, not ES modules**. An earlier version of
-     * this test had `client.ts` do `import { API_URL } from "./config"`, and it passed against
-     * the pre-fix code — verified by running it with `SafeDeleteTool` reverted. An ES6 module
-     * specifier is a PSI reference to the *file*, so layer 1 (`ReferencesSearch` on the
-     * `PsiFile`) caught it and layer 3 never had to work. The test looked like coverage of this
-     * fix and was coverage of a layer that was never broken.
-     *
-     * Nothing here imports anything, so layer 1 has no file reference to find and layer 2 is
-     * Android-only: if the tool refuses this delete, layer 3 enumerated the declaration. The
-     * context assertion pins that further — the blocking usage is the line that *uses* the
-     * constant, not an import line.
-     */
-    fun testUsedGlobalScriptConstantRefusesFileDeleteThroughTheDeclarationScan() = runBlocking {
-        Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
-        registerSourceRoot("sd-jsglobal-src")
-        writeProjectFile(
-            "sd-jsglobal-src/timeouts.js", """
-            var API_TIMEOUT_MS = 5000;
-        """.trimIndent()
-        )
-        writeProjectFile(
-            "sd-jsglobal-src/consumer.js", """
-            function timeoutSeconds() {
-                return API_TIMEOUT_MS / 1000;
-            }
-        """.trimIndent()
-        )
-
-        assertNoDirectlyNamedChildren("sd-jsglobal-src/timeouts.js")
-
-        val result = SafeDeleteTool().execute(project, buildJsonObject {
-            put("file", "sd-jsglobal-src/timeouts.js")
-            put("target_type", "file")
-        })
-
-        assertToolSucceeded("A refusal is a structured answer, not a protocol error", result)
-        val payload = decodeFileBlocked(toolText(result))
-        assertFalse("canDelete must be false while API_TIMEOUT_MS is still used", payload.canDelete)
-        assertEquals("timeouts.js", payload.fileName)
-        assertEquals(1, payload.symbolCount)
-        val usage = payload.blockingUsages.first { it.file == "sd-jsglobal-src/consumer.js" }
-        assertEquals("return API_TIMEOUT_MS / 1000;", usage.context)
-        assertProjectFileExists("sd-jsglobal-src/timeouts.js")
-        assertFileContains("sd-jsglobal-src/timeouts.js", "API_TIMEOUT_MS")
     }
 
     /**

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
@@ -2,6 +2,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.IndexNotReadyException
@@ -10,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.junit.Assume
 
 /**
  * Behavior coverage for `ide_refactor_safe_delete`.
@@ -633,6 +635,107 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
 
         assertNotNull("Cancellation must propagate, not turn into a successful delete", thrown)
         assertFileContains("sd-pcefail-src/pcefail/PceFail.java", "unusedHelper")
+    }
+
+    // ── Issue #336: the file-mode usage scan must actually enumerate the file's declarations ──
+    //
+    // File mode looks for external usages in three layers, and layer 3 — "search every
+    // top-level declaration" — was the only one that fires for an ordinary source file.
+    // It walked `psiFile.children` and stopped there, so any language that nests its
+    // top-level declarations below the file node produced *zero* declarations to search:
+    // the scan found nothing, `externalUsages` stayed empty, and the tool deleted a file
+    // that the rest of the project still referenced while reporting success.
+    //
+    // TypeScript reproduces it exactly. `export const X = …` names the `JSVariable` inside a
+    // `JSVarStatement`, never the file's own child. Scala (the language in the report) has
+    // the same shape via `ScPackaging`, but its plugin is not on the test classpath.
+
+    fun testTypeScriptModuleConstantIsCountedAsATopLevelDeclaration() = runBlocking {
+        Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
+        registerSourceRoot("sd-tsdecl-src")
+        writeProjectFile(
+            "sd-tsdecl-src/settings.ts", """
+            export const API_URL = "https://example.test";
+        """.trimIndent()
+        )
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "sd-tsdecl-src/settings.ts")
+            put("target_type", "file")
+        })
+
+        assertToolSucceeded("Deleting an unreferenced module should succeed", result)
+        val payload = decodeRefactoring(toolText(result))
+        // The count is the assertion: at zero declarations the usage scan never ran, and the
+        // deletion below proves nothing about safety.
+        assertEquals(
+            "Successfully deleted file 'settings.ts' (contained 1 symbol(s) with no external usages)",
+            payload.message
+        )
+        assertProjectFileAbsent("sd-tsdecl-src/settings.ts")
+    }
+
+    fun testImportedTypeScriptModuleConstantRefusesFileDelete() = runBlocking {
+        Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
+        registerSourceRoot("sd-tsblocked-src")
+        writeProjectFile(
+            "sd-tsblocked-src/config.ts", """
+            export const API_URL = "https://example.test";
+        """.trimIndent()
+        )
+        writeProjectFile(
+            "sd-tsblocked-src/client.ts", """
+            import { API_URL } from "./config";
+
+            export function endpoint(): string {
+                return API_URL + "/v1";
+            }
+        """.trimIndent()
+        )
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "sd-tsblocked-src/config.ts")
+            put("target_type", "file")
+        })
+
+        assertToolSucceeded("A refusal is a structured answer, not a protocol error", result)
+        val payload = decodeFileBlocked(toolText(result))
+        assertFalse("canDelete must be false while API_URL is imported elsewhere", payload.canDelete)
+        assertEquals("config.ts", payload.fileName)
+        // How many PSI references one ES6 import binding produces is the JS plugin's business;
+        // that at least one of them is reported, and that it points at the importing file, is ours.
+        assertTrue("Expected at least one blocking usage, got ${payload.externalUsageCount}", payload.externalUsageCount >= 1)
+        assertTrue(
+            "Blocking usages must name the importing file. Got: ${payload.blockingUsages.map { it.file }}",
+            payload.blockingUsages.any { it.file == "sd-tsblocked-src/client.ts" }
+        )
+        assertProjectFileExists("sd-tsblocked-src/config.ts")
+        assertFileContains("sd-tsblocked-src/config.ts", "API_URL")
+    }
+
+    /**
+     * The other half of issue #336: when the scan finds nothing to search, saying so is the
+     * difference between "checked, and it is safe" and "there was nothing here to check".
+     * A plain-text file has no declarations in any language, so this is the honest wording —
+     * and it is the wording an agent needs in order to not read silence as a clean bill of health.
+     */
+    fun testDeletingAFileWithNoDeclarationsSaysTheScanFoundNothingToCheck() = runBlocking {
+        registerSourceRoot("sd-nodecl-src")
+        writeProjectFile("sd-nodecl-src/notes.txt", "just some prose, no declarations here\n")
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "sd-nodecl-src/notes.txt")
+            put("target_type", "file")
+        })
+
+        assertToolSucceeded("An unreferenced text file must still be deletable", result)
+        val payload = decodeRefactoring(toolText(result))
+        assertEquals(
+            "Successfully deleted file 'notes.txt' (no top-level declarations found in it — " +
+                "only direct references to the file itself were checked)",
+            payload.message
+        )
+        assertProjectFileAbsent("sd-nodecl-src/notes.txt")
     }
 
     /**

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
@@ -643,15 +643,22 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
     // ── Issue #336: the file-mode usage scan must actually enumerate the file's declarations ──
     //
     // File mode looks for external usages in three layers, and layer 3 — "search every
-    // top-level declaration" — was the only one that fires for an ordinary source file.
+    // top-level declaration" — is the only one that fires for an ordinary source file.
     // It walked `psiFile.children` and stopped there, so any language that nests its
     // top-level declarations below the file node produced *zero* declarations to search:
     // the scan found nothing, `externalUsages` stayed empty, and the tool deleted a file
     // that the rest of the project still referenced while reporting success.
     //
-    // TypeScript reproduces it exactly. `export const X = …` names the `JSVariable` inside a
-    // `JSVarStatement`, never the file's own child. Scala (the language in the report) has
-    // the same shape via `ScPackaging`, but its plugin is not on the test classpath.
+    // JS/TS reproduces it: `const X = …` names the `JSVariable` inside a `JSVarStatement`,
+    // never the file's own child. Scala (the language in the report) has the same shape via
+    // `ScPackaging`, but its plugin is not on the test classpath.
+    //
+    // Both tests below were confirmed to FAIL against the pre-fix `SafeDeleteTool` by reverting
+    // it and running them. That check is what caught a third test which did *not* fail: an
+    // ES-module fixture whose `import … from "./config"` is a reference to the file itself, so
+    // layer 1 blocked the delete and layer 3 was never exercised. It now lives below as
+    // `testModuleImportingTheFileByPathRefusesFileDelete`, labelled for the layer it covers.
+    // Keep fixtures here free of module imports, or they stop testing this fix.
 
     fun testTypeScriptModuleConstantIsCountedAsATopLevelDeclaration() = runBlocking {
         Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
@@ -685,7 +692,63 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
         assertProjectFileAbsent("sd-tsdecl-src/settings.ts")
     }
 
-    fun testImportedTypeScriptModuleConstantRefusesFileDelete() = runBlocking {
+    /**
+     * The end-to-end half: a nested declaration that something else uses must block the delete.
+     *
+     * The fixture is deliberately **global-script JS, not ES modules**. An earlier version of
+     * this test had `client.ts` do `import { API_URL } from "./config"`, and it passed against
+     * the pre-fix code — verified by running it with `SafeDeleteTool` reverted. An ES6 module
+     * specifier is a PSI reference to the *file*, so layer 1 (`ReferencesSearch` on the
+     * `PsiFile`) caught it and layer 3 never had to work. The test looked like coverage of this
+     * fix and was coverage of a layer that was never broken.
+     *
+     * Nothing here imports anything, so layer 1 has no file reference to find and layer 2 is
+     * Android-only: if the tool refuses this delete, layer 3 enumerated the declaration. The
+     * context assertion pins that further — the blocking usage is the line that *uses* the
+     * constant, not an import line.
+     */
+    fun testUsedGlobalScriptConstantRefusesFileDeleteThroughTheDeclarationScan() = runBlocking {
+        Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
+        registerSourceRoot("sd-jsglobal-src")
+        writeProjectFile(
+            "sd-jsglobal-src/timeouts.js", """
+            var API_TIMEOUT_MS = 5000;
+        """.trimIndent()
+        )
+        writeProjectFile(
+            "sd-jsglobal-src/consumer.js", """
+            function timeoutSeconds() {
+                return API_TIMEOUT_MS / 1000;
+            }
+        """.trimIndent()
+        )
+
+        assertNoDirectlyNamedChildren("sd-jsglobal-src/timeouts.js")
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "sd-jsglobal-src/timeouts.js")
+            put("target_type", "file")
+        })
+
+        assertToolSucceeded("A refusal is a structured answer, not a protocol error", result)
+        val payload = decodeFileBlocked(toolText(result))
+        assertFalse("canDelete must be false while API_TIMEOUT_MS is still used", payload.canDelete)
+        assertEquals("timeouts.js", payload.fileName)
+        assertEquals(1, payload.symbolCount)
+        val usage = payload.blockingUsages.first { it.file == "sd-jsglobal-src/consumer.js" }
+        assertEquals("return API_TIMEOUT_MS / 1000;", usage.context)
+        assertProjectFileExists("sd-jsglobal-src/timeouts.js")
+        assertFileContains("sd-jsglobal-src/timeouts.js", "API_TIMEOUT_MS")
+    }
+
+    /**
+     * Layer 1 coverage, kept for what it actually tests rather than what it looked like it
+     * tested: an ES6 module specifier (`from "./config"`) is a PSI reference to the *file*, so
+     * `ReferencesSearch` on the `PsiFile` blocks the delete without layer 3 contributing
+     * anything. Confirmed to pass against the pre-fix code, so it is **not** coverage of #336 —
+     * it is coverage of the file-reference layer, and it fails if that layer breaks.
+     */
+    fun testModuleImportingTheFileByPathRefusesFileDelete() = runBlocking {
         Assume.assumeTrue("JavaScript plugin required for this fixture", PluginDetectors.javaScript.isAvailable)
         registerSourceRoot("sd-tsblocked-src")
         writeProjectFile(
@@ -710,10 +773,8 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
 
         assertToolSucceeded("A refusal is a structured answer, not a protocol error", result)
         val payload = decodeFileBlocked(toolText(result))
-        assertFalse("canDelete must be false while API_URL is imported elsewhere", payload.canDelete)
+        assertFalse("canDelete must be false while another module imports the file", payload.canDelete)
         assertEquals("config.ts", payload.fileName)
-        // How many PSI references one ES6 import binding produces is the JS plugin's business;
-        // that at least one of them is reported, and that it points at the importing file, is ours.
         assertTrue("Expected at least one blocking usage, got ${payload.externalUsageCount}", payload.externalUsageCount >= 1)
         assertTrue(
             "Blocking usages must name the importing file. Got: ${payload.blockingUsages.map { it.file }}",

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
@@ -7,6 +7,9 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiNamedElement
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -659,6 +662,13 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
         """.trimIndent()
         )
 
+        // Precondition, and the whole reason this fixture stands in for the Scala report: the
+        // declaration is NOT a direct child of the file, so the old direct-children scan had
+        // nothing to search. Asserted rather than assumed — if a future JS PSI flattens this
+        // shape, the fixture silently stops reproducing #336, and that must fail loudly here
+        // rather than leave the assertion below passing for the wrong reason.
+        assertNoDirectlyNamedChildren("sd-tsdecl-src/settings.ts")
+
         val result = SafeDeleteTool().execute(project, buildJsonObject {
             put("file", "sd-tsdecl-src/settings.ts")
             put("target_type", "file")
@@ -736,6 +746,31 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
             payload.message
         )
         assertProjectFileAbsent("sd-nodecl-src/notes.txt")
+    }
+
+    /**
+     * Asserts that [relativePath] declares nothing at its own top level — every named element
+     * sits below a wrapper node. This is the PSI shape that broke `collectTopLevelDeclarations`
+     * in issue #336, and pinning it is what keeps the tests above honest reproductions of the
+     * bug rather than assertions that would have passed before the fix too.
+     */
+    private fun assertNoDirectlyNamedChildren(relativePath: String) {
+        val basePath = requireNotNull(project.basePath)
+        val virtualFile = requireNotNull(
+            LocalFileSystem.getInstance().refreshAndFindFileByPath("$basePath/$relativePath")
+        ) { "Missing test file $relativePath" }
+        val psiFile = requireNotNull(PsiManager.getInstance(project).findFile(virtualFile)) {
+            "No PSI for $relativePath — is the language plugin on the test classpath?"
+        }
+        val namedChildren = psiFile.children
+            .filter { it is PsiNamedElement && it !is PsiFile && it.name != null }
+            .map { "${it.javaClass.simpleName}(${(it as PsiNamedElement).name})" }
+        assertEquals(
+            "$relativePath must nest its declaration below the file node for this fixture to " +
+                "reproduce #336, but the file declares these directly",
+            emptyList<String>(),
+            namedChildren
+        )
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #336 — `ide_refactor_safe_delete` with `target_type: "file"` deleting a still-referenced file and reporting success.

### The reported root cause does not hold, but the bug is real

The report attributes it to `PsiDocumentManager.getDocument()` returning `null` for a file that is not open in an editor. It does not: `PsiDocumentManagerBase.getDocument()` falls through to `FileDocumentManager.getDocument()`, which loads the document from disk for any physical, event-system-enabled file. The suite already proves this — `testReferencedJavaFileIsRefusedAndTheReferencingFileIsReported` writes both fixtures straight to disk, never opens an editor, and asserts `symbolCount == 1`. Editor state is not the variable.

The variable is **the shape of the file's PSI**. `collectTopLevelDeclarations` walked `psiFile.children` and stopped there, so any language that nests its top-level declarations one node below the file yielded *zero* declarations. Layers 1 and 2 never fire for an ordinary source file (references resolve to the classes, not to the `PsiFile`; the resource probe is Android-only), so layer 3 — "search every top-level declaration" — is the whole check. With nothing to iterate, `externalUsages` stayed empty and the file was deleted.

Scala, the language in the report, hits this whenever the file has a `package` clause: every definition then lives inside an `ScPackaging` node, making the classes grandchildren of the file. It is not Scala-specific — the same shape breaks `const X = …` in JS/TS (the name is on the `JSVariable` inside a `JSVarStatement`), `type Foo struct{}` in Go (the name is on the `GoTypeSpec` inside a `GoTypeDeclaration`), and Python module-level constants.

The report's framing of the *severity* is exactly right, and is what this PR treats as the defect: a `document == null` bailout returning `emptyList()` is a **complete-looking but empty** result, which is precisely what the class's own `UsageSearchException` handling exists to prevent ("an incomplete search must never be reported as 'no usages'"). Symbol mode is unaffected, as reported.

### What changed

- **The walk descends through unnamed wrapper nodes** (bounded, `MAX_WRAPPER_DEPTH = 3` — what `ES6ExportDeclaration > JSVarStatement > JSVariable` needs), stopping at the first named element on each path. It therefore never walks into a class or function body: those members die with the declaration and cannot be broken independently, and searching each of them would turn one file delete into hundreds of index queries.
- **`PsiClassOwner.getClasses()` is unioned on top.** For Java/Kotlin/Scala/Groovy it is the language's own authoritative answer to "what does this file declare", and it unwraps package nesting whatever shape the language chose. Declarations are deduplicated by navigation element, so a Kotlin light class and the `KtClass` it wraps land once rather than doubling the reported usage count.
- **The document no longer gates the collection.** Line and column are display-only; a missing document now degrades the *positions* to `0` (the encoding this tool already used for usages in documentless files) instead of the symbol list to empty.
- **A delete that had nothing to check says so.** `contained 0 symbol(s) with no external usages` reads like a completed safety check; it is not one. That case now reports that no top-level declarations were found and only direct references to the file itself were checked.
- Removed `collectNamedElementsWithPositions` — dead since its callers were rewritten (its KDoc still claimed two), and carrying the identical `document == null → emptyList()` bailout. Folded the duplicated line/column arithmetic in `findUsages` into the shared `positionOf` helper, which also gained an out-of-bounds guard.

Java behaviour is deliberately unchanged: a `PsiJavaFile`'s classes are already direct children, and the new descent finds nothing named under `PsiPackageStatement` or `PsiImportList`, so `symbolCount` and every existing assertion stay as they were.

Also bumps `pluginVersion` to 5.8.2 (patch — bug fix). Changelog entries stay under `[Unreleased]` for the release pipeline to move.

### Tests, and how each one was verified

Rather than argue that these tests catch the bug, I ran them against the bug: a temporary commit reverted `SafeDeleteTool.kt` to its pre-fix state on `main` while keeping the tests, CI ran, and the results below are that run's. The commit was then removed from the branch. **That check earned its keep — it caught a test of mine that was vacuous.**

| Test | Pre-fix result | What it covers |
|---|---|---|
| `testTypeScriptModuleConstantIsCountedAsATopLevelDeclaration` | **FAILS** — `expected <contained [1] symbol(s)> but was <contained [0] symbol(s)>` | The fix itself: the enumeration is non-empty for a nested declaration |
| `testDeletingAFileWithNoDeclarationsSaysTheScanFoundNothingToCheck` | **FAILS** — old message text | The honest "nothing to check" wording |
| `testModuleImportingTheFileByPathRefusesFileDelete` | **PASSES** | Layer 1 — *not* this fix (see below) |

The first test is additionally guarded by `assertNoDirectlyNamedChildren`, which asserts the fixture's declaration really is nested below the file node. Without that, a future JS PSI that flattens the shape would leave the test passing while covering nothing.

**The vacuous test this caught.** That third row was originally written as end-to-end coverage of the fix, with `client.ts` doing `import { API_URL } from "./config"`. It passed against the pre-fix code, because an ES6 module specifier is a PSI reference to the *file* — layer 1 caught it and layer 3 never ran. It is kept (it does cover the file-reference layer and fails if that breaks) but renamed and documented for the layer it actually exercises.

**What is deliberately absent.** There is no end-to-end "nested declaration is used from another file, so the delete is refused" test. I wrote one using global-script JS to dodge the layer-1 shortcut, and it cannot run in this harness: a cross-file search for a JS/TS *symbol* reaches the platform's `polySymbols` module, which dies with `NoSuchMethodError: kotlin.sequences.SequencesKt.sequenceOf(java.lang.Object)` at `SymbolReferencePattern.getStaticPrefixes` — an older kotlin-stdlib on the test classpath than `polySymbols` was compiled against. The plugin ships no kotlin-stdlib of its own, so a real IDE supplies a matching one and this does not arise there. The stack trace and reasoning are recorded in the test file where the test would have been. Coverage of the fix therefore rests on two halves: the enumeration is non-empty for a nested declaration (proven above), plus the existing Java fixtures showing a non-empty enumeration makes layer 3 block the delete. Worth noting the failure mode if that `polySymbols` path ever did throw in production: `findUsages` wraps it in `UsageSearchException` and the tool refuses the delete — it fails closed.

### Verification

CI green: Build, Test (`./gradlew check`, full suite, `:test` executed rather than cached), Inspect code, Qodana (no new problems). The new tests are confirmed to have *executed* rather than been skipped by their `Assume` guards — Gradle here is configured with `testLogging { events("skipped", "failed") }` and no skip lines appear, and `PluginDetectorLeakUnitTest` asserts `PluginDetectors.javaScript.isAvailable` in the same passing run, which is the exact condition those guards test.

**What is not verified, stated plainly:**

- **Scala itself was never executed.** Its plugin is not on the test classpath, so the language in the original report is covered by argument (`ScalaFileImpl.getClasses()` exists precisely to unwrap packagings) plus the `PsiClassOwner` union as a second, independent path to the same answer — not by a test. What CI does establish is that the *class* of bug is real and reachable in a shipped language, not hypothetical. Putting Scala in `platformBundledPlugins` for tests would close this properly, but that is a bigger call than this fix and yours to make.
- **The document-decoupling change has no test.** It is correct by construction, but I believe it is close to unreachable in practice: the conditions that produce a null document (binary, oversized) also produce no declarations. It is included because it removes a fail-open shape, not because I reproduced it.
- The environment I worked in blocks `download.jetbrains.com` and `cache-redirector.jetbrains.com`, so the IntelliJ Platform artifact never resolved and `./gradlew test` could not run locally at any point. Every result above is CI's. `./scripts/check-pr.sh` passes all 15 static checks and fails only on that test step.

### Considered and rejected

A hard fail-closed refusal when the enumeration comes back empty. There is no dependency-free predicate that separates "this language file should have declarations" from "this file legitimately has none": `PsiNamedElement` is implemented by `XmlTag`, `JsonProperty` and `YAMLKeyValue`, so a deep-scan guard would refuse to delete every XML/JSON/YAML file, and a `PsiClassOwner`-scoped guard would refuse to delete `package-info.java`. Widening the enumeration plus an honest message is the version that fixes the bug without trading it for a worse one.

## Checklist

- [x] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections)
- [x] `./scripts/check-pr.sh` passes — all 15 static checks; its `./gradlew test` step could not run here (see Verification above)
- [x] `./gradlew test` passes — via CI's `./gradlew check`, full suite; not runnable locally in my environment
- [x] New tools (if any): none — no `ToolNames`/`ToolRegistry`/`McpSettings` or golden-manifest changes; the tool's name, description and input schema are untouched, as are all result models
- [x] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H5maPFbekKQS82abfzbqQ