### PR TITLE
Add GitHub Actions workflow for NodeJS with Webpack

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,0 +1,28 @@
+name: NodeJS with Webpack
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Build
+      run: |
+        npm install
+        npx webpack


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Checklist

Every PR must comply with [CONTRIBUTING.md](../CONTRIBUTING.md) — read it first.

- [ ] `CHANGELOG.md` entry added under `[Unreleased]` only (no `## [x.y.z]` version sections)
- [ ] `./scripts/check-pr.sh` passes
- [ ] `./gradlew test` passes (full suite, not just `-Ptier=unit`)
- [ ] New tools (if any): registered in `ToolNames`, `ToolRegistry`, and `McpSettings` (opt-in defaults), documented in all six doc locations, and the golden tool manifest regenerated with its diff reviewed
- [ ] No forbidden files (`.idea/gradle.xml`, `scripts/build-install.sh`, `docs/pr-*.md`)
