### PR TITLE
Move tool enable/disable to a new Exposed Tools settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Tool enable/disable moved to a new "Exposed Tools" settings page** — the "Available Tools (uncheck to disable)" checkbox list left the main settings page and now lives on a child page at Settings → Tools → Index MCP Server → Exposed Tools, mirroring the IDE's own MCP Server settings layout. The main page keeps the server host/port, history, projects mode, response format, sync, and lifecycle sections unchanged; the per-tool checkboxes, tooltips, and "Server is initializing..." guard behave exactly as before, and no stored state changes — existing per-tool enable/disable settings carry over untouched.
+
 ## [5.9.2] - 2026-08-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ enable the write tools.
 - [Quick Start](#quick-start)
 - [Community Integrations](#community-integrations)
 - [Client Configuration](#client-configuration)
-- [Available Tools](#available-tools)
+- [Exposed Tools](#exposed-tools)
 - [Multi-Project Support](#multi-project-support)
 - [Lifecycle Management](#lifecycle-management)
 - [Tool Window](#tool-window)
@@ -256,7 +256,7 @@ Each JetBrains IDE has a unique default port and server name to allow running mu
 
 > **Tip**: Use the "Install on Coding Agents" button in the tool window - it automatically uses the correct server name and port for your IDE.
 
-## Available Tools
+## Exposed Tools
 
 The plugin provides **52 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd> > <kbd>Exposed Tools</kbd>.
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Each JetBrains IDE has a unique default port and server name to allow running mu
 
 ## Available Tools
 
-The plugin provides **52 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>.
+The plugin provides **52 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd> > <kbd>Exposed Tools</kbd>.
 
 ### Universal Tools
 
@@ -487,7 +487,7 @@ Configure the plugin at <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP 
 | Project List in Error Responses | Expanded | Controls `available_projects` detail for invalid/missing `project_path` errors. `Expanded` includes workspace sub-projects; `Compact` returns only top-level project roots |
 | Sync External Changes | false | Sync external file changes before operations (**WARNING: significant performance impact**) |
 | Response Format | JSON | Tool response serialization: JSON or TOON |
-| Disabled Tools | Tool-specific | Per-tool enable/disable toggles. Disabled tools stay hidden and cannot be called until enabled |
+| Disabled Tools | Tool-specific | Per-tool enable/disable toggles on the Exposed Tools sub-page. Disabled tools stay hidden and cannot be called until enabled |
 | **Lifecycle Management** | | |
 | Enable lifecycle management | false | Master toggle for the automatic sleep/wake state machine — no automatic sleep/wake happens until this is enabled |
 | Active → Background (minutes) | 2 | Focus-loss grace period before switching to Power Save Mode |

--- a/USAGE.md
+++ b/USAGE.md
@@ -807,7 +807,7 @@ File problems are collected through explicit daemon analysis, so they do not dep
 ### ide_project_diagnostics
 
 > **Availability**: Universal Tool - works in all JetBrains IDEs
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings → Tools → Index MCP Server → Exposed Tools
 
 Analyzes many files — up to the whole project, including files not open in any editor — for code problems, with fail-closed coverage metadata (issue #246).
 
@@ -988,7 +988,7 @@ Force the IDE to synchronize its virtual file system and PSI cache with external
 
 ### ide_reload_project
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Force-reload the project build model (Maven, Gradle, or both). Equivalent to clicking **"Reload All Maven Projects"** or **"Reload Gradle Project"** in the IDE.
 
@@ -1016,7 +1016,7 @@ Build model reload scheduled for Maven in 'engine'. IntelliJ is resolving depend
 
 ### ide_link_build_system
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Link an unlinked Maven or Gradle project so the IDE resolves its dependencies. Use when `ide_reload_project` reports "build file found on disk but project is not linked" — this tool does the equivalent of clicking "Load Maven/Gradle Project" in the IDE notification bar.
 
@@ -1039,7 +1039,7 @@ Link an unlinked Maven or Gradle project so the IDE resolves its dependencies. U
 
 ### ide_import_modules
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 > **Requires**: Maven plugin
 
 Import one or more external Maven project directories as modules into the current IntelliJ window, enabling cross-project code intelligence and refactoring. Already imported module roots are skipped.
@@ -1074,7 +1074,7 @@ Imported 2 module(s):
 
 ### ide_open_workspace
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 > **Requires**: Maven plugin
 
 Scan a root directory for Maven projects and open them all in one IntelliJ window with full cross-project code intelligence. Alternatively, provide an explicit list of Maven project paths. Creates a temporary aggregator POM with relative module paths.
@@ -1126,7 +1126,7 @@ Workspace opened with 3 Maven projects from /Users/dev/monorepo. IntelliJ is ind
 
 ### ide_build_project
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Build the project using the IDE's build system (supports JPS, Gradle, Maven, CMake (CLion)).
 
@@ -1185,7 +1185,7 @@ Build the project using the IDE's build system (supports JPS, Gradle, Maven, CMa
 
 ### ide_run_tests
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Run tests using the IDE's run configuration infrastructure. Returns structured pass/fail results with per-test error messages, failure stack traces, and console output.
 
@@ -1275,7 +1275,7 @@ Failed or errored tests carry a `stackTrace` alongside `errorMessage`. Very long
 
 ### ide_read_file
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Read file content by file path or fully qualified class name.
 
@@ -1329,7 +1329,7 @@ Read file content by file path or fully qualified class name.
 
 ### ide_get_active_file
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Get the currently active file(s) open in the IDE editor, including split panes.
 
@@ -1376,7 +1376,7 @@ Get the currently active file(s) open in the IDE editor, including split panes.
 
 ### ide_open_file
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Open a file in the IDE editor with optional line/column navigation.
 
@@ -1421,7 +1421,7 @@ Open a file in the IDE editor with optional line/column navigation.
 
 ### ide_find_symbol
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Searches for code symbols (classes, interfaces, methods, fields, and functions) by name using the IDE's semantic index and IntelliJ's Go to Symbol matching.
 
@@ -1540,7 +1540,7 @@ For Markdown heading outlines, use `ide_file_structure`.
 
 ### ide_install_plugin
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Install a plugin zip into the IDE, replacing any existing version. When no path is given, auto-detects the most recently modified zip in `build/distributions/` of the active project — the output of `./gradlew buildPlugin`.
 
@@ -1579,7 +1579,7 @@ Plugin 'com.example.my-plugin' installed from my-plugin-1.0.0.zip. Restart the I
 
 ### ide_restart
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Restart the IDE. This terminates the MCP connection — the AI assistant will lose connectivity and must reconnect after the IDE comes back up.
 
@@ -1614,7 +1614,7 @@ Restart the IDE. This terminates the MCP connection — the AI assistant will lo
 
 ### ide_set_power_save_mode
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Enable or disable IDE Power Save Mode. When enabled, background inspections and code analysis are suspended, reducing CPU and memory pressure. The index and all code intelligence operations (find usages, refactoring, navigation) remain fully functional.
 
@@ -1655,7 +1655,7 @@ Power Save Mode enabled (IDE-wide).
 
 ### ide_close_project
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Close an open project window and free its memory. The project can be reopened later via Recent Projects or `ide_open_project`.
 
@@ -1695,7 +1695,7 @@ Project 'myproject' is closing.
 
 ### ide_create_module
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Add a directory as an IntelliJ module with a content root, enabling code intelligence for non-Maven projects (TypeScript, plain directories, etc.). Supports optional directory exclusions. For Maven projects, use `ide_import_modules` instead.
 
@@ -1750,7 +1750,7 @@ Note: indexing is async — call ide_index_status if subsequent tools hit dumb m
 
 ### ide_open_project
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Open a project by filesystem path and wait until indexing is complete, so subsequent MCP tool calls against the opened project succeed immediately. If the project is already open, returns successfully right away.
 
@@ -1978,7 +1978,7 @@ Move a file to a new directory using the IDE's refactoring engine. Applies langu
 
 ### ide_reformat_code
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Reformat code according to the project's code style settings. Equivalent to the IDE's "Reformat Code" action (<kbd>Ctrl+Alt+L</kbd> / <kbd>Cmd+Opt+L</kbd>).
 
@@ -2028,7 +2028,7 @@ Reformat code according to the project's code style settings. Equivalent to the 
 
 ### ide_optimize_imports
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Optimize imports in a file: remove unused imports and organize the remaining imports according to the project code style. Equivalent to the IDE's "Optimize Imports" action (<kbd>Ctrl+Alt+O</kbd> / <kbd>Cmd+Opt+O</kbd>). Does **not** reformat code. Supports undo (Ctrl/Cmd+Z).
 
@@ -2061,7 +2061,7 @@ Optimize imports in a file: remove unused imports and organize the remaining imp
 
 ### ide_structural_search_replace
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Pattern-based code search and transformation using IntelliJ's Structural Search and Replace (SSR) engine. Matches code patterns structurally rather than textually — understands types, expressions, statements, and code structure.
 
@@ -2132,7 +2132,7 @@ When `replacePattern` is omitted, the tool performs search-only and returns matc
 
 ### ide_edit_member
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Replace an entire member declaration (signature + body) with new content. The tool locates the member by name, optional parameter count, and optional line number, then replaces the complete declaration.
 
@@ -2188,7 +2188,7 @@ Replace an entire member declaration (signature + body) with new content. The to
 
 ### ide_change_signature
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Change a method's signature — name, return type, visibility, and parameters — with automatic updates to all callers using IntelliJ's Change Signature refactoring. Supports reordering, adding, removing, and renaming parameters.
 
@@ -2280,7 +2280,7 @@ Change a method's signature — name, return type, visibility, and parameters �
 
 ### ide_create_file
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Create a new source file with content, immediately indexed by IntelliJ. The file is created through IntelliJ's VFS, so it is instantly available for `ide_find_references`, `ide_refactor_rename`, `ide_edit_member`, and all other IDE tools without needing `ide_sync_files`.
 
@@ -2327,7 +2327,7 @@ Use this instead of the Write tool for creating `.java`, `.kt`, `.ts`, `.tsx`, `
 
 ### ide_replace_text_in_file
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Find and replace text in a file using IntelliJ's Document API. Performs plain text or regex replacement through IntelliJ's document model, so changes are immediately visible to the index, PSI, and all other IDE tools without needing `ide_sync_files`.
 
@@ -2396,7 +2396,7 @@ Use this for mechanical text substitutions — e.g., replacing a method call wra
 
 ### ide_insert_member
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Insert a new member (method, field, inner class, etc.) at a structural position within a class or at the top level of a file.
 
@@ -2454,7 +2454,7 @@ Insert a new member (method, field, inner class, etc.) at a structural position 
 
 ### ide_replace_member
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Replace only the body of a method or the initializer of a field, preserving the existing signature. This is safer than `ide_edit_member` when the signature should remain unchanged.
 
@@ -2930,7 +2930,7 @@ Finds the complete inheritance hierarchy for a method - all parent methods it ov
 
 ### ide_file_structure
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Get the hierarchical structure of a source file, similar to the IDE's Structure view (<kbd>Cmd+7</kbd> / <kbd>Alt+7</kbd>).
 
@@ -2985,7 +2985,7 @@ These tools require the Java plugin and are only available in **IntelliJ IDEA** 
 
 ### ide_list_tests
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 > **Availability**: Requires Java plugin — only available in **IntelliJ IDEA** and **Android Studio** (uses the `com.intellij.testFramework` extension point declared by the Java plugin)
 
 List all test methods discovered by the IDE's test framework extension points (JUnit, TestNG, etc.).
@@ -3037,7 +3037,7 @@ List all test methods discovered by the IDE's test framework extension points (J
 
 ### ide_convert_java_to_kotlin
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Convert one or more Java files to Kotlin using IntelliJ's built-in J2K (Java-to-Kotlin) converter.
 
@@ -3340,7 +3340,7 @@ Accepts an optional `path` parameter to release a closed managed project without
 
 ### ide_release_all_projects
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Release every managed project (including closed ones) from lifecycle management at once. Also disables Power Save Mode globally.
 
@@ -3354,7 +3354,7 @@ Release every managed project (including closed ones) from lifecycle management 
 
 ### ide_enroll_all_projects
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Enroll every currently open project in lifecycle management. Projects already managed are skipped.
 
@@ -3402,7 +3402,7 @@ Query recent lifecycle events from the in-memory ring buffer (default 500 entrie
 
 ### ide_set_lifecycle_log_file
 
-> **Default**: Disabled - enable in Settings > Tools > Index MCP Server
+> **Default**: Disabled - enable in Settings > Tools > Index MCP Server → Exposed Tools
 
 Enable or disable writing lifecycle events to the persistent log file on disk (`mcp-lifecycle.log`, written alongside `idea.log`). The in-memory ring buffer queried by `ide_lifecycle_log` is always active regardless of this setting.
 

--- a/docs/mcp-kotlin-sdk-migration.md
+++ b/docs/mcp-kotlin-sdk-migration.md
@@ -176,7 +176,7 @@ class McpToolDispatcher(
             ?: return CallToolResult.error("Tool '$toolName' not found")
         if (!McpSettings.getInstance().isToolEnabled(toolName))
             return CallToolResult.error("Tool '$toolName' is disabled. Enable it in " +
-                "Settings → Index MCP Server → Available Tools.")
+                "Settings → Tools → Index MCP Server → Exposed Tools.")
 
         val projectPath = arguments[ParamNames.PROJECT_PATH]?.stringOrNull()
         val resolved = ProjectResolver.resolveOrOpen(projectPath)

--- a/smoke-tests/mcp-protocol.md
+++ b/smoke-tests/mcp-protocol.md
@@ -13,7 +13,7 @@ Most tools this protocol exercises are **disabled by default** and hidden from `
 `ide_set_power_save_mode`, `ide_open_project`, `ide_close_project`, `ide_install_plugin`,
 `ide_restart`, `ide_set_lifecycle_log_file`, and every lifecycle tool except
 `ide_project_status` (see `DEFAULT_DISABLED_TOOLS` in `McpSettings.kt`). Enable them first in
-Settings → Tools → Index MCP Server → Available Tools, or every affected step fails with a
+Settings → Tools → Index MCP Server → Exposed Tools, or every affected step fails with a
 disabled-tool error on a fresh install.
 
 ### How to call the server

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/mcp/McpToolDispatcher.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/mcp/McpToolDispatcher.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.json.contentOrNull
  * The MCP protocol itself — JSON-RPC framing, `initialize`, version negotiation, `tools/list`
  * dispatch — belongs to the SDK. What is left is IDE-specific and lives here:
  *
- *  1. the enabled/disabled gate from Settings → Index MCP Server → Available Tools
+ *  1. the enabled/disabled gate from Settings → Tools → Index MCP Server → Exposed Tools
  *  2. resolving `project_path` to an open [Project], reopening it if the lifecycle manager
  *     closed it
  *  3. recording the call in the per-project command history shown in the tool window
@@ -87,7 +87,7 @@ class McpToolDispatcher @JvmOverloads constructor(
 
         if (!McpSettings.getInstance().isToolEnabled(toolName)) {
             return CallToolResult.error(
-                "Tool '$toolName' is disabled. Enable it in Settings → Index MCP Server → Available Tools."
+                "Tool '$toolName' is disabled. Enable it in Settings → Tools → Index MCP Server → Exposed Tools."
             )
         }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -51,7 +51,6 @@ class McpSettingsConfigurable : Configurable {
     private var syncExternalChangesCheckBox: JBCheckBox? = null
     private var availableProjectsModeComboBox: ComboBox<McpSettings.AvailableProjectsMode>? = null
     private var responseFormatComboBox: ComboBox<McpSettings.ResponseFormat>? = null
-    private val toolCheckBoxes = mutableMapOf<String, JBCheckBox>()
     private var uiDisposable: Disposable? = null
 
     // Lifecycle UI fields
@@ -139,7 +138,6 @@ class McpSettingsConfigurable : Configurable {
             add(warningRow)
         }
 
-        val availableToolsPanel = createToolsPanel()
         val lifecyclePanel = createLifecyclePanel()
 
         panel = FormBuilder.createFormBuilder()
@@ -153,9 +151,6 @@ class McpSettingsConfigurable : Configurable {
             .addSeparator(10)
             .addComponent(JBLabel(McpBundle.message("lifecycle.section.title")), 5)
             .addComponent(lifecyclePanel, 1)
-            .addSeparator(10)
-            .addComponent(JBLabel(McpBundle.message("settings.tools.title")), 5)
-            .addComponent(availableToolsPanel, 5)
             .addComponentFillVertically(JPanel(), 0)
             .panel
 
@@ -313,34 +308,6 @@ class McpSettingsConfigurable : Configurable {
         content.repaint()
     }
 
-    private fun createToolsPanel(): JComponent {
-        val toolsContainer = JPanel().apply {
-            layout = BoxLayout(this, BoxLayout.Y_AXIS)
-        }
-
-        val mcpService = McpServerService.getInstance()
-        if (!mcpService.isInitialized) {
-            toolsContainer.add(JBLabel("Server is initializing...").apply {
-                foreground = JBColor(0xD9A343, 0xD9A343)
-            })
-            return toolsContainer
-        }
-
-        val toolRegistry = mcpService.getToolRegistry()
-        val allTools = toolRegistry.getAllToolDefinitions().sortedBy { it.name }
-        val settings = McpSettings.getInstance()
-
-        for (tool in allTools) {
-            val checkbox = JBCheckBox(tool.name, settings.isToolEnabled(tool.name)).apply {
-                toolTipText = tool.description
-            }
-            toolCheckBoxes[tool.name] = checkbox
-            toolsContainer.add(checkbox)
-        }
-
-        return toolsContainer
-    }
-
     override fun isModified(): Boolean {
         val settings = McpSettings.getInstance()
 
@@ -358,12 +325,6 @@ class McpSettingsConfigurable : Configurable {
             lifecycleLogToFileCheckBox?.isSelected != settings.lifecycleLogToFile ||
             minimumOpenProjectsSpinner?.value != settings.minimumOpenProjects) {
             return true
-        }
-
-        for ((toolName, checkbox) in toolCheckBoxes) {
-            if (checkbox.isSelected != settings.isToolEnabled(toolName)) {
-                return true
-            }
         }
 
         return false
@@ -434,8 +395,6 @@ class McpSettingsConfigurable : Configurable {
         settings.lifecycleLogToFile = lifecycleLogToFileCheckBox?.isSelected ?: false
         settings.minimumOpenProjects = minimumOpenProjectsSpinner?.value as? Int ?: 4
 
-        settings.updateToolEnabledStates(toolCheckBoxes.mapValues { (_, checkbox) -> checkbox.isSelected })
-
         // Auto-restart server if host/port changed. Must run on a pooled thread:
         // EmbeddedServer.stop() blocks (runBlocking) while in-flight MCP calls drain — calls
         // that may themselves be waiting for the EDT — and the CIO bind is blocking too, so
@@ -494,8 +453,8 @@ class McpSettingsConfigurable : Configurable {
 
         // If the port matches our current server's port and it's running, we consider it available.
         // We skip the bind check here because our own server is already occupying the port,
-        // which would cause a false "address in use" error (especially when switching 
-        // between 0.0.0.0 and 127.0.0.1). We trust that we will stop our server 
+        // which would cause a false "address in use" error (especially when switching
+        // between 0.0.0.0 and 127.0.0.1). We trust that we will stop our server
         // before binding to the new address during restart.
         if (port == currentPort && mcpService.isInitialized && mcpService.isServerRunning()) {
             return true
@@ -520,7 +479,7 @@ class McpSettingsConfigurable : Configurable {
         syncExternalChangesCheckBox?.isSelected = settings.syncExternalChanges
         availableProjectsModeComboBox?.selectedItem = settings.availableProjectsMode
         responseFormatComboBox?.selectedItem = settings.responseFormat
-        
+
         hostValidationErrorLabel?.isVisible = false
         hostValidationIcon?.isVisible = false
         hostValidIcon?.isVisible = false
@@ -535,10 +494,6 @@ class McpSettingsConfigurable : Configurable {
         lifecycleLogBufferSizeSpinner?.value = settings.lifecycleLogBufferSize
         lifecycleLogToFileCheckBox?.isSelected = settings.lifecycleLogToFile
         minimumOpenProjectsSpinner?.value = settings.minimumOpenProjects
-
-        for ((toolName, checkbox) in toolCheckBoxes) {
-            checkbox.isSelected = settings.isToolEnabled(toolName)
-        }
     }
 
     private fun updateHostWarning(host: String) {
@@ -581,11 +536,11 @@ class McpSettingsConfigurable : Configurable {
 
                 ApplicationManager.getApplication().executeOnPooledThread {
                     val isValid = isValidHost(host)
-                    val labelMessage = if (host.isEmpty()) 
-                        McpBundle.message("settings.serverHost.empty") 
-                    else 
+                    val labelMessage = if (host.isEmpty())
+                        McpBundle.message("settings.serverHost.empty")
+                    else
                         McpBundle.message("settings.serverHost.invalidShort")
-                    
+
                     // Use empty message for ComponentValidator to show red border but avoid tooltip popup
                     // as we are showing the error message in the label next to the input
                     val info = if (isValid) null else ValidationInfo("", field)
@@ -625,7 +580,6 @@ class McpSettingsConfigurable : Configurable {
         syncExternalChangesCheckBox = null
         availableProjectsModeComboBox = null
         responseFormatComboBox = null
-        toolCheckBoxes.clear()
         lifecycleEnabledCheckBox = null
         focusToBackgroundSpinner = null
         backgroundToDormantSpinner = null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpToolsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpToolsConfigurable.kt
@@ -1,0 +1,90 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.settings
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpBundle
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
+import com.intellij.openapi.options.Configurable
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import javax.swing.BoxLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Settings page listing every registered MCP tool with an enable/disable checkbox.
+ * Registered in plugin.xml as a child of mcp.settings, mirroring the IDE's own
+ * MCP Server settings layout.
+ */
+class McpToolsConfigurable : Configurable {
+
+    private var panel: JPanel? = null
+    private val toolCheckBoxes = mutableMapOf<String, JBCheckBox>()
+
+    override fun getDisplayName(): String = McpBundle.message("settings.exposedTools.title")
+
+    override fun createComponent(): JComponent {
+        panel = FormBuilder.createFormBuilder()
+            .addComponent(JBLabel(McpBundle.message("settings.tools.title")), 5)
+            .addComponent(createToolsPanel(), 5)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+        return panel!!
+    }
+
+    private fun createToolsPanel(): JComponent {
+        val toolsContainer = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        }
+
+        val mcpService = McpServerService.getInstance()
+        if (!mcpService.isInitialized) {
+            toolsContainer.add(JBLabel("Server is initializing...").apply {
+                foreground = JBColor(0xD9A343, 0xD9A343)
+            })
+            return toolsContainer
+        }
+
+        val toolRegistry = mcpService.getToolRegistry()
+        val allTools = toolRegistry.getAllToolDefinitions().sortedBy { it.name }
+        val settings = McpSettings.getInstance()
+
+        for (tool in allTools) {
+            val checkbox = JBCheckBox(tool.name, settings.isToolEnabled(tool.name)).apply {
+                toolTipText = tool.description
+            }
+            toolCheckBoxes[tool.name] = checkbox
+            toolsContainer.add(checkbox)
+        }
+
+        return toolsContainer
+    }
+
+    override fun isModified(): Boolean {
+        val settings = McpSettings.getInstance()
+        for ((toolName, checkbox) in toolCheckBoxes) {
+            if (checkbox.isSelected != settings.isToolEnabled(toolName)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun apply() {
+        McpSettings.getInstance().updateToolEnabledStates(
+            toolCheckBoxes.mapValues { (_, checkbox) -> checkbox.isSelected }
+        )
+    }
+
+    override fun reset() {
+        val settings = McpSettings.getInstance()
+        for ((toolName, checkbox) in toolCheckBoxes) {
+            checkbox.isSelected = settings.isToolEnabled(toolName)
+        }
+    }
+
+    override fun disposeUIResources() {
+        panel = null
+        toolCheckBoxes.clear()
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolRegistry.kt
@@ -179,7 +179,7 @@ class ToolRegistry {
 
     /**
      * Gets ALL tool definitions regardless of enabled/disabled state.
-     * Used by settings UI to display all available tools.
+     * Used by settings UI to display all exposed tools.
      *
      * @return List of all tool definitions
      */

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -158,6 +158,7 @@ for detailed documentation and examples.</p>
         <!-- Settings -->
         <applicationService serviceImplementation="com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings"/>
         <applicationConfigurable id="mcp.settings" parentId="tools" displayName="Index MCP Server" instance="com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettingsConfigurable"/>
+        <applicationConfigurable id="mcp.settings.tools" parentId="mcp.settings" displayName="Exposed Tools" instance="com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpToolsConfigurable"/>
 
         <!-- Startup Activity -->
         <postStartupActivity implementation="com.github.hechtcarmel.jetbrainsindexmcpplugin.startup.McpServerStartupActivity"/>

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -94,7 +94,7 @@ especially on large repositories.<br><br>\
 <b>Only enable if:</b> Rename/find-usages is missing references in files<br>\
 that were just created by external tools (like Claude Code's write command).<br><br>\
 <b>Recommended:</b> Keep disabled. Most use cases don't require this.</html>
-settings.tools.title=Available Tools (uncheck to disable)
+settings.tools.title=Exposed Tools (uncheck to disable)
 settings.exposedTools.title=Exposed Tools
 
 # Agent Rule Tip

--- a/src/main/resources/messages/McpBundle.properties
+++ b/src/main/resources/messages/McpBundle.properties
@@ -95,6 +95,7 @@ especially on large repositories.<br><br>\
 that were just created by external tools (like Claude Code's write command).<br><br>\
 <b>Recommended:</b> Keep disabled. Most use cases don't require this.</html>
 settings.tools.title=Available Tools (uncheck to disable)
+settings.exposedTools.title=Exposed Tools
 
 # Agent Rule Tip
 tip.agentRule.text=Tip: Copy this rule to your CLAUDE.md/AGENTS.md/.cursorrules file.

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -28,7 +28,7 @@ If both `mcp__intellij-index__*` (this plugin) and `mcp__intellij__*` (JetBrains
 | Build | `ide_build_project` (this plugin, disabled by default — returns structured errors/warnings); `mcp__intellij__*` only when it is not enabled |
 | Terminal, run non-test processes, formatting beyond code style | `mcp__intellij__*` only |
 
-**Always use `mcp__intellij-index__` for code intelligence. At least one project must be open in IntelliJ. If your target project is not open but another one is, call `ide_open_project` with the working directory path — note it is disabled by default and must be enabled in Settings > Tools > Index MCP Server, and it requires at least one project to already be open (as the JSON-RPC context). IntelliJ does NOT require `.idea` to exist — it opens any directory and creates its own project configuration. Only ask the user to open a project manually when zero projects are open or `ide_open_project` is disabled.** Do not fall back to bash for semantic operations — IDE tools understand types, references, and inheritance; grep does not.
+**Always use `mcp__intellij-index__` for code intelligence. At least one project must be open in IntelliJ. If your target project is not open but another one is, call `ide_open_project` with the working directory path — note it is disabled by default and must be enabled in Settings → Tools → Index MCP Server → Exposed Tools, and it requires at least one project to already be open (as the JSON-RPC context). IntelliJ does NOT require `.idea` to exist — it opens any directory and creates its own project configuration. Only ask the user to open a project manually when zero projects are open or `ide_open_project` is disabled.** Do not fall back to bash for semantic operations — IDE tools understand types, references, and inheritance; grep does not.
 
 ## Core Rule
 
@@ -163,7 +163,7 @@ When working in a git worktree (e.g., `/project/.claude/worktrees/agent-xyz` or 
 
 ## Lifecycle Management
 
-When multiple projects are open simultaneously, the lifecycle manager sleeps and wakes them based on window focus and MCP activity. It is opt-in and disabled by default — enable "Enable lifecycle management" in Settings > Tools > Index MCP Server. Once enabled, projects enroll automatically on first MCP use.
+When multiple projects are open simultaneously, the lifecycle manager sleeps and wakes them based on window focus and MCP activity. It is opt-in and disabled by default — enable "Enable lifecycle management" in Settings → Tools → Index MCP Server. Once enabled, projects enroll automatically on first MCP use.
 
 **States:** `active` (full IDE) → `background` (Power Save on) → `dormant` (editors closed, PSI cache freed) → `closed` (fully unloaded). Projects auto-reopen transparently when an MCP tool targets a closed project.
 
@@ -175,7 +175,7 @@ All lifecycle action tools are disabled by default:
 
 ## Disabled-by-Default Tools
 
-These tools exist but are disabled by default. They are omitted from `tools/list`, and direct `tools/call` requests are rejected until the user enables them in IDE settings (Settings > Tools > Index MCP Server):
+These tools exist but are disabled by default. They are omitted from `tools/list`, and direct `tools/call` requests are rejected until the user enables them in IDE settings (Settings → Tools → Index MCP Server → Exposed Tools):
 
 `ide_build_project`, `ide_change_signature`, `ide_close_project`, `ide_convert_java_to_kotlin`, `ide_create_file`, `ide_create_module`, `ide_edit_member`, `ide_enroll_all_projects`, `ide_file_structure`, `ide_find_symbol`, `ide_get_active_file`, `ide_get_project_modes`, `ide_import_modules`, `ide_insert_member`, `ide_install_plugin`, `ide_lifecycle_log`, `ide_link_build_system`, `ide_list_tests`, `ide_open_file`, `ide_open_project`, `ide_open_workspace`, `ide_optimize_imports`, `ide_project_diagnostics`, `ide_read_file`, `ide_reformat_code`, `ide_release_all_projects`, `ide_release_project`, `ide_reload_project`, `ide_replace_member`, `ide_replace_text_in_file`, `ide_restart`, `ide_run_tests`, `ide_set_all_project_modes`, `ide_set_lifecycle_log_file`, `ide_set_power_save_mode`, `ide_set_project_mode`, `ide_structural_search_replace`, `ide_symbol_info`
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpToolsConfigurableTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpToolsConfigurableTest.kt
@@ -1,0 +1,138 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.settings
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.openapi.options.Configurable
+import com.intellij.ui.components.JBCheckBox
+
+/**
+ * Drives the real [McpToolsConfigurable] the same way the settings dialog does
+ * (createComponent -> reset -> apply/reset -> disposeUIResources), with the server
+ * service initialized so the tool list is populated.
+ */
+class McpToolsConfigurableTest : McpPlatformTestCase() {
+
+    private lateinit var originalSettings: McpSettings.State
+
+    override fun setUp() {
+        super.setUp()
+        McpServerService.getInstance().initialize()
+        originalSettings = McpSettings.getInstance().state.copy(
+            disabledTools = McpSettings.getInstance().state.disabledTools.toMutableSet()
+        )
+    }
+
+    override fun tearDown() {
+        try {
+            McpSettings.getInstance().loadState(originalSettings)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testComponentShowsCheckboxForEveryRegisteredTool() {
+        val allTools = McpServerService.getInstance().getToolRegistry()
+            .getAllToolDefinitions().sortedBy { it.name }
+        assertTrue("the tool registry must expose tools for the settings page to list", allTools.isNotEmpty())
+
+        withConfigurable { configurable ->
+            val checkboxes = readField<Map<String, JBCheckBox>>(configurable, "toolCheckBoxes")
+            assertEquals(
+                "the page must list every registered tool exactly once",
+                allTools.map { it.name }.toSet(),
+                checkboxes.keys
+            )
+
+            val settings = McpSettings.getInstance()
+            for (tool in allTools) {
+                val checkbox = checkboxes.getValue(tool.name)
+                assertEquals(tool.name, checkbox.text)
+                assertEquals(tool.description, checkbox.toolTipText)
+                assertEquals(settings.isToolEnabled(tool.name), checkbox.isSelected)
+            }
+        }
+    }
+
+    fun testCheckboxesAreListedSortedByName() {
+        val expected = McpServerService.getInstance().getToolRegistry()
+            .getAllToolDefinitions().map { it.name }.sorted()
+
+        withConfigurable { configurable ->
+            val checkboxes = readField<Map<String, JBCheckBox>>(configurable, "toolCheckBoxes")
+            assertEquals("tools must be listed in sorted order", expected, checkboxes.values.map { it.text })
+        }
+    }
+
+    fun testIsModifiedReflectsCheckboxState() {
+        withConfigurable { configurable ->
+            assertFalse("a freshly reset page must not report modifications", configurable.isModified())
+
+            val checkboxes = readField<Map<String, JBCheckBox>>(configurable, "toolCheckBoxes")
+            val checkbox = checkboxes.values.first()
+            checkbox.isSelected = !checkbox.isSelected
+
+            assertTrue("toggling a checkbox must mark the page modified", configurable.isModified())
+
+            configurable.reset()
+            assertFalse("reset must restore checkboxes from settings", configurable.isModified())
+        }
+    }
+
+    fun testApplyPersistsToggleThroughRealMcpSettings() {
+        val settings = McpSettings.getInstance()
+        val toolName = McpServerService.getInstance().getToolRegistry().getAllToolDefinitions().first().name
+        val enabledBefore = settings.isToolEnabled(toolName)
+
+        withConfigurable { configurable ->
+            val checkboxes = readField<Map<String, JBCheckBox>>(configurable, "toolCheckBoxes")
+            checkboxes.getValue(toolName).isSelected = !enabledBefore
+
+            configurable.apply()
+
+            assertEquals(
+                "apply must persist the toggle into real McpSettings",
+                !enabledBefore,
+                settings.isToolEnabled(toolName)
+            )
+            assertFalse("apply must leave the page unmodified", configurable.isModified())
+
+            configurable.reset()
+            assertEquals(
+                "reset must reload checkboxes from the applied settings",
+                !enabledBefore,
+                checkboxes.getValue(toolName).isSelected
+            )
+        }
+    }
+
+    fun testChildRegisteredUnderMcpSettingsParentInPluginXml() {
+        val eps = Configurable.APPLICATION_CONFIGURABLE.extensionList
+        val child = eps.firstOrNull { it.id == "mcp.settings.tools" }
+        assertNotNull("the Exposed Tools page must be registered in plugin.xml", child)
+        assertEquals("the Exposed Tools page must be nested under the main page", "mcp.settings", child!!.parentId)
+        assertEquals(
+            "the Exposed Tools page must be backed by McpToolsConfigurable",
+            McpToolsConfigurable::class.java.name,
+            child.instanceClass
+        )
+        assertNotNull("the main settings page registration must remain", eps.firstOrNull { it.id == "mcp.settings" })
+    }
+
+    private fun withConfigurable(block: (McpToolsConfigurable) -> Unit) {
+        val configurable = McpToolsConfigurable()
+        try {
+            configurable.createComponent()
+            configurable.reset()
+            block(configurable)
+        } finally {
+            configurable.disposeUIResources()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> readField(configurable: McpToolsConfigurable, name: String): T {
+        val field = McpToolsConfigurable::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(configurable) as T
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpToolsConfigurableUninitializedTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpToolsConfigurableUninitializedTest.kt
@@ -1,0 +1,79 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.settings
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Covers the "Server is initializing..." guard branch. The service singleton is app-level
+ * and outlives any one test class, so the uninitialized state is forced via reflection and
+ * restored afterwards — no public API un-initializes the service.
+ */
+class McpToolsConfigurableUninitializedTest : McpPlatformTestCase() {
+
+    fun testShowsInitializingGuardWithoutServer() {
+        val service = McpServerService.getInstance()
+        val wasInitialized = setServiceInitialized(service, false)
+        try {
+            withConfigurable { configurable ->
+                val panel = readField<JPanel>(configurable, "panel")
+                assertNotNull(
+                    "the page must show the initializing guard",
+                    findLabel(panel, "Server is initializing...")
+                )
+                assertTrue(
+                    "no tool checkboxes may exist before the server is initialized",
+                    readField<Map<String, JBCheckBox>>(configurable, "toolCheckBoxes").isEmpty()
+                )
+                assertFalse(configurable.isModified())
+
+                configurable.apply()
+                configurable.reset()
+            }
+        } finally {
+            setServiceInitialized(service, wasInitialized)
+        }
+    }
+
+    private fun setServiceInitialized(service: McpServerService, initialized: Boolean): Boolean {
+        val field = McpServerService::class.java.getDeclaredField("isInitialized")
+        field.isAccessible = true
+        val previous = field.getBoolean(service)
+        field.setBoolean(service, initialized)
+        return previous
+    }
+
+    private fun findLabel(root: JComponent, text: String): JBLabel? {
+        val queue = ArrayDeque<JComponent>()
+        queue.add(root)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (current is JBLabel && current.text == text) return current
+            for (i in 0 until current.componentCount) {
+                (current.getComponent(i) as? JComponent)?.let { queue.add(it) }
+            }
+        }
+        return null
+    }
+
+    private fun withConfigurable(block: (McpToolsConfigurable) -> Unit) {
+        val configurable = McpToolsConfigurable()
+        try {
+            configurable.createComponent()
+            configurable.reset()
+            block(configurable)
+        } finally {
+            configurable.disposeUIResources()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> readField(configurable: McpToolsConfigurable, name: String): T {
+        val field = McpToolsConfigurable::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(configurable) as T
+    }
+}


### PR DESCRIPTION
## Summary

Moves the "Available Tools (uncheck to disable)" checkbox list off the main settings page onto a new child page at Settings → Tools → Index MCP Server → **Exposed Tools**.

- New `McpToolsConfigurable` child page registered in `plugin.xml` under `mcp.settings`, holding the per-tool checkboxes, tooltips, and the "Server is initializing..." guard exactly as before
- `McpSettingsConfigurable` keeps the server host/port, history, projects mode, response format, sync, and lifecycle sections unchanged
- No stored state changes — existing per-tool enable/disable settings carry over untouched
- New platform tests cover the initialized and uninitialized-server paths
- Docs updated: CHANGELOG, README, `docs/mcp-kotlin-sdk-migration.md`, `smoke-tests/mcp-protocol.md`

## Why

This plugin now exposes many tools, making the main interface increasingly cluttered. I’ve moved the tools out of the main plugin screen and into a separate page, mirroring the IDE’s own MCP Server settings layout. Possible next steps could be adding categories and displaying the description as a secondary column, similar to the official MCP Server interface.