### PR TITLE
Suggest ide_diagnostics on tool execution failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Fixed
 
+- **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "Run ide_diagnostics for possibly more information." so the agent has an immediate next step rather than stopping.
+
+## [5.8.3] - 2026-08-26
+
+### Fixed
+
 - **`ide_run_tests` no longer aborts with a misleading "did not start within 15 seconds" error on slow projects** ([#339](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/339)) — the hardcoded 15s process-start guard is replaced by the remaining `waitSeconds` budget (~45–55s by default). The error message now also tells the agent to retry or raise `waitSeconds`.
 
 ## [5.8.2] - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "Run ide_diagnostics for possibly more information." so the agent has an immediate next step rather than stopping.
+- **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "Run ide_diagnostics for more details" so the agent has an immediate next step rather than stopping.
 
 ## [5.8.3] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@
 
 ## [Unreleased]
 
-## [5.8.3] - 2026-08-25
-
-### Fixed
+### Changed
 
 - **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "Run ide_diagnostics for possibly more information." so the agent has an immediate next step rather than stopping.
 
-## [5.8.3] - 2026-08-26
+## [5.8.3] - 2026-08-25
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "Run ide_diagnostics for more details" so the agent has an immediate next step rather than stopping.
+- **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "run `ide_diagnostics` for more details" so the agent has an immediate next step rather than stopping.
 
 ## [5.8.3] - 2026-08-25
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -873,9 +873,11 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
      * @param message The error message
      * @return A [CallToolResult] with `isError = true`
      */
-    protected fun createErrorResult(message: String): CallToolResult {
+    protected fun createErrorResult(message: String, vararg hintTools: String): CallToolResult {
+        val text = message.takeIf { hintTools.isEmpty() }
+            ?: "${message.removeSuffix(".")}. Run ${hintTools.joinToString()} for more details."
         return CallToolResult(
-            content = listOf(TextContent(text = message)),
+            content = listOf(TextContent(text = text)),
             isError = true
         )
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -325,8 +325,8 @@ class RunTestsTool : AbstractMcpTool() {
         } catch (e: Exception) {
             connection.disconnect()
             return createErrorResult(
-                (e.message ?: "Test process failed to start for '$configName'.") +
-                        " Run ide_diagnostics for more details."
+                (e.message ?: "Test process failed to start for '$configName'") +
+                        " — run `ide_diagnostics` for more details."
             )
         } ?: run {
             connection.disconnect()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -326,7 +326,7 @@ class RunTestsTool : AbstractMcpTool() {
             connection.disconnect()
             return createErrorResult(
                 (e.message ?: "Test process failed to start for '$configName'.") +
-                        " Run ide_diagnostics for possibly more information."
+                        " Run ide_diagnostics for more details."
             )
         } ?: run {
             connection.disconnect()

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -324,10 +324,7 @@ class RunTestsTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             connection.disconnect()
-            return createErrorResult(
-                (e.message ?: "Test process failed to start for '$configName'") +
-                        " — run `ide_diagnostics` for more details."
-            )
+            return createErrorResult(e.message ?: "Test process failed to start for '$configName'.", ToolNames.DIAGNOSTICS)
         } ?: run {
             connection.disconnect()
             return createErrorResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -324,7 +324,10 @@ class RunTestsTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             connection.disconnect()
-            return createErrorResult(e.message ?: "Test process failed to start for '$configName'.")
+            return createErrorResult(
+                (e.message ?: "Test process failed to start for '$configName'.") +
+                        " Run ide_diagnostics for possibly more information."
+            )
         } ?: run {
             connection.disconnect()
             return createErrorResult(
@@ -485,7 +488,7 @@ class RunTestsTool : AbstractMcpTool() {
             override fun processNotStarted(executorId: String, environment: ExecutionEnvironment) {
                 if (environment !== env) return
                 processHandlerDeferred.completeExceptionally(
-                    IllegalStateException("Test process failed to start for '$configName'.")
+                    IllegalStateException("Test process failed to start for '$configName'. Run ide_diagnostics for possibly more information.")
                 )
             }
         })

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/RunTestsTool.kt
@@ -488,7 +488,7 @@ class RunTestsTool : AbstractMcpTool() {
             override fun processNotStarted(executorId: String, environment: ExecutionEnvironment) {
                 if (environment !== env) return
                 processHandlerDeferred.completeExceptionally(
-                    IllegalStateException("Test process failed to start for '$configName'. Run ide_diagnostics for possibly more information.")
+                    IllegalStateException("Test process failed to start for '$configName'.")
                 )
             }
         })

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -368,7 +368,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
-            createErrorResult("Change signature failed: ${cause.message} — run `ide_diagnostics` for more details.")
+            createErrorResult("Change signature failed: ${cause.message}", ToolNames.DIAGNOSTICS)
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -152,7 +152,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
         }
 
         return when {
-            prep.isFailure -> createErrorResult(prep.exceptionOrNull()?.message ?: "Failed to prepare change")
+            prep.isFailure -> createErrorResult((prep.exceptionOrNull()?.message ?: "Failed to prepare change") + " Run ide_diagnostics for possibly more information.")
             else -> {
                 val p = prep.getOrThrow()
                 applyChange(
@@ -368,7 +368,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
-            createErrorResult("Change signature failed: ${cause.message}")
+            createErrorResult("Change signature failed: ${cause.message} Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -152,7 +152,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
         }
 
         return when {
-            prep.isFailure -> createErrorResult((prep.exceptionOrNull()?.message ?: "Failed to prepare change") + " Run ide_diagnostics for possibly more information.")
+            prep.isFailure -> createErrorResult((prep.exceptionOrNull()?.message ?: "Failed to prepare change") + ". Run ide_diagnostics for possibly more information.")
             else -> {
                 val p = prep.getOrThrow()
                 applyChange(
@@ -368,7 +368,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
-            createErrorResult("Change signature failed: ${cause.message} Run ide_diagnostics for possibly more information.")
+            createErrorResult("Change signature failed: ${cause.message}. Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -368,7 +368,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
-            createErrorResult("Change signature failed: ${cause.message}. Run ide_diagnostics for more details.")
+            createErrorResult("Change signature failed: ${cause.message} — run `ide_diagnostics` for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -368,7 +368,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
             throw e
         } catch (e: Exception) {
             val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
-            createErrorResult("Change signature failed: ${cause.message}. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Change signature failed: ${cause.message}. Run ide_diagnostics for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -152,7 +152,7 @@ class ChangeSignatureTool : AbstractMcpTool() {
         }
 
         return when {
-            prep.isFailure -> createErrorResult((prep.exceptionOrNull()?.message ?: "Failed to prepare change") + ". Run ide_diagnostics for possibly more information.")
+            prep.isFailure -> createErrorResult(prep.exceptionOrNull()?.message ?: "Failed to prepare change")
             else -> {
                 val p = prep.getOrThrow()
                 applyChange(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
@@ -187,7 +187,7 @@ class ConvertJavaToKotlinTool : AbstractRefactoringTool() {
             }.result
         } catch (e: Exception) {
             LOG.error("Conversion failed", e)
-            createErrorResult("Conversion failed: ${e.message}")
+            createErrorResult("Conversion failed: ${e.message} Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
@@ -187,7 +187,7 @@ class ConvertJavaToKotlinTool : AbstractRefactoringTool() {
             }.result
         } catch (e: Exception) {
             LOG.error("Conversion failed", e)
-            createErrorResult("Conversion failed: ${e.message}. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Conversion failed: ${e.message}. Run ide_diagnostics for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
@@ -1,5 +1,6 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
@@ -187,7 +188,7 @@ class ConvertJavaToKotlinTool : AbstractRefactoringTool() {
             }.result
         } catch (e: Exception) {
             LOG.error("Conversion failed", e)
-            createErrorResult("Conversion failed: ${e.message} — run `ide_diagnostics` for more details.")
+            createErrorResult("Conversion failed: ${e.message}", ToolNames.DIAGNOSTICS)
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
@@ -187,7 +187,7 @@ class ConvertJavaToKotlinTool : AbstractRefactoringTool() {
             }.result
         } catch (e: Exception) {
             LOG.error("Conversion failed", e)
-            createErrorResult("Conversion failed: ${e.message} Run ide_diagnostics for possibly more information.")
+            createErrorResult("Conversion failed: ${e.message}. Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ConvertJavaToKotlinTool.kt
@@ -187,7 +187,7 @@ class ConvertJavaToKotlinTool : AbstractRefactoringTool() {
             }.result
         } catch (e: Exception) {
             LOG.error("Conversion failed", e)
-            createErrorResult("Conversion failed: ${e.message}. Run ide_diagnostics for more details.")
+            createErrorResult("Conversion failed: ${e.message} — run `ide_diagnostics` for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -288,7 +288,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for more details.")
+            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"} — run `ide_diagnostics` for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -288,7 +288,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -288,7 +288,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"} Run ide_diagnostics for possibly more information.")
+            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -288,7 +288,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"}")
+            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"} Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MoveFileTool.kt
@@ -1,5 +1,6 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
@@ -288,7 +289,7 @@ open class MoveFileTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"} — run `ide_diagnostics` for more details.")
+            createErrorResult("Move failed: ${errorMessage ?: "Unknown error"}", ToolNames.DIAGNOSTICS)
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -91,7 +91,7 @@ class OptimizeImportsTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Optimize imports failed: $errorMessage Run ide_diagnostics for possibly more information.")
+            createErrorResult("Optimize imports failed: $errorMessage. Run ide_diagnostics for possibly more information.")
         } else {
             createJsonResult(
                 RefactoringResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -91,7 +91,7 @@ class OptimizeImportsTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Optimize imports failed: $errorMessage. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Optimize imports failed: $errorMessage. Run ide_diagnostics for more details.")
         } else {
             createJsonResult(
                 RefactoringResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -91,7 +91,7 @@ class OptimizeImportsTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Optimize imports failed: $errorMessage. Run ide_diagnostics for more details.")
+            createErrorResult("Optimize imports failed: $errorMessage — run `ide_diagnostics` for more details.")
         } else {
             createJsonResult(
                 RefactoringResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -91,7 +91,7 @@ class OptimizeImportsTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Optimize imports failed: $errorMessage")
+            createErrorResult("Optimize imports failed: $errorMessage Run ide_diagnostics for possibly more information.")
         } else {
             createJsonResult(
                 RefactoringResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/OptimizeImportsTool.kt
@@ -91,7 +91,7 @@ class OptimizeImportsTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Optimize imports failed: $errorMessage — run `ide_diagnostics` for more details.")
+            createErrorResult("Optimize imports failed: $errorMessage", ToolNames.DIAGNOSTICS)
         } else {
             createJsonResult(
                 RefactoringResult(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -137,7 +137,7 @@ class ReformatCodeTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Reformat failed: $errorMessage")
+            createErrorResult("Reformat failed: $errorMessage Run ide_diagnostics for possibly more information.")
         } else {
             val operations = buildList {
                 add("reformatted")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -137,7 +137,7 @@ class ReformatCodeTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Reformat failed: $errorMessage. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Reformat failed: $errorMessage. Run ide_diagnostics for more details.")
         } else {
             val operations = buildList {
                 add("reformatted")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -137,7 +137,7 @@ class ReformatCodeTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Reformat failed: $errorMessage. Run ide_diagnostics for more details.")
+            createErrorResult("Reformat failed: $errorMessage — run `ide_diagnostics` for more details.")
         } else {
             val operations = buildList {
                 add("reformatted")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -137,7 +137,7 @@ class ReformatCodeTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Reformat failed: $errorMessage Run ide_diagnostics for possibly more information.")
+            createErrorResult("Reformat failed: $errorMessage. Run ide_diagnostics for possibly more information.")
         } else {
             val operations = buildList {
                 add("reformatted")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReformatCodeTool.kt
@@ -137,7 +137,7 @@ class ReformatCodeTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Reformat failed: $errorMessage — run `ide_diagnostics` for more details.")
+            createErrorResult("Reformat failed: $errorMessage", ToolNames.DIAGNOSTICS)
         } else {
             val operations = buildList {
                 add("reformatted")

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -1,6 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
@@ -348,7 +349,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Rename failed: $errorMessage — run `ide_diagnostics` for more details.")
+            createErrorResult("Rename failed: $errorMessage", ToolNames.DIAGNOSTICS)
         } else {
             val result = renameExecutionResult!!
             val relatedNote = if (result.relatedRenamesCount > 0) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -348,7 +348,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Rename failed: $errorMessage Run ide_diagnostics for possibly more information.")
+            createErrorResult("Rename failed: $errorMessage. Run ide_diagnostics for possibly more information.")
         } else {
             val result = renameExecutionResult!!
             val relatedNote = if (result.relatedRenamesCount > 0) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -348,7 +348,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Rename failed: $errorMessage. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Rename failed: $errorMessage. Run ide_diagnostics for more details.")
         } else {
             val result = renameExecutionResult!!
             val relatedNote = if (result.relatedRenamesCount > 0) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -348,7 +348,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Rename failed: $errorMessage. Run ide_diagnostics for more details.")
+            createErrorResult("Rename failed: $errorMessage — run `ide_diagnostics` for more details.")
         } else {
             val result = renameExecutionResult!!
             val relatedNote = if (result.relatedRenamesCount > 0) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -348,7 +348,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         return if (errorMessage != null) {
-            createErrorResult("Rename failed: $errorMessage")
+            createErrorResult("Rename failed: $errorMessage Run ide_diagnostics for possibly more information.")
         } else {
             val result = renameExecutionResult!!
             val relatedNote = if (result.relatedRenamesCount > 0) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -361,7 +361,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for more details.")
+            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"} — run `ide_diagnostics` for more details.")
         }
     }
 
@@ -415,7 +415,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for more details.")
+            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"} — run `ide_diagnostics` for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -361,7 +361,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for possibly more information.")
+            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for more details.")
         }
     }
 
@@ -415,7 +415,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for possibly more information.")
+            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for more details.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -361,7 +361,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"} Run ide_diagnostics for possibly more information.")
+            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for possibly more information.")
         }
     }
 
@@ -415,7 +415,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"} Run ide_diagnostics for possibly more information.")
+            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"}. Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -361,7 +361,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}")
+            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"} Run ide_diagnostics for possibly more information.")
         }
     }
 
@@ -415,7 +415,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"}")
+            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"} Run ide_diagnostics for possibly more information.")
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -1,5 +1,6 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
@@ -361,7 +362,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"} — run `ide_diagnostics` for more details.")
+            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}", ToolNames.DIAGNOSTICS)
         }
     }
 
@@ -415,7 +416,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 )
             )
         } else {
-            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"} — run `ide_diagnostics` for more details.")
+            createErrorResult("File deletion failed: ${errorMessage ?: "Unknown error"}", ToolNames.DIAGNOSTICS)
         }
     }
 


### PR DESCRIPTION
## Summary

When a tool execution fails due to an unexpected IDE-side error, agents currently receive a message like:

```
Tool: ide_run_tests
Status: ERROR

Parameters:
{"target":"com.some.project.ExampleTest","project_path":"<path>"}

Error:
Test process failed to start for 'ExampleTest'.
```

There is no next step. The agent stops, retries blindly or even starts using a different tool.

## Why

- Reduces dead ends: agent gets an actionable next step instead of stopping
- No false claims: "possibly more information" rather than "compilation errors" (we genuinely don't know the cause)
- Consistent: same hint across all similar failure points

## Implementation note

After investigation, `processNotStarted` (the IntelliJ `ExecutionListener` callback that triggers this error) fires in three scenarios: before-run tasks fail (e.g. a "Make" compilation step), the runner throws an `ExecutionException`, or the process creation itself fails. The most common real-world trigger is compilation errors — and `ide_diagnostics` is exactly the right tool to surface those.

Crucially, the public `ExecutionListener.processNotStarted` signature carries **no throwable** — we cannot tell the agent *why* it failed. So we don't claim to know: we just suggest the tool that has the best chance of giving more information.

The same pattern applies to other tool execution failures where the cause is opaque and code state may be involved.

## Changes

Added mention of using the ide_diagnostics tool in the execution-failure error messages in:

- `ide_run_tests` — `processNotStarted` callback and its fallback
- `ide_refactor_rename` — rename execution failure
- `ide_move_file` — move execution failure
- `ide_change_signature` — preparation failure and execution failure
- `ide_convert_java_to_kotlin` — conversion failure
- `ide_refactor_safe_delete` — safe delete and file deletion failures
- `ide_optimize_imports` — optimize imports failure
- `ide_reformat_code` — reformat failure

Input-validation errors (file not found, missing parameters, invalid values) are intentionally left unchanged — those messages are already clear and `ide_diagnostics` would not help.

## Test
I built the plugin locally and deliberately removed an import. I then asked Claude to run a test. After the test failed, Claude automatically ran `ide_diagnostics`, identified and fixed the issue, and reran the test successfully. This is exactly the workflow that this MR is intended to enable.