### PR TITLE
chore: bump pluginVersion to 5.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- **Tool execution failures now suggest running `ide_diagnostics`** — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "run `ide_diagnostics` for more details" so the agent has an immediate next step rather than stopping.
+- **Tool execution failures now suggest running `ide_diagnostics`** ([#343](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/343)) — when `ide_run_tests`, `ide_refactor_rename`, `ide_move_file`, `ide_change_signature`, `ide_convert_java_to_kotlin`, `ide_refactor_safe_delete`, `ide_optimize_imports`, or `ide_reformat_code` fail during execution (not due to bad input), the error message now appends "Run `ide_diagnostics` for more details." so the agent has an immediate next step rather than stopping.
 
 ## [5.8.3] - 2026-08-25
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.8.3
+pluginVersion = 5.8.4
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary

Release prep after #343 merged, in two small pieces:

- **`gradle.properties`**: `pluginVersion` 5.8.3 → 5.8.4. Patch bump per the SemVer table in CONTRIBUTING.md — #343 changes existing error messages (opaque execution failures now point the agent at `ide_diagnostics`) with no new tool, feature, or schema change.
- **`CHANGELOG.md`**: polish of the existing `[Unreleased]` entry only, mirroring what #340 did for #339 — it gains its PR link ([#343](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/pull/343)) per house style, and its quoted hint now matches the shipped message verbatim: the merged implementation appends `. Run ide_diagnostics for more details.` (via the new `createErrorResult(message, vararg hintTools)` helper), while the entry quoted a lowercase "run … for more details".

One note: the `[5.8.3]` section regression flagged during review **never reached `main`** — the final commits of #343 restored the released section, the #339 entry under its `### Fixed`, and both compare links before the merge. So no repair was needed here; entries stay under `[Unreleased]` and the release pipeline moves them under 5.8.4 at release time, per CONTRIBUTING.md.

## Checklist

Every PR must comply with [CONTRIBUTING.md](../CONTRIBUTING.md) — read it first.

- [x] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections) — no new entry needed for a version-bump chore (matching #340); the existing entry was polished and no version sections were touched
- [x] `./scripts/check-pr.sh` passes — all 15 static checks green; its test step could not run in this environment (no access to JetBrains download servers), see next item
- [ ] `./gradlew test` passes (full suite, not just `-Ptier=unit`) — not runnable in this environment for the same reason; the diff is `gradle.properties` + `CHANGELOG.md` only, so CI is the verifier here
- [x] New tools (if any): registered in `ToolNames`, `ToolRegistry`, and `McpSettings` (opt-in defaults), documented in all six doc locations, and the golden tool manifest regenerated with its diff reviewed — N/A, no tool changes
- [x] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAjieE8QzkGZT5qgXqye6t

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAjieE8QzkGZT5qgXqye6t)_