### PR TITLE
chore: bump pluginVersion to 5.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- **`ide_run_tests` no longer aborts with a misleading "did not start within 15 seconds" error on slow projects** — the hardcoded 15s process-start guard is replaced by the remaining `waitSeconds` budget (~45–55s by default). The error message now also tells the agent to retry or raise `waitSeconds`.
+- **`ide_run_tests` no longer aborts with a misleading "did not start within 15 seconds" error on slow projects** ([#339](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/339)) — the hardcoded 15s process-start guard is replaced by the remaining `waitSeconds` budget (~45–55s by default). The error message now also tells the agent to retry or raise `waitSeconds`.
 
 ## [5.8.2] - 2026-08-23
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.8.2
+pluginVersion = 5.8.3
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary

Version bump for the next patch release, following #339 (the `ide_run_tests` process-start guard fix):

- `gradle.properties`: `pluginVersion` 5.8.2 → **5.8.3**. Patch bump per the SemVer table in CONTRIBUTING.md — #339 is a bug fix.
- `CHANGELOG.md`: the existing `[Unreleased]` entry gains a link to [#339](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/339), matching the house style of previous entries (e.g. 5.8.2's link to #336). No version section is added — the release pipeline moves `[Unreleased]` under `[5.8.3]` at release time.

No other files reference the version, and no docs describe the old 15s process-start behavior, so nothing else needed updating.

## Checklist

Every PR must comply with [CONTRIBUTING.md](../CONTRIBUTING.md) — read it first.

- [x] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections) — entry already present from #339; this PR only adds the PR link
- [x] `./scripts/check-pr.sh` passes — static checks verified; the script's final full-test step was not run locally (version-bump-only diff, no code changes), CI runs the suite on this PR
- [x] `./gradlew test` passes (full suite, not just `-Ptier=unit`) — deferred to this PR's CI; the diff touches no source or test files
- [x] New tools (if any): none
- [x] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152of5bokBE1WzTbwU6y466

---
_Generated by [Claude Code](https://claude.ai/code/session_0152of5bokBE1WzTbwU6y466)_