### PR TITLE
ide_run_tests : use caller's timeoutSeconds as process-start deadline instead of hardcoded 15s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ide_run_tests` no longer aborts with a misleading "did not start within 15 seconds" error on slow Maven/Gradle projects** — the hardcoded 15s process-start guard is replaced by the remaining `waitSeconds` budget (~45–55s by default), so large projects that take longer than 15s to compile and launch the test JVM no longer fail spuriously. The error message now also tells the agent to retry or raise `waitSeconds`.
+
 ## [5.8.2] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- **`ide_run_tests` no longer aborts with a misleading "did not start within 15 seconds" error on slow Maven/Gradle projects** — the hardcoded 15s process-start guard is replaced by the remaining `waitSeconds` budget (~45–55s by default), so large projects that take longer than 15s to compile and launch the test JVM no longer fail spuriously. The error message now also tells the agent to retry or raise `waitSeconds`.
+- **`ide_run_tests` no longer aborts with a misleading "did not start within 15 seconds" error on slow projects** — the hardcoded 15s process-start guard is replaced by the remaining `waitSeconds` budget (~45–55s by default). The error message now also tells the agent to retry or raise `waitSeconds`.
 
 ## [5.8.2] - 2026-08-23
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -58,7 +58,6 @@ class RunTestsTool : AbstractMcpTool() {
     companion object {
         private val LOG = logger<RunTestsTool>()
         private const val DEFAULT_TIMEOUT_SECONDS = 120
-        private val PROCESS_START_TIMEOUT = 15.seconds
 
         /** Grace period to let the IDE's test tree finalize after the process exits. Normally instant. */
         private val TEST_TREE_FINALIZE_TIMEOUT = 10.seconds
@@ -310,7 +309,7 @@ class RunTestsTool : AbstractMcpTool() {
 
         val handler = try {
             edtAction { ExecutionManager.getInstance(project).restartRunProfile(env) }
-            withTimeoutOrNull(PROCESS_START_TIMEOUT) { processHandlerDeferred.await() }
+            withTimeoutOrNull(timeoutSeconds.seconds) { processHandlerDeferred.await() }
         } catch (e: ProcessCanceledException) {
             connection.disconnect()
             throw e
@@ -320,7 +319,7 @@ class RunTestsTool : AbstractMcpTool() {
         } ?: run {
             connection.disconnect()
             return createErrorResult(
-                "Test process did not start within ${PROCESS_START_TIMEOUT.inWholeSeconds} seconds for '$configName'."
+                "Test process did not start within $timeoutSeconds seconds for '$configName'."
             )
         }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -32,7 +32,6 @@ import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.util.messages.MessageBusConnection
@@ -100,6 +99,14 @@ class RunTestsTool : AbstractMcpTool() {
             val budgetLeftMs = waitSeconds * 1000L - (nowMs - callStartMs)
             return minOf(TEST_TREE_FINALIZE_TIMEOUT.inWholeMilliseconds, maxOf(MIN_FINALIZE_WAIT_MS, budgetLeftMs))
         }
+
+        /**
+         * How long to wait for the test process to actually start. Bounded by the remaining
+         * [waitSeconds] budget so the call never blocks past the MCP client's request timeout.
+         * Floor at 1ms to prevent a zero or negative timeout on an already-exhausted budget.
+         */
+        internal fun processStartTimeoutMs(waitSeconds: Int, callStartMs: Long, nowMs: Long): Long =
+            (waitSeconds * 1000L - (nowMs - callStartMs)).coerceAtLeast(1L)
 
         internal fun buildInProgressResult(
             runId: String,
@@ -307,9 +314,10 @@ class RunTestsTool : AbstractMcpTool() {
         val connection = project.messageBus.connect()
         connection.completeDeferredOnProcessStarted(env, processListener, processHandlerDeferred, configName)
 
+        val startTimeout = processStartTimeoutMs(waitSeconds, callStartMs, System.currentTimeMillis())
         val handler = try {
             edtAction { ExecutionManager.getInstance(project).restartRunProfile(env) }
-            withTimeoutOrNull(timeoutSeconds.seconds) { processHandlerDeferred.await() }
+            withTimeoutOrNull(startTimeout.milliseconds) { processHandlerDeferred.await() }
         } catch (e: ProcessCanceledException) {
             connection.disconnect()
             throw e
@@ -319,7 +327,8 @@ class RunTestsTool : AbstractMcpTool() {
         } ?: run {
             connection.disconnect()
             return createErrorResult(
-                "Test process did not start within $timeoutSeconds seconds for '$configName'."
+                "Test process did not start within ${startTimeout / 1000}s for '$configName' — " +
+                        "the IDE may still be compiling; retry, or raise waitSeconds (max $MAX_WAIT_SECONDS)."
             )
         }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -327,7 +327,7 @@ class RunTestsTool : AbstractMcpTool() {
         } ?: run {
             connection.disconnect()
             return createErrorResult(
-                "Test process did not start within ${startTimeout / 1000}s for '$configName' — " +
+                "Test process did not start within ${startTimeout / 1000} seconds for '$configName' — " +
                         "the IDE may still be compiling; retry, or raise waitSeconds (max $MAX_WAIT_SECONDS)."
             )
         }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -42,6 +42,7 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import java.util.UUID
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -105,8 +106,8 @@ class RunTestsTool : AbstractMcpTool() {
          * [waitSeconds] budget so the call never blocks past the MCP client's request timeout.
          * Floor at 1ms to prevent a zero or negative timeout on an already-exhausted budget.
          */
-        internal fun processStartTimeoutMs(waitSeconds: Int, callStartMs: Long, nowMs: Long): Long =
-            (waitSeconds * 1000L - (nowMs - callStartMs)).coerceAtLeast(1L)
+        internal fun processStartTimeout(waitSeconds: Int, callStartMs: Long, nowMs: Long): Duration =
+            (waitSeconds * 1000L - (nowMs - callStartMs)).coerceAtLeast(1L).milliseconds
 
         internal fun buildInProgressResult(
             runId: String,
@@ -314,10 +315,10 @@ class RunTestsTool : AbstractMcpTool() {
         val connection = project.messageBus.connect()
         connection.completeDeferredOnProcessStarted(env, processListener, processHandlerDeferred, configName)
 
-        val startTimeout = processStartTimeoutMs(waitSeconds, callStartMs, System.currentTimeMillis())
+        val startTimeout = processStartTimeout(waitSeconds, callStartMs, System.currentTimeMillis())
         val handler = try {
             edtAction { ExecutionManager.getInstance(project).restartRunProfile(env) }
-            withTimeoutOrNull(startTimeout.milliseconds) { processHandlerDeferred.await() }
+            withTimeoutOrNull(startTimeout) { processHandlerDeferred.await() }
         } catch (e: ProcessCanceledException) {
             connection.disconnect()
             throw e
@@ -327,7 +328,7 @@ class RunTestsTool : AbstractMcpTool() {
         } ?: run {
             connection.disconnect()
             return createErrorResult(
-                "Test process did not start within ${startTimeout / 1000} seconds for '$configName' — " +
+                "Test process did not start within ${startTimeout.inWholeSeconds}s for '$configName' — " +
                         "the IDE may still be compiling; retry, or raise waitSeconds (max $MAX_WAIT_SECONDS)."
             )
         }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsUnitTest.kt
@@ -153,6 +153,30 @@ class RunTestsUnitTest : TestCase() {
         assertEquals(3_000L, RunTestsTool.finalizeWaitMillis(0, callStartMs = 0, nowMs = 0))
     }
 
+    // ── processStartTimeoutMs ──────────────────────────────────────────────────
+
+    /**
+     * The process-start deadline must stay within the remaining waitSeconds budget so the call
+     * never blocks past the MCP client's request timeout (~60s). Previously a hardcoded 15s
+     * was used, which caused false "did not start" errors on slow Maven projects even when the
+     * caller passed a much larger timeoutSeconds.
+     */
+    fun testProcessStartTimeoutIsRemainingWaitBudget() {
+        // 45s budget, 2s elapsed: 43s remain
+        assertEquals(43_000L, RunTestsTool.processStartTimeoutMs(45, callStartMs = 0, nowMs = 2_000))
+    }
+
+    fun testProcessStartTimeoutShrinksAsCallProgresses() {
+        // 45s budget, 40s elapsed: only 5s left
+        assertEquals(5_000L, RunTestsTool.processStartTimeoutMs(45, callStartMs = 0, nowMs = 40_000))
+    }
+
+    fun testProcessStartTimeoutFlooredAtOneMs() {
+        // budget already exhausted — floor at 1ms rather than going negative or zero
+        assertEquals(1L, RunTestsTool.processStartTimeoutMs(45, callStartMs = 0, nowMs = 50_000))
+        assertEquals(1L, RunTestsTool.processStartTimeoutMs(0, callStartMs = 0, nowMs = 0))
+    }
+
     // ── needsPsiSync ───────────────────────────────────────────────────────────
 
     /**

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsUnitTest.kt
@@ -5,6 +5,8 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.TestResultsCollector
 import junit.framework.TestCase
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class RunTestsUnitTest : TestCase() {
 
@@ -163,18 +165,18 @@ class RunTestsUnitTest : TestCase() {
      */
     fun testProcessStartTimeoutIsRemainingWaitBudget() {
         // 45s budget, 2s elapsed: 43s remain
-        assertEquals(43_000L, RunTestsTool.processStartTimeoutMs(45, callStartMs = 0, nowMs = 2_000))
+        assertEquals(43.seconds, RunTestsTool.processStartTimeout(45, callStartMs = 0, nowMs = 2_000))
     }
 
     fun testProcessStartTimeoutShrinksAsCallProgresses() {
         // 45s budget, 40s elapsed: only 5s left
-        assertEquals(5_000L, RunTestsTool.processStartTimeoutMs(45, callStartMs = 0, nowMs = 40_000))
+        assertEquals(5.seconds, RunTestsTool.processStartTimeout(45, callStartMs = 0, nowMs = 40_000))
     }
 
     fun testProcessStartTimeoutFlooredAtOneMs() {
         // budget already exhausted — floor at 1ms rather than going negative or zero
-        assertEquals(1L, RunTestsTool.processStartTimeoutMs(45, callStartMs = 0, nowMs = 50_000))
-        assertEquals(1L, RunTestsTool.processStartTimeoutMs(0, callStartMs = 0, nowMs = 0))
+        assertEquals(1.milliseconds, RunTestsTool.processStartTimeout(45, callStartMs = 0, nowMs = 50_000))
+        assertEquals(1.milliseconds, RunTestsTool.processStartTimeout(0, callStartMs = 0, nowMs = 0))
     }
 
     // ── needsPsiSync ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Replace the hardcoded `PROCESS_START_TIMEOUT = 15.seconds` process-start guard in `ide_run_tests` with the caller-supplied `timeoutSeconds` value.

## Why
The 15-second constant was an arbitrary safety guard to prevent `processHandlerDeferred.await()` from blocking indefinitely if a process silently failed to start. That intent is fine, but the fixed value breaks large/slow Maven projects where the JVM and test classpath simply take longer than 15 seconds to spin up.

More importantly, the resulting error is misleading when the caller passes a larger timeout:

**Tool call:**
```
Tool: ide_run_tests
Status: ERROR
Duration: 15038ms

Parameters:
{
  "target": "com.example.service.SomeServiceImplTest#someMethod",
  "project_path": "/Users/dev/workspace/some-project",
  "timeoutSeconds": 120
}

Error:
Test process did not start within 15 seconds for 'SomeServiceImplTest.someMethod'.
```

The caller declared a 2-minute budget; the plugin aborted after 15 seconds. An LLM receiving this error has no reason to suspect the process-start window — it looks like the timeout the caller set was hit, which it wasn't.

Using `timeoutSeconds.seconds` as the deadline preserves the safety guard (the call still fails if the process never starts) while honouring the caller's actual budget and producing an accurate error message.