### PR TITLE
chore: bump pluginVersion to 5.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- **Tool enable/disable moved to a new "Exposed Tools" settings page** — the "Available Tools (uncheck to disable)" checkbox list left the main settings page and now lives on a child page at Settings → Tools → Index MCP Server → Exposed Tools, mirroring the IDE's own MCP Server settings layout. The main page keeps the server host/port, history, projects mode, response format, sync, and lifecycle sections unchanged; the per-tool checkboxes, tooltips, and "Server is initializing..." guard behave exactly as before, and no stored state changes — existing per-tool enable/disable settings carry over untouched.
+- **Tool enable/disable moved to a new "Exposed Tools" settings page** — the "Available Tools (uncheck to disable)" checkbox list left the main settings page and now lives on a child page at Settings → Tools → Index MCP Server → Exposed Tools, mirroring the IDE's own MCP Server settings layout. The main page keeps the server host/port, history, projects mode, response format, sync, and lifecycle sections unchanged; the per-tool checkboxes, tooltips, and "Server is initializing..." guard behave exactly as before, and no stored state changes — existing per-tool enable/disable settings carry over untouched. Every reference to the old location follows the move: the error an MCP client gets when calling a disabled tool, the bundled agent skill, and the docs now all point to the Exposed Tools page.
 
 ## [5.9.2] - 2026-08-29
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.hechtcarmel.jetbrainsindexmcpplugin
 pluginName = IDE Index MCP Server
 pluginRepositoryUrl = https://github.com/hechtcarmel/jetbrains-index-mcp-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 5.9.2
+pluginVersion = 5.9.3
 
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Summary

Prepares the 5.9.3 release carrying the Exposed Tools settings page move (#354):

- `gradle.properties`: `pluginVersion` 5.9.2 → 5.9.3 (patch bump, matching the convention for "Changed"-only releases, cf. 5.8.4)
- `CHANGELOG.md`: extends the existing `[Unreleased]` entry with one sentence noting that every reference to the old location follows the move — the disabled-tool error message MCP clients see, the bundled agent skill, and the docs

No `## [5.9.3]` section is added — the release workflow's `patchChangelog` creates it at publish time.

## Checklist

Every PR must comply with [CONTRIBUTING.md](../CONTRIBUTING.md) — read it first.

- [x] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections)
- [x] `./scripts/check-pr.sh` — all 15 static checks pass; its `./gradlew test` step cannot resolve the IntelliJ platform in the sandbox (proxy 403 on cache-redirector.jetbrains.com), so tests are covered by CI on this PR
- [x] `./gradlew test` — runs in CI on this PR; the diff contains no code (version string + one changelog sentence), and the same code passed the full suite on #354's head
- [x] New tools: none in this PR
- [x] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WM1CEMt2tZ4YGhXBe3Hauk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM1CEMt2tZ4YGhXBe3Hauk)_