### PR TITLE
Restore the 5.9.3 changelog section that unmerged #356 was meant to add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - **`ide_refactor_rename` no longer fails for every Kotlin symbol with "Analysis is not allowed: Called in the EDT thread"** ([#357](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/357)) — the read-only-scope pre-check added for [#310](https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/issues/310) called `RenameProcessor.findUsages()` directly on the EDT. For a Kotlin target that search resolves references through the Kotlin Analysis API, which in K2 mode (the Kotlin plugin's default in current IDEs) forbids resolution on the EDT — so every Kotlin symbol rename failed before touching any file, while Java renames, which never enter the Analysis API, kept working. The pre-check search now runs the way `BaseRefactoringProcessor.run()` runs its own usage search: on a pooled thread under a read action behind the platform's modal progress (and under a plain read action when the caller is already off the EDT). `ide_change_signature` had the same pattern and is fixed the same way — its pre-check search enters the Kotlin Analysis API whenever Kotlin call sites reference the changed Java method. A cancelled pre-check search now fails open (the refactoring proceeds and `run()` repeats the search under its own cancellable progress); read-only files in scope are still reported as an actionable error exactly as before.
 
+## [5.9.3] - 2026-08-31
+
 ### Changed
 
 - **Tool enable/disable moved to a new "Exposed Tools" settings page** — the "Available Tools (uncheck to disable)" checkbox list left the main settings page and now lives on a child page at Settings → Tools → Index MCP Server → Exposed Tools, mirroring the IDE's own MCP Server settings layout. The main page keeps the server host/port, history, projects mode, response format, sync, and lifecycle sections unchanged; the per-tool checkboxes, tooltips, and "Server is initializing..." guard behave exactly as before, and no stored state changes — existing per-tool enable/disable settings carry over untouched. Every reference to the old location follows the move: the error an MCP client gets when calling a disabled tool, the bundled agent skill, and the docs now all point to the Exposed Tools page.
@@ -1215,7 +1217,8 @@
 - **Transport**: HTTP+SSE with JSON-RPC 2.0
 
 [Unreleased]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.9.4...HEAD
-[5.9.4]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.9.2...v5.9.4
+[5.9.4]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.9.3...v5.9.4
+[5.9.3]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.9.2...v5.9.3
 [5.9.2]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.9.1...v5.9.2
 [5.9.1]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.9.0...v5.9.1
 [5.9.0]: https://github.com/hechtcarmel/jetbrains-index-mcp-plugin/compare/v5.8.4...v5.9.0


### PR DESCRIPTION
## Summary

#356 is the bot changelog PR from the 5.9.3 release. It was never merged, so when 5.9.4 was released the next day `patchChangelog` re-scooped the still-`[Unreleased]` 5.9.3 entry together with the 5.9.4 fix, and #359 filed both under `## [5.9.4]`. #356 now conflicts with #359 on the same lines, and even a mechanical resolution would leave an empty `5.9.3` section above `5.9.4` with the Exposed Tools entry still filed under 5.9.4.

This PR replaces #356 with the split the release history actually had:

- `## [5.9.3] - 2026-08-31` inserted between the 5.9.4 **Fixed** block and the Exposed Tools **Changed** entry (tag `5.9.3` = d2db75b already contains #354)
- `[5.9.4]` compare link now spans `5.9.3...5.9.4`, and a `[5.9.3]` link is added

`CHANGELOG.md` is the only file touched.

## Checklist

- [ ] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections) — **deliberately not**: this PR is the release-time bookkeeping that bot PR #356 failed to land, so it adds a `## [5.9.3]` section on purpose
- [ ] `./scripts/check-pr.sh` passes — fails only on the versioned-section rule above, which is expected here; its `./gradlew test` step could not run in the authoring environment because Maven Central rate-limited dependency downloads (HTTP 429)
- [ ] `./gradlew test` passes (full suite, not just `-Ptier=unit`) — not runnable in the authoring environment for the same reason; CI on this PR is the verification
- [x] New tools (if any): none
- [x] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MumzrTShN6dvHBgHBXHts

---
_Generated by [Claude Code](https://claude.ai/code/session_013MumzrTShN6dvHBgHBXHts)_