### PR TITLE
Add semantic handles and refactoring previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Opaque, server-owned `symbolId` handles for semantic navigation and refactoring** — symbol/class search, definition, references, symbol info, implementations, and hierarchy results now expose reusable IDs backed by IntelliJ `SmartPsiElementPointer`s. Symbol-targeting semantic and refactoring tools accept the ID instead of coordinates, preserve or replace it with current `updatedSymbol` metadata after a refactoring, and explicitly invalidate it after safe delete. Handles are scoped to the exact open project and MCP server generation, bounded by a 4,096-entry access-order LRU and a one-hour inactivity TTL; deleted/unrestorable PSI returns `SYMBOL_ID_EXPIRED` without selecting a nearby declaration. The handle is intentionally non-canonical: one PSI declaration may have several unequal, simultaneously valid IDs, while reusing one concrete ID remains stable across line shifts and rename.
+- **Additive structured targets** — target-aware semantic and refactoring tools accept exactly one nested `target` variant: `{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`. Runtime validation rejects mixed/ambiguous selectors, the dispatcher routes by nested `target.symbolId`, and all legacy top-level selectors remain supported.
+- **Non-mutating refactoring previews** — `ide_refactor_rename`, `ide_refactor_safe_delete`, and `ide_change_signature` accept `dryRun: true` and return a common contract with applicability, current target metadata, the planned change, estimated affected files, usage/conflict counts, warnings, and elapsed time. Preview performs resolution and conflict discovery without entering the refactoring/source-write phase, saving documents, mutating source, or creating an undo command.
+- **Bounded hierarchy pagination** — type and call hierarchy tools enforce `maxNodes` during deterministic breadth-first traversal and return `returnedNodes`, `truncated`, `elapsedMs`, `hasMore`, and an opaque `cursor`. Continuation frontiers are smart-pointer backed, scoped to the exact session/project, and kept in an independent cache of at most 128 snapshots with a ten-minute inactivity TTL; pages are the progress contract for stateless HTTP. Type hierarchy keeps the legacy `supertypes`/`subtypes` arrays and adds `traversal: [{direction, element}]` so the combined BFS order is observable without breaking existing clients.
+- **Structured file outlines** — `ide_file_structure` preserves the formatted `structure` string and adds `nodes` with name, semantic kind, signature, modifiers, source range, children, and an optional `symbolId` bound to the exact extracted PSI element.
+- **Multi-file `ide_diagnostics`** — a non-empty `files` array (up to 100 supplied paths, with lexical aliases analyzed only once) is available as an alternative to `file`. All requested files share one analysis deadline, problems are aggregated, and `fileAnalyses` reports mode/freshness/timeout/message metadata for every analyzed path; location filters and intentions remain single-file only.
+
+### Changed
+
+- **Bounded cache retention and maintenance** — symbol lookup avoids linear scans and expiry is amortized; symbol/hierarchy caches clean idle state on a schedule and drop closed projects promptly. Hierarchy history shares persistent storage, keeps at most ten snapshots per traversal, reuses retained successor cursors on retries, and enforces global pointer/text budgets with eviction counters. Existing one-hour symbol and ten-minute cursor idle TTLs remain unchanged.
+- **Fresh MCP schemas publish the new contracts** — semantic/refactoring schemas expose `symbolId` and structured `target`, and all three previewable refactorings expose `dryRun`. The protocol contract covers a fresh `initialize` → `tools/list`. The server continues to advertise `tools.listChanged: false`; after a plugin update, reconnect/restart MCP clients such as Codex because their `ALL_TOOLS` registry may be cached for the connection.
+
+### Fixed
+
+- **Exact member identity after full replacement** — replacement content is validated before editing; comments, malformed content, or multiple declarations cannot rebind a method handle to its containing class. Only the verified replacement receives the old handle, which is invalidated if exact restoration fails.
+- **Hierarchy pages preserve valid handles and distinct declarations** — every returned page refreshes root/node handles, anonymous/local declarations no longer collapse by name, and Java/Python scope/generated filters run before result limits.
+- **Large outlines do not evict their own handles** — the complete outline remains available while handle allocation is capped at 500 eligible nodes, with explicit `symbolIdsTruncated`/`symbolIdsOmitted` metadata.
+- **Diagnostics disclose response-cap omissions** — aggregate and per-file `problemsTruncated`, per-file returned counts, and retry guidance distinguish hidden problems from a clean file after the shared 100-problem limit, independently of freshness/timeouts.
+- **Kotlin class metadata is semantic** — interfaces, classes, enum classes, annotation classes, and objects are distinguished from Kotlin PSI flags instead of implementation class names. Qualified names use the shared Kotlin-aware `PsiUtils.qualifiedName` path. Anonymous implementations now receive a readable base-type/location name and keep `qualifiedName: null`.
+- **Targeted sync notices deleted paths** — `ide_sync_files` refreshes the nearest existing parent of a requested path that was deleted outside the IDE and separately reports requested paths, actual refresh roots, and deleted paths. The complete batch is constrained to project/content roots and rejects absolute, traversal, and symlink escapes.
+- **MCP server startup on current 2025.3 IDE builds** — the loopback origin guard no longer links against Ktor's private static `HttpMethod.Get`/`Options` fields, which caused an `IllegalAccessError` and left the tool window at “MCP Server Initializing…” with no HTTP endpoint.
+
 ## [5.9.5] - 2026-09-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,7 @@ Three tiers, selected by class-name suffix:
      schema into `src/test/resources/contract/tool-manifest.json`. This is the regression net
      for large refactors: one assertion covers every registered tool × every schema property, so
      a dropped `register(...)` call or a mutated parameter type fails here instead of shipping.
-     Scope: 49 of the 52 tools in `ToolNames.ALL` (the three needing the Kotlin or Maven plugin
+     Scope: 51 of the 54 tools in `ToolNames.ALL` (the three needing the Kotlin or Maven plugin
      are covered by set-equality instead), and **inputs only**.
    - `ResultShapeContractUnitTest` snapshots the other half of the client contract — the response
      side — into `src/test/resources/contract/result-shapes.txt`: the wire key set, JSON value
@@ -502,7 +502,7 @@ Tools are organized by IDE availability.
 - `ide_find_symbol` - Search for symbols (classes, methods, fields, functions) by name with IntelliJ Go to Symbol matching (disabled by default)
 - `ide_search_text` - Text search using IntelliJ Find in Files with context filtering (substring matching for plain text, regex matching when enabled). Optional `paths` restricts the search to project-relative globs (`!` prefix excludes)
 - `ide_read_file` - Read file content by path or qualified name, including library/jar sources (disabled by default)
-- `ide_diagnostics` - Unified diagnostics tool: per-file code analysis (errors, warnings, intentions), build output from last build, and test results from open test run tabs. Supports `includeBuildErrors`, `includeTestResults`, `severity` filter, `testResultFilter`, `maxBuildErrors`, `maxTestResults`. The `file` parameter is now optional. The result's `analysisMode` reports which path produced file problems: `open_daemon` or `closed_batch`. The analyzed file is refreshed from disk and committed to PSI first, so an out-of-band edit is analyzed as written without an `ide_sync_files` call.
+- `ide_diagnostics` - Unified diagnostics tool: per-file code analysis (errors, warnings, intentions), build output from last build, and test results from open test run tabs. Supports one `file` or up to 100 unique `files` under a shared timeout budget, plus `includeBuildErrors`, `includeTestResults`, `severity`, `testResultFilter`, `maxBuildErrors`, and `maxTestResults`. The result's `analysisMode` reports which path produced single-file problems (`open_daemon` or `closed_batch`); multi-file calls use `fileAnalyses`. The analyzed files are refreshed from disk and committed to PSI first, so an out-of-band edit is analyzed as written without an `ide_sync_files` call.
 - `ide_project_diagnostics` - Batch/project-scope diagnostics for many files including unopened ones, with fail-closed coverage metadata (issue #246): every file in scope gets exactly one state (`analyzed`/`timed_out`/`failed`/`skipped`/`not_analyzed`) and `complete` is true only when every considered file was analyzed, so an empty problems list can never be mistaken for a clean project. Reuses the per-file analysis engine (open files get daemon highlights, closed files the public batch pass). Long analyses long-poll via `analysisId` (same pattern as `ide_build_project`); one analysis per project at a time. (disabled by default)
 - `ide_index_status` - Check indexing status (dumb/smart mode)
 - `ide_sync_files` - Force sync IDE's virtual file system and PSI cache with external file changes
@@ -628,6 +628,93 @@ The plugin supports cursor-based pagination for search tools that return flat re
 **Schema:** All parameters are optional in the schema (no `required` array) because the Anthropic API does not support `anyOf`/`oneOf` at the top level. Validation is done at runtime — if `cursor` is absent, the tool checks for its required search params and returns an error if missing.
 
 **Backward compatibility:** Old `limit`/`maxResults` parameters work as aliases for `pageSize`. Legacy cursors (without embedded pageSize) are still decodable but require an explicit `pageSize` parameter.
+
+### Opaque Symbol IDs
+
+Semantic discovery results carry a `symbolId` backed by a server-side
+`SmartPsiElementPointer`. The token itself is opaque and contains no path, offset, name, or
+project data. Prefer it to coordinates when chaining `ide_find_references`,
+`ide_find_definition`, `ide_symbol_info`, hierarchy/implementation tools, and symbol-oriented
+refactorings; it disambiguates overloads and local declarations and follows ordinary source
+movement.
+
+The ID is deliberately a non-canonical session handle: binding one PSI declaration more than once
+may yield several unequal handles that are all valid simultaneously. Never use ID equality as
+symbol equality. Reusing one concrete handle remains stable across line shifts and rename while it
+is still inside the session/project/TTL/LRU bounds.
+
+`SymbolIdRegistry` is an application service owned by the running MCP server generation. It is
+access-order LRU bounded (4,096 entries), expires entries after one hour of inactivity, keys them
+to the exact `Project` object identity, and is cleared on MCP server stop/restart. It stores no
+fallback query. A missing, evicted, wrong-project, deleted, or otherwise unrestorable pointer must
+return `SYMBOL_ID_EXPIRED` — never resolve by saved coordinates or choose a nearby PSI element.
+Keep lookup O(1) without promoting rejected lookups. Successful access promotes entries;
+expiry work is amortized rather than scanning all handles on every bind. Both symbol and hierarchy
+registries sweep every five minutes and remove closed-project state through lifecycle listeners.
+Maintain lock order `McpServerEpoch` then registry monitor; maintenance/stats must never invert it.
+After a successful symbol refactoring, return `updatedSymbol` with current metadata and the same
+ID when it can be rebound (otherwise a new ID); safe delete returns `invalidatedSymbolId`.
+Full member replacement must validate a single declaration in a nonphysical PSI copy before
+editing, then rebind only the exact committed replacement. Never restore an ID from the old
+offset or a containing declaration; invalidate it if exact post-edit restoration fails.
+
+Target-aware semantic/refactoring tools additionally accept exactly one nested `target` variant:
+`{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`. Runtime normalization
+maps it to the legacy selectors; nested and top-level selectors must not be mixed. The dispatcher
+must inspect `target.symbolId` when routing a request to an owning project. Keep legacy top-level
+selectors for compatibility.
+
+After a plugin install/update and IDE reload, reconnect or restart the MCP client. Clients such as
+Codex cache `ALL_TOOLS`; an existing connection can therefore retain old schemas. Keep
+`ServerCapabilities.Tools.listChanged=false` until every server transport can actually publish and
+serve tool-list change notifications.
+
+Refactoring preview is one shared wire contract for rename, safe delete, and change signature.
+With `dryRun=true`, perform target resolution, validation, usage/conflict discovery, and affected
+file estimation, then return `RefactoringPreviewResult`. Do not enter the refactoring/source-write
+phase, call document save APIs, run the mutating processor phase, or register an undo command.
+Tests must compare every fixture file byte-for-byte before and after the preview.
+
+Hierarchy traversal belongs to the tools, not recursive language-handler collection. Request one
+edge at a time and emit deterministic breadth-first pages, enforcing `maxNodes` while nodes are
+returned and expanded. Continuations are separate from ordinary search pagination: keep a
+session/project-bound smart-pointer frontier with its own 128-snapshot cache and ten-minute inactivity
+TTL, and return `returnedNodes`, `truncated`, `elapsedMs`, `hasMore`, and `cursor`. Use persistent
+history collections shared between pages, retain at most ten snapshots per traversal, and prefer
+evicting old replay snapshots over current frontiers. Aggregate budgets are 163,840 pointer slots
+and 10,240,000 characters (visited keys plus snapshot text), conservatively summed per snapshot;
+these are retention weights, not measured heap bytes. Internal read-only `stats()` snapshots
+report occupancy, hits/misses, eviction reasons, and weights without extending TTL. TTL defaults
+are compatibility bounds, not a measured optimum; tune them from observed workloads.
+Root and disclosed node handles must be rebound on every page, including unchanged PSI and retries;
+do not allocate handles for undisclosed frontier nodes. Keep exact live-pointer identity for the
+accepted traversal, including local/anonymous declarations; never silently truncate its history.
+Call hierarchy defaults to 20 nodes on a fresh request and 100 with a cursor; type hierarchy defaults
+to 100 throughout. Type hierarchy
+must additionally retain the legacy `supertypes`/`subtypes` arrays and emit
+`traversal: [{direction, element}]` in the exact combined wire/BFS order; clients cannot reconstruct
+that order by concatenating the direction-specific arrays. Do not advertise live progress on the
+stateless HTTP transport.
+
+`ide_diagnostics` keeps the single-`file` response compatible and accepts up to 100 unique `files`
+as an exclusive alternative. A multi-file request has one shared deadline, one aggregate `problems` list, and one
+`FileDiagnosticsAnalysis` per requested path. Code problems share a 100-item response cap: collect
+one extra matching problem as lookahead, expose aggregate/per-file `problemsTruncated`, and report
+per-file returned `problemCount`. Probe even files reached after the cap so hidden problems are
+explicit; freshness and timeouts are independent of output truncation. Location/intention fields
+remain single-file only.
+For targeted VFS sync, validate the whole batch inside the selected base/content root before
+refreshing anything. A deleted target refreshes its nearest existing parent; expose requested,
+actually refreshed, and deleted paths separately, and reject traversal/absolute/symlink escapes.
+
+`ide_file_structure.structure` is compatibility output and must remain. Build `nodes` from the
+exact extracted PSI elements and bind `symbolId` there; never reconstruct node identity from a line
+number. Preserve the complete outline but bind at most `MAX_PAGE_SIZE` (500) eligible nodes in
+preorder per response, reporting `symbolIdsTruncated` and `symbolIdsOmitted`. Kotlin class kind comes
+from semantic Kt PSI flags (`INTERFACE`, `CLASS`, `ENUM`,
+`ANNOTATION`, `OBJECT`), and qualified names go through `PsiUtils.qualifiedName`. Anonymous
+implementations use `<anonymous implementation of Base at File.kt:line>` and keep
+`qualifiedName=null`.
 
 ### Search Collection Pattern (Processor)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,8 +452,9 @@ call sites". It is thin in these areas:
   most for `ide_reformat_code` and `ide_optimize_imports`.
 - **Reflection-based language handlers are largely unverified.** Python, Go, PHP and Rust handlers
   are reached only through reflection against plugins absent from the test classpath. The Python
-  hierarchy and call-hierarchy handlers have no automated coverage at all — verify changes to them
-  in the corresponding IDE by hand.
+  hierarchy and native caller lookup still need verification in the corresponding IDE. The
+  post-native caller collection path has neutral-PSI regression fixtures for scope filtering,
+  limits, and declaration identity; these do not exercise the Python plugin's reflection API.
 - **No test exercises real Kotlin PSI.** The Kotlin plugin is not on the test classpath, so every
   Kotlin-specific code path — light-class handling in `JavaHandlers.kt`, `KtProperty` resolution in
   `JavaSymbolReferenceHandler`, the Kotlin branches of the refactoring tools — is covered only by

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Download the [latest release](https://plugins.jetbrains.com/plugin/29174-ide-ind
 4. **Use the tool window** (bottom panel: "Index MCP Server") to copy configuration or monitor commands
 5. **Change port** (optional): Click "Change port, disable tools" in the toolbar or go to <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd>
 
+> **After installing or updating the plugin:** reconnect or restart the MCP client after the IDE
+> loads the new plugin. Clients such as Codex cache their `ALL_TOOLS` registry, so an existing
+> connection can keep an older schema even though a fresh `tools/list` is correct. The server
+> deliberately advertises `listChanged: false` until notifications work on every transport.
+
 ### Using the "Install on Coding Agents" Button
 
 The easiest way to configure your AI assistant:
@@ -258,7 +263,84 @@ Each JetBrains IDE has a unique default port and server name to allow running mu
 
 ## Exposed Tools
 
-The plugin provides **52 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd> > <kbd>Exposed Tools</kbd>.
+The plugin provides **54 MCP tools** organized by availability. Tools marked *(disabled by default)* can be enabled in <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Index MCP Server</kbd> > <kbd>Exposed Tools</kbd>.
+
+### Opaque symbol handles
+
+Semantic discovery results include an opaque `symbolId`. Pass that ID back instead of
+`file` + `line` + `column` (or `language` + `symbol`) to target the exact declaration in
+`ide_find_references`, `ide_find_definition`, `ide_symbol_info`, the hierarchy tools, and
+symbol-oriented refactorings (`ide_refactor_rename`, `ide_change_signature`,
+`ide_edit_member`, `ide_replace_member`, and `ide_refactor_safe_delete`). This is especially
+useful for overloads and local symbols. Reusing a particular handle remains stable when edits move
+the declaration to another line or rename it.
+
+The ID contains no file path or symbol data. The running MCP server keeps an IntelliJ
+`SmartPsiElementPointer` in a 4,096-entry access-order LRU with a one-hour inactivity TTL. IDs
+belong to one exact project instance and are cleared whenever the MCP server restarts. If the
+file/declaration was deleted, the pointer can no longer be restored, the ID expired, or it came
+from another project/server session, the tool returns `SYMBOL_ID_EXPIRED`; it never guesses a
+nearby element. Successful refactorings return `updatedSymbol` (including the retained or
+replacement ID and current metadata); safe delete returns `invalidatedSymbolId`.
+
+`symbolId` is a session handle, not a canonical symbol identity. Binding the same PSI declaration
+twice may produce two different IDs that remain valid at the same time. Never compare IDs to decide
+whether two results represent the same declaration; compare semantic metadata or resolve them.
+
+Target-aware semantic and symbol-refactoring tools also accept an additive structured selector.
+Exactly one nested variant is allowed, and `target` cannot be mixed with legacy top-level selectors
+(including tool-specific selectors such as `className`):
+
+```json
+{ "target": { "symbolId": "sym_..." } }
+{ "target": { "position": { "file": "src/Foo.kt", "line": 12, "column": 9 } } }
+{ "target": { "qualifiedName": "com.example.Foo#bar", "language": "Kotlin" } }
+```
+
+Existing top-level `symbolId`, `file`/`line`/`column`, and `language`/`symbol` requests remain
+supported.
+
+### Safe previews and bounded semantic results
+
+`ide_refactor_rename`, `ide_refactor_safe_delete`, and `ide_change_signature` accept
+`dryRun: true`. A preview resolves and validates the same target, searches usages and conflicts,
+and returns `dryRun`, `canApply`, current target metadata, `plannedChange`, `affectedFiles`, usage
+and conflict counts, warnings, and `elapsedMs`. It never enters the refactoring/source-write phase,
+saves documents, or adds an undo command, so callers can inspect the plan before sending the same
+request without `dryRun`.
+
+The hierarchy tools apply `maxNodes` while traversing, not after constructing the full graph. They
+return deterministic breadth-first pages with `returnedNodes`, `truncated`, `hasMore`, `cursor`,
+and `elapsedMs`. Cursors are opaque, bound to the current MCP session and exact project, and backed
+by a separate cache capped at 128 snapshots, ten per traversal, with a ten-minute inactivity TTL
+and aggregate pointer/text budgets. Eviction prefers old replay snapshots to current frontiers.
+Returned root/node handles are rebound on every page, even when PSI is unchanged. The stateless
+HTTP transport does not provide reliable live progress; consume pages until `hasMore` is false.
+
+Type-hierarchy pages retain the legacy direction-specific `supertypes` and `subtypes` arrays and
+also expose `traversal: [{direction, element}]`. Use `traversal` when the exact combined BFS order
+matters; `direction` is `supertype` or `subtype`. Existing clients can continue reading the two
+legacy arrays unchanged.
+
+`ide_diagnostics` accepts either one `file` or a non-empty `files` array. Multi-file analysis uses
+one shared timeout budget, aggregates problems, and reports `mode`, `fresh`, `timedOut`, and
+`message` for every requested file in `fileAnalyses`; location filters and intention lookup remain
+single-file only. Code problems share a 100-item response cap. `problemsTruncated` marks omitted
+problems, and each `fileAnalyses` entry reports its returned `problemCount` and `problemsTruncated`.
+Freshness is not completeness: re-query truncated files individually, with narrower line ranges
+if necessary. `ide_sync_files` can target paths that have already been deleted: it refreshes the
+nearest existing parent inside the selected project/content root and reports `requestedPaths`,
+actual `refreshedRoots`, and `deletedPaths`. Absolute paths, traversal, and symlink escapes are
+rejected.
+
+`ide_file_structure` keeps its original formatted `structure` string and also returns structured
+`nodes`. Each node contains `name`, `kind`, `signature`, `modifiers`, `line`, `endLine`, `children`,
+and a nullable `symbolId` bound directly to that PSI element. Kotlin class metadata distinguishes
+interfaces, classes, enums, annotations, and objects semantically and uses Kotlin fully qualified
+names when available. All outline nodes are retained, but at most 500 receive handles per response;
+`symbolIdsTruncated` and `symbolIdsOmitted` report handle-budget omissions. Anonymous implementations
+have a readable location-based name such as
+`<anonymous implementation of SomeInterface at File.kt:42>` and `qualifiedName: null`.
 
 ### Universal Tools
 
@@ -266,17 +348,17 @@ These tools work in all supported JetBrains IDEs.
 
 | Tool | Description |
 |------|-------------|
-| `ide_find_references` | Find all references to a symbol across the entire project, optionally restricted to path globs via `paths` |
-| `ide_find_definition` | Find the definition/declaration location of a symbol |
-| `ide_symbol_info` | Resolved signature and documentation for the symbol at a position — parameter and return types expanded to fully qualified names (Java), structured `parameters`, modifiers, containing declaration, and the doc comment as plain text, without reading the file *(disabled by default)* |
-| `ide_find_class` | Search for classes/interfaces by name with camelCase/substring/wildcard matching |
+| `ide_find_references` | Find all references to a symbol across the entire project, optionally restricted to path globs via `paths`; accepts `symbolId` |
+| `ide_find_definition` | Find the definition/declaration location of a symbol; returns and accepts `symbolId` |
+| `ide_symbol_info` | Resolved signature and documentation for a symbol, addressable by `symbolId` or position — parameter and return types expanded to fully qualified names (Java), structured `parameters`, modifiers, containing declaration, and the doc comment as plain text, without reading the file *(disabled by default)* |
+| `ide_find_class` | Search for classes/interfaces by name with camelCase/substring/wildcard matching; every result includes `symbolId` |
 | `ide_find_file` | Search for files by name using IDE's file index |
-| `ide_find_symbol` | Search for symbols (classes, methods, fields, functions) by name with IntelliJ Go to Symbol matching *(disabled by default)* |
+| `ide_find_symbol` | Search for symbols (classes, methods, fields, functions) by name with IntelliJ Go to Symbol matching; every result includes `symbolId` *(disabled by default)* |
 | `ide_search_text` | Text search using IntelliJ Find in Files with context filtering (substring and regex matching), optionally restricted to path globs via `paths` |
-| `ide_diagnostics` | Analyze file problems with fresh editor diagnostics for open files or public batch diagnostics for closed files, plus optional build/test results; intentions are best-effort |
+| `ide_diagnostics` | Analyze one `file` or up to 100 unique `files` under one shared timeout budget, with fresh editor diagnostics for open files or public batch diagnostics for closed files, plus optional build/test results; intentions are best-effort and single-file only |
 | `ide_project_diagnostics` | Batch/project-scope diagnostics for many files including unopened ones, with fail-closed coverage metadata: a `complete` flag plus per-file `analyzed`/`timed_out`/`failed`/`skipped`/`not_analyzed` states, so an empty result can never be mistaken for a clean project. Long analyses return an `analysisId` to poll *(disabled by default)* |
 | `ide_index_status` | Check if the IDE is in dumb mode or smart mode |
-| `ide_sync_files` | Force sync IDE's virtual file system and PSI cache with external file changes |
+| `ide_sync_files` | Force sync IDE's virtual file system and PSI cache with external file changes, including deleted targets via their nearest existing parent |
 | `ide_reload_project` | Force-reload Maven or Gradle build model after modifying `pom.xml`/`build.gradle` *(disabled by default)* |
 | `ide_link_build_system` | Link an unlinked Maven/Gradle project for dependency resolution *(disabled by default)* |
 | `ide_import_modules` | Import external Maven project directories as modules into the current IntelliJ window *(disabled by default, requires Maven plugin)* |
@@ -292,17 +374,17 @@ These tools work in all supported JetBrains IDEs.
 | `ide_open_project` | Open a project by absolute path and wait until indexing completes (configurable timeout); returns immediately if already open *(disabled by default)* |
 | `ide_install_plugin` | Install a plugin zip into the IDE, replacing any existing version — auto-detects `build/distributions/*.zip` when no path is given *(disabled by default)* |
 | `ide_restart` | Restart the IDE — terminates the MCP connection; call after `ide_install_plugin` *(disabled by default)* |
-| `ide_refactor_rename` | Rename a symbol or file and update all references across the project (all languages; use `targetType` for explicit file mode) |
+| `ide_refactor_rename` | Preview with `dryRun`, or rename a symbol by `symbolId`/position (or a file) and update all references across the project (all languages; use `targetType` for explicit file mode) |
 | `ide_move_file` | Move a file to a new directory, applying language-aware reference/package updates when the IDE provides a semantic move backend |
 | `ide_reformat_code` | Reformat code using project code style with import optimization *(disabled by default)* |
 | `ide_optimize_imports` | Optimize imports without reformatting code *(disabled by default)* |
 | `ide_structural_search_replace` | Pattern-based code search and transformation using IntelliJ's Structural Search and Replace engine, optionally restricted to path globs via `paths` (Java, Kotlin) *(disabled by default)* |
 | `ide_create_file` | Create a new source file with content, immediately indexed by IntelliJ — use instead of Write for `.java`, `.kt`, `.ts`, `.tsx`, `.py` files *(disabled by default)* |
 | `ide_replace_text_in_file` | Find and replace text in a file using IntelliJ's Document API — changes immediately visible to index and PSI without `ide_sync_files` *(disabled by default)* |
-| `ide_change_signature` | Change method signature with automatic caller updates (Java only) *(disabled by default)* |
-| `ide_edit_member` | Replace an entire member declaration (signature + body) with new content (Java, Kotlin) *(disabled by default)* |
+| `ide_change_signature` | Preview with `dryRun`, or change a method signature by `symbolId` or position with automatic caller updates (Java only) *(disabled by default)* |
+| `ide_edit_member` | Replace an entire member declaration (signature + body) by `symbolId` or member selector (Java, Kotlin) *(disabled by default)* |
 | `ide_insert_member` | Insert a new member at a structural position in a class or file (Java, Kotlin) *(disabled by default)* |
-| `ide_replace_member` | Replace a method body or field initializer only, preserving the signature (Java, Kotlin) *(disabled by default)* |
+| `ide_replace_member` | Replace a method body or field initializer by `symbolId` or member selector, preserving the signature (Java, Kotlin) *(disabled by default)* |
 
 ### Extended Tools (Language-Aware)
 
@@ -310,11 +392,11 @@ These tools activate based on available language plugins:
 
 | Tool | Description | Languages |
 |------|-------------|-----------|
-| `ide_type_hierarchy` | Get the complete type hierarchy (supertypes and subtypes) | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
-| `ide_call_hierarchy` | Analyze method call relationships (callers or callees) | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
-| `ide_find_implementations` | Find all implementations of an interface or abstract method | Java, Kotlin, Python, JS/TS, PHP, Rust |
-| `ide_find_super_methods` | Find the full inheritance hierarchy of methods that a method overrides/implements | Java, Kotlin, Python, JS/TS, PHP |
-| `ide_file_structure` | Get hierarchical file structure (similar to IDE's Structure view) with start and end line numbers for each element *(disabled by default)* | Java, Kotlin, Python, JS/TS, PHP, Markdown |
+| `ide_type_hierarchy` | Get a bounded, cursor-paginated type hierarchy in deterministic breadth-first order, accepting and returning `symbolId` | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
+| `ide_call_hierarchy` | Analyze callers or callees in bounded, cursor-paginated breadth-first order, accepting and returning `symbolId` | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
+| `ide_find_implementations` | Find all implementations of an interface or abstract method, accepting and returning `symbolId` | Java, Kotlin, Python, JS/TS, PHP, Rust |
+| `ide_find_super_methods` | Find the full inheritance hierarchy of methods that a method overrides/implements, accepting and returning `symbolId` | Java, Kotlin, Python, JS/TS, PHP |
+| `ide_file_structure` | Get both the compatible formatted `structure` and structured PSI-bound `nodes` with ranges and optional `symbolId` *(disabled by default)* | Java, Kotlin, Python, JS/TS, PHP, Markdown |
 
 PHP file structure support requires the PHP plugin and is available in PhpStorm or IntelliJ IDEA Ultimate with the PHP plugin enabled.
 
@@ -324,9 +406,10 @@ PHP file structure support requires the PHP plugin and is available in PhpStorm 
 |------|-------------|
 | `ide_list_tests` | List all test methods/classes discovered by the IDE's test framework extension points (JUnit, TestNG, etc.) *(disabled by default, requires Java plugin)* |
 | `ide_convert_java_to_kotlin` | Convert Java files to Kotlin using IntelliJ's built-in converter *(disabled by default, requires Java + Kotlin plugins)* |
-| `ide_refactor_safe_delete` | Safely delete an element, checking for usages first (Java/Kotlin only) |
+| `ide_refactor_safe_delete` | Preview with `dryRun`, or safely delete an element by `symbolId` or position after checking usages (Java/Kotlin only) |
 
-> **Note**: Refactoring tools modify source files. All changes support undo via <kbd>Ctrl/Cmd+Z</kbd>.
+> **Note**: Applied refactorings modify source files and support undo via
+> <kbd>Ctrl/Cmd+Z</kbd>. `dryRun: true` previews do not modify files or create an undo command.
 
 ### Project Lifecycle Management Tools
 
@@ -389,7 +472,9 @@ For agent-heavy workflows: [recommended IDE settings](docs/recommended-ide-setti
 
 ## Multi-Project Support
 
-When multiple projects are open in a single IDE window, you must specify which project to use with the `project_path` parameter:
+When multiple projects are open in a single IDE window, specify which project to use with the
+`project_path` parameter. The exception is a symbol-ID-only call: the server routes a valid
+`symbolId` to the exact project instance that owns it.
 
 ```json
 {
@@ -405,6 +490,7 @@ When multiple projects are open in a single IDE window, you must specify which p
 
 If `project_path` is omitted:
 - **Single project open**: That project is used automatically
+- **Valid `symbolId` supplied**: Its owning project instance is used automatically
 - **Multiple projects open**: An error is returned with the list of available projects
 
 ### Workspace Projects

--- a/USAGE.md
+++ b/USAGE.md
@@ -19,10 +19,10 @@ These tools work in every supported JetBrains IDE:
 | `ide_find_file` | Search files by name | Enabled |
 | `ide_find_symbol` | Search code symbols by name *(disabled by default)* | Disabled |
 | `ide_search_text` | Text search using IntelliJ Find in Files (substring + regex) | Enabled |
-| `ide_diagnostics` | Analyze file problems with fresh IDE diagnostics, plus optional build/test results | Enabled |
+| `ide_diagnostics` | Analyze one file or a small multi-file batch under one shared budget, plus optional build/test results | Enabled |
 | `ide_project_diagnostics` | Batch/project-scope diagnostics for many files including unopened ones, with fail-closed coverage metadata; long analyses return an `analysisId` to poll | Disabled |
 | `ide_index_status` | Check indexing status | Enabled |
-| `ide_sync_files` | Force sync VFS/PSI cache | Enabled |
+| `ide_sync_files` | Force sync VFS/PSI cache, including deleted paths through existing parents | Enabled |
 | `ide_reload_project` | Reload linked Maven/Gradle build models | Disabled |
 | `ide_import_modules` | Import external Maven projects as modules | Disabled |
 | `ide_open_workspace` | Scan root directory for Maven projects, or open an explicit module list, in one window | Disabled |
@@ -32,12 +32,12 @@ These tools work in every supported JetBrains IDE:
 | `ide_read_file` | Read file content by path or qualified name | Disabled |
 | `ide_get_active_file` | Get currently active editor file(s) | Disabled |
 | `ide_open_file` | Open file in editor with navigation | Disabled |
-| `ide_refactor_rename` | Rename symbol with reference updates (all languages) | Enabled |
+| `ide_refactor_rename` | Preview or rename a symbol with reference updates (all languages) | Enabled |
 | `ide_move_file` | Move file to new directory with IDE-aware move semantics | Enabled |
 | `ide_reformat_code` | Reformat code using project code style | Disabled |
 | `ide_optimize_imports` | Optimize imports without reformatting code | Disabled |
 | `ide_structural_search_replace` | Pattern-based code search and transformation (Java, Kotlin) | Disabled |
-| `ide_change_signature` | Change method signature with automatic caller updates (Java) | Disabled |
+| `ide_change_signature` | Preview or change a method signature with automatic caller updates (Java) | Disabled |
 | `ide_create_file` | Create a new source file with content, immediately indexed by IntelliJ | Disabled |
 | `ide_replace_text_in_file` | Find and replace text using IntelliJ's Document API | Disabled |
 | `ide_edit_member` | Replace an entire member declaration (signature + body) with new content (Java, Kotlin) | Disabled |
@@ -50,11 +50,11 @@ These tools activate based on available language plugins:
 
 | Tool | Description | Languages |
 |------|-------------|-----------|
-| `ide_type_hierarchy` | Get type inheritance hierarchy | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
-| `ide_call_hierarchy` | Analyze method call relationships | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
+| `ide_type_hierarchy` | Get bounded, cursor-paginated type hierarchy pages | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
+| `ide_call_hierarchy` | Get bounded, cursor-paginated caller/callee pages | Java, Kotlin, Python, JS/TS, Go, PHP, Rust |
 | `ide_find_implementations` | Find interface implementations | Java, Kotlin, Python, JS/TS, PHP, Rust |
 | `ide_find_super_methods` | Find overridden methods | Java, Kotlin, Python, JS/TS, PHP |
-| `ide_file_structure` | Hierarchical file structure with start/end line numbers *(disabled by default)* | Java, Kotlin, Python, JS/TS, PHP, Markdown |
+| `ide_file_structure` | Compatible formatted outline plus structured PSI-bound nodes *(disabled by default)* | Java, Kotlin, Python, JS/TS, PHP, Markdown |
 
 ### Java-Specific Tools
 
@@ -62,7 +62,7 @@ These tools activate based on available language plugins:
 |------|-------------|
 | `ide_list_tests` | List all test methods/classes discovered by the IDE's test frameworks *(disabled by default)* |
 | `ide_convert_java_to_kotlin` | Convert Java files to Kotlin using the IDE converter *(disabled by default)* |
-| `ide_refactor_safe_delete` | Safely delete with usage check |
+| `ide_refactor_safe_delete` | Preview or safely delete with usage checking |
 
 ### Project Lifecycle Management Tools
 
@@ -165,7 +165,7 @@ All tools accept an optional `project_path` parameter:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `project_path` | string | No | Absolute path to the project root. Required when multiple projects are open in the IDE. For workspace projects, use the sub-project path. |
+| `project_path` | string | No | Absolute path to the project root. Required when multiple projects are open unless the call targets a valid `symbolId`, whose owning project is inferred. For workspace projects, use the sub-project path. |
 
 ### Position Parameters
 
@@ -177,6 +177,107 @@ Most tools operate on a specific location in code and require these parameters:
 | `line` | integer | 1-based line number |
 | `column` | integer | 1-based column number. For dotted expressions like `json.dumps()` or `os.path.join()`, point to the member token (`dumps`, `join`) when targeting the member definition. |
 
+### Opaque Symbol IDs
+
+Semantic discovery calls return `symbolId`, an opaque handle to the exact PSI declaration. Use it
+instead of `file` + `line` + `column` or `language` + `symbol` when chaining calls. It is accepted
+by `ide_find_references`, `ide_find_definition`, `ide_symbol_info`, `ide_type_hierarchy`,
+`ide_call_hierarchy`, `ide_find_implementations`, `ide_find_super_methods`,
+`ide_refactor_rename`, `ide_change_signature`, `ide_edit_member`, `ide_replace_member`, and
+`ide_refactor_safe_delete`. Target selectors are mutually exclusive: when `symbolId` is present,
+omit coordinates and name-based selectors.
+
+The ID is backed only by an IntelliJ `SmartPsiElementPointer` inside the running MCP server. It is
+scoped to the exact project instance and MCP server generation, kept in a 4,096-entry access-order
+LRU, and expires after one hour without access. A line shift does not invalidate it. Server/MCP
+restart, LRU/TTL expiry, deleting the declaration/file, or an unrestorable pointer returns
+`SYMBOL_ID_EXPIRED`; the server never chooses the nearest element. Rediscover the declaration to
+obtain a new ID. Successful refactorings return current `updatedSymbol` metadata with the same ID
+when it can be rebound (otherwise a new one); safe delete returns `invalidatedSymbolId`.
+
+The handle is intentionally non-canonical. The same PSI symbol can have several unequal,
+simultaneously valid IDs, and ID equality must never be used as symbol equality. Reusing one
+particular handle is stable across line shifts and rename while its session/project/TTL/LRU bounds
+remain valid.
+
+```json
+{
+  "name": "ide_symbol_info",
+  "arguments": { "symbolId": "sym_opaque-value-from-a-prior-result" }
+}
+```
+
+### Structured Target
+
+Target-aware semantic and symbol-refactoring tools accept the new nested form below in addition to
+all legacy top-level selectors. Choose exactly one variant and do not mix `target` with top-level
+`symbolId`, `file`/`line`/`column`, `language`/`symbol`, or a tool-specific selector such as
+`className`:
+
+```json
+{ "target": { "symbolId": "sym_..." } }
+{ "target": { "position": { "file": "src/Foo.kt", "line": 12, "column": 9 } } }
+{ "target": { "qualifiedName": "com.example.Foo#bar", "language": "Kotlin" } }
+```
+
+Validation is performed at runtime so clients whose JSON Schema implementation does not support
+union combinators still receive a portable schema. A nested `target.symbolId` also routes the call
+to its exact owning project instance when several projects are open.
+
+After installing a new plugin build and reloading/restarting the IDE, reconnect or restart the MCP
+client before checking these fields. Clients such as Codex cache `ALL_TOOLS`, so an existing
+connection may retain the previous input schemas. A fresh `initialize` → `tools/list` publishes the
+current schema. The server advertises `tools.listChanged: false`; it does not promise tool-list
+change notifications on the current transports.
+
+### Semantic Class Metadata
+
+Kotlin declarations are classified from Kotlin PSI semantics: `INTERFACE`, `CLASS`, `ENUM`,
+`ANNOTATION`, and `OBJECT` are distinct even though several share the same runtime PSI class.
+Semantic results use Kotlin `getFqName()` through the common qualified-name path when available.
+Anonymous implementations deliberately have no qualified name; their display name identifies the
+base type and source location, for example
+`<anonymous implementation of SomeInterface at File.kt:42>` with `qualifiedName: null`.
+
+### Refactoring Preview Contract
+
+`ide_refactor_rename`, `ide_refactor_safe_delete`, and `ide_change_signature` accept
+`dryRun: true`. The request follows normal target resolution, validation, usage discovery, and
+conflict discovery, but does not enter the refactoring/source-write phase, save documents, or
+create an undo command.
+File contents therefore remain byte-for-byte unchanged.
+
+All three tools return the same top-level preview shape:
+
+```json
+{
+  "dryRun": true,
+  "canApply": true,
+  "target": {
+    "symbolId": "sym_opaque-handle",
+    "name": "findUser",
+    "kind": "method",
+    "container": "com.example.UserService",
+    "file": "src/main/java/com/example/UserService.java",
+    "line": 15,
+    "column": 17,
+    "qualifiedName": "com.example.UserService#findUser",
+    "language": "Java"
+  },
+  "plannedChange": { "operation": "rename", "from": "findUser", "to": "findUserById" },
+  "affectedFiles": ["src/main/java/com/example/UserService.java"],
+  "usageCount": 4,
+  "conflictCount": 0,
+  "warnings": [],
+  "elapsedMs": 18
+}
+```
+
+`canApply: false` means the preview found a blocker or could not complete discovery; inspect
+`warnings` and `conflictCount`. `affectedFiles` is an estimate from the preview search. To apply,
+send the operation again with `dryRun` omitted or `false`; a preview itself is never an apply token
+and does not reserve project state.
+
 ### Symbol Reference Parameters
 
 Some tools support identifying the target element by fully qualified symbol reference instead of file position. The following parameters are available as an alternative to `file` + `line` + `column`:
@@ -186,7 +287,8 @@ Some tools support identifying the target element by fully qualified symbol refe
 | `language` | string | Language of the symbol (e.g., `"Java"`). Required when using `symbol`. Unsupported languages are rejected at runtime; use `file` + `line` + `column` for languages without symbol-reference support. |
 | `symbol` | string | Fully qualified symbol reference. **Java format:** `com.example.ClassName`, `com.example.ClassName#memberName`. **JS/TS format:** `modulePath#exportName`, `modulePath#default`, or `modulePath#ClassName.memberName`. |
 
-**Important:** The two parameter groups are **mutually exclusive** — provide either `file` + `line` + `column` OR `language` + `symbol`, not both.
+**Important:** The three target forms are **mutually exclusive** — provide `symbolId`, `file` +
+`line` + `column`, or `language` + `symbol`, not more than one.
 
 **Supported languages:** Java, JavaScript, TypeScript, Python, and PHP. Availability is dynamic — a language is accepted only when its plugin is installed (e.g., Python in PyCharm, PHP in PhpStorm). Unsupported languages return an explicit error listing the currently supported symbol-reference languages.
 
@@ -246,12 +348,13 @@ Finds all references to a symbol across the entire project using IntelliJ's sema
 - Understanding code dependencies
 - Preparing for refactoring
 
-**Target (mutually exclusive):** `file` + `line` + `column` OR `language` + `symbol`
+**Target (mutually exclusive):** `symbolId` OR `file` + `line` + `column` OR `language` + `symbol`
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | Conditional | Opaque ID returned by a previous semantic result. Omit all other target selectors. |
 | `file` | string | Conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | Conditional | 1-based line number. Required for position-based lookup. |
 | `column` | integer | Conditional | 1-based column number. Required for position-based lookup. |
@@ -325,7 +428,18 @@ Finds all references to a symbol across the entire project using IntelliJ's sema
   "totalCollected": 2,
   "offset": 0,
   "pageSize": 100,
-  "stale": false
+  "stale": false,
+  "resolvedSymbol": {
+    "symbolId": "sym_opaque-handle",
+    "name": "findUser",
+    "kind": "method",
+    "container": "com.example.UserService",
+    "file": "src/main/java/com/example/UserService.java",
+    "line": 15,
+    "column": 17,
+    "qualifiedName": "com.example.UserService#findUser(java.lang.String)",
+    "language": "Java"
+  }
 }
 ```
 
@@ -347,12 +461,13 @@ Finds the definition/declaration location of a symbol at a given source location
 - Understanding where a method, class, variable, or field is declared
 - Looking up the original definition from a usage site
 
-**Target (mutually exclusive):** `file` + `line` + `column` OR `language` + `symbol`
+**Target (mutually exclusive):** `symbolId` OR `file` + `line` + `column` OR `language` + `symbol`
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | Conditional | Opaque ID returned by a previous semantic result. Omit all other target selectors. |
 | `file` | string | Conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | Conditional | 1-based line number. Required for position-based lookup. |
 | `column` | integer | Conditional | 1-based column number. Required for position-based lookup. |
@@ -396,6 +511,7 @@ Finds the definition/declaration location of a symbol at a given source location
 
 ```json
 {
+  "symbolId": "sym_opaque-handle",
   "file": "src/main/java/com/example/UserService.java",
   "line": 15,
   "column": 17,
@@ -431,12 +547,13 @@ types as the IDE resolved them.
 | `quick_navigation` | Any language with a documentation provider — Kotlin, Python, JS/TS, Go, PHP, Rust | As that language's Quick Documentation renders them; often short |
 | `element_text` | No documentation provider answered | The declaration's own source line |
 
-**Target (mutually exclusive):** `file` + `line` + `column` OR `language` + `symbol`
+**Target (mutually exclusive):** `symbolId` OR `file` + `line` + `column` OR `language` + `symbol`
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | Conditional | Opaque ID returned by a previous semantic result. Omit all other target selectors. |
 | `file` | string | Conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | Conditional | 1-based line number. Required for position-based lookup. |
 | `column` | integer | Conditional | 1-based column number. Required for position-based lookup. |
@@ -466,6 +583,7 @@ types as the IDE resolved them.
 
 ```json
 {
+  "symbolId": "sym_opaque-handle",
   "name": "findUser",
   "kind": "method",
   "qualifiedName": "com.example.UserService#findUser(java.lang.String)",
@@ -493,7 +611,7 @@ passed straight back to `ide_find_references`, `ide_call_hierarchy`, or `ide_fin
 as the `symbol` argument. A callable includes its resolved parameter list, because the bare
 `Container#name` form is rejected as ambiguous as soon as the method is overloaded. On the other
 `signatureSource` paths the container is a best-effort dotted AST path rather than a resolved FQN,
-so address those symbols by position instead.
+so address those symbols by `symbolId` or position instead.
 
 ---
 
@@ -546,6 +664,7 @@ Searches for classes and interfaces by name using the IDE's class index.
 {
   "classes": [
     {
+      "symbolId": "sym_user-service",
       "name": "UserService",
       "qualifiedName": "com.example.service.UserService",
       "kind": "INTERFACE",
@@ -709,7 +828,11 @@ Analyzes code diagnostics from three sources:
 - optional build output from the last build,
 - optional test results from open test run tabs.
 
-File problems are collected through explicit daemon analysis, so they do not depend on the target project window being active. Intentions/quick fixes are best-effort and require the file to already be open in an editor.
+File problems are collected through explicit daemon analysis, so they do not depend on the target
+project window being active. Analyze either one `file` or a non-empty `files` list. Multi-file calls
+share one configured analysis timeout budget for the whole request, rather than restarting the
+budget for every file. Intentions/quick fixes are best-effort, require the file to already be open
+in an editor, and are available only in single-file mode.
 
 **Use when:**
 - Finding code issues in a file
@@ -723,11 +846,12 @@ File problems are collected through explicit daemon analysis, so they do not dep
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | No | Path to the file relative to project root. Enables per-file code analysis. At least one of `file`, `includeBuildErrors`, or `includeTestResults` must be provided |
-| `line` | integer | No | 1-based line number for intention lookup (default: 1) |
-| `column` | integer | No | 1-based column number for intention lookup (default: 1) |
-| `startLine` | integer | No | Filter problems to start from this line |
-| `endLine` | integer | No | Filter problems to end at this line |
+| `file` | string | No | One project-relative file to analyze. Mutually exclusive with `files`. At least one of `file`, `files`, `includeBuildErrors`, or `includeTestResults` must be provided |
+| `files` | string[] | No | Up to 100 non-empty, unique project-relative file paths analyzed under one shared timeout budget. Mutually exclusive with `file` |
+| `line` | integer | No | 1-based line number for intention lookup (default: 1). Single `file` only |
+| `column` | integer | No | 1-based column number for intention lookup (default: 1). Single `file` only |
+| `startLine` | integer | No | Filter problems to start from this line. Single `file` only |
+| `endLine` | integer | No | Filter problems to end at this line. Single `file` only |
 | `includeBuildErrors` | boolean | No | Include errors/warnings from the last build (default: `false`) |
 | `includeTestResults` | boolean | No | Include test results from open test run tabs (default: `false`) |
 | `severity` | string | No | Filter diagnostics by `all`, `errors`, or `warnings` (default: `all`) |
@@ -764,6 +888,24 @@ File problems are collected through explicit daemon analysis, so they do not dep
 }
 ```
 
+**Example Request (multiple files):**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_diagnostics",
+    "arguments": {
+      "files": [
+        "src/main/java/com/example/UserService.java",
+        "src/main/java/com/example/UserController.java"
+      ],
+      "severity": "errors"
+    }
+  }
+}
+```
+
 **Example Response:**
 
 ```json
@@ -793,8 +935,11 @@ File problems are collected through explicit daemon analysis, so they do not dep
 - `analysisTimedOut = true` means the file analysis budget was exceeded; build/test sections may still be returned.
 - `analysisMessage` explains degraded cases such as timeouts or missing live editor context for intentions.
 - `analysisMode` reports which analysis path produced the file problems: `open_daemon` (file open in an editor, fresh daemon highlights) or `closed_batch` (public batch analysis); `null` when no analysis ran.
+- The four legacy top-level analysis fields above apply to single-file calls. Multi-file calls return one aggregate `problems` list and `fileAnalyses: [{file, mode, fresh, timedOut, message, problemCount, problemsTruncated}]`, including an entry for a missing, deleted, failed, or unprocessed requested file.
+- Code problems share a 100-item response cap. Top-level `problemsTruncated` reports known omissions (absent without code analysis); each file's flag identifies affected paths and its `problemCount` counts returned problems, not all detected problems. A file can be fresh with zero returned problems and `problemsTruncated: true`. Re-query such a path using `file`, narrowing `startLine`/`endLine` if needed. A false flag only means no collected problems were omitted by the cap; check freshness/timeouts separately.
+- The multi-file timeout is shared. Once it is exhausted, remaining files are reported with `fresh: false`, `timedOut: true`, and an explanatory `message`; they do not each receive another full timeout.
 - The analyzed file is refreshed from disk and committed to PSI before analysis, so problems describe the file as it is on disk. There is no need to call `ide_sync_files` first after editing a file with an external tool.
-- `line` and `column` affect intention lookup only; file problems are collected for the whole file, then filtered by `startLine` / `endLine` if provided.
+- `line` and `column` affect intention lookup only; file problems are collected for the whole file, then filtered by `startLine` / `endLine` if provided. All four location fields are rejected with `files`.
 
 **Severity Values:**
 - `ERROR` - Compilation error
@@ -958,7 +1103,7 @@ Force the IDE to synchronize its virtual file system and PSI cache with external
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `paths` | array of strings | No | File or directory paths relative to project root to sync. If omitted, syncs the entire project |
+| `paths` | string[] | No | File or directory paths relative to the selected project/content root. A deleted path refreshes its nearest existing parent. Absolute paths, `..` traversal, and symlink escapes are rejected. If omitted or empty, syncs the entire selected root |
 
 **Example Request:**
 
@@ -980,9 +1125,19 @@ Force the IDE to synchronize its virtual file system and PSI cache with external
 {
   "syncedPaths": ["src/main/java/com/example/NewFile.java"],
   "syncedAll": false,
-  "message": "Synced 1 path(s)"
+  "message": "Synchronized 1 path(s).",
+  "requestedPaths": ["src/main/java/com/example/NewFile.java"],
+  "refreshedRoots": ["src/main/java/com/example/NewFile.java"],
+  "deletedPaths": []
 }
 ```
+
+For a requested path that no longer exists, `requestedPaths` and `deletedPaths` preserve the
+original relative path while `refreshedRoots` identifies the nearest existing parent actually
+marked dirty and recursively refreshed. Overlapping targets are reduced to the minimum set of
+refresh roots. The complete batch is validated before the VFS is touched, so one escaping or
+unsafe path fails the call without partially refreshing earlier paths. Neither `paths` nor a
+`project_path` routing hint can escape the selected project's base/content roots.
 
 ---
 
@@ -1484,6 +1639,7 @@ Searches for code symbols (classes, interfaces, methods, fields, and functions) 
 {
   "symbols": [
     {
+      "symbolId": "sym_user-service",
       "name": "UserService",
       "qualifiedName": "com.example.service.UserService",
       "kind": "INTERFACE",
@@ -1493,6 +1649,7 @@ Searches for code symbols (classes, interfaces, methods, fields, and functions) 
       "containerName": null
     },
     {
+      "symbolId": "sym_user-service-impl",
       "name": "UserServiceImpl",
       "qualifiedName": "com.example.service.UserServiceImpl",
       "kind": "CLASS",
@@ -1502,6 +1659,7 @@ Searches for code symbols (classes, interfaces, methods, fields, and functions) 
       "containerName": null
     },
     {
+      "symbolId": "sym_find-user",
       "name": "findUser",
       "qualifiedName": "com.example.service.UserService.findUser",
       "kind": "METHOD",
@@ -1524,6 +1682,7 @@ Searches for code symbols (classes, interfaces, methods, fields, and functions) 
 - `INTERFACE` - Interface
 - `ENUM` - Enum type
 - `ANNOTATION` - Annotation type
+- `OBJECT` - Kotlin object declaration
 - `RECORD` - Record class (Java 16+)
 - `METHOD` - Method
 - `FIELD` - Field or constant
@@ -1792,7 +1951,9 @@ Project 'myproject' is open and ready.
 
 ## Refactoring Tools
 
-> **Note**: All refactoring tools modify source files. Changes can be undone with Ctrl/Cmd+Z.
+> **Note**: Applying a refactoring modifies source files and can be undone with Ctrl/Cmd+Z.
+> `dryRun: true` on rename, safe delete, and change signature is strictly non-mutating and creates
+> no undo command.
 
 ### ide_refactor_rename
 
@@ -1806,6 +1967,7 @@ Renames a symbol or file and updates all references across the project. This too
 - **Automatic related element renaming** - getters/setters, overriding methods, test classes are renamed automatically
 - Explicit `targetType` mode selection (`symbol` or `file`)
 - Conflict detection before rename execution (returns error instead of showing dialog)
+- Read-only preview with usage/conflict discovery (`dryRun: true`)
 - Supports IDE undo for rename changes
 
 **Use when:**
@@ -1817,13 +1979,55 @@ Renames a symbol or file and updates all references across the project. This too
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | Yes | Path to the file containing the symbol |
+| `target` | object | Conditional | Structured symbol selector containing exactly one of `symbolId`, `position: {file, line, column}`, or `qualifiedName` + `language`. Mutually exclusive with legacy top-level selectors. |
+| `symbolId` | string | Conditional | Exact symbol handle. Omit `file`, `line`, and `column`; `targetType` may be omitted or set to `symbol`. |
+| `file` | string | Conditional | Path to the file containing the symbol, or the file to rename. Required for legacy position-based symbol lookup and file rename. |
+| `language` | string | Conditional | Legacy qualified-name selector language; requires `symbol` and is mutually exclusive with other target selectors. |
+| `symbol` | string | Conditional | Legacy qualified symbol name; requires `language` and is mutually exclusive with other target selectors. |
 | `targetType` | string | No | `symbol` (requires 1-based `line` + `column`) or `file` (renames the file itself; placeholder coordinates are ignored) |
 | `line` | integer | No | 1-based line number for symbol rename |
 | `column` | integer | No | 1-based column number for symbol rename |
 | `newName` | string | Yes | The new name for the symbol |
 | `overrideStrategy` | string | No | How to handle overriding methods: `"rename_base"` (default), `"rename_only_current"`, or `"ask"` |
 | `relatedRenamingStrategy` | string | No | How to handle automatic renaming of related symbols: `"all"` (default), `"none"`, `"accessors_and_tests"`, or `"ask"` |
+| `dryRun` | boolean | No | Resolve and validate the target, discover usages/conflicts, and return a preview without changing or saving files (default: `false`) |
+
+**Example Request (symbolId):**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_refactor_rename",
+    "arguments": {
+      "symbolId": "sym_opaque-handle",
+      "newName": "findUserById"
+    }
+  }
+}
+```
+
+**Example Request (preview):**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_refactor_rename",
+    "arguments": {
+      "target": { "symbolId": "sym_opaque-handle" },
+      "newName": "findUserById",
+      "dryRun": true
+    }
+  }
+}
+```
+
+The common preview response is described in [Refactoring Preview Contract](#refactoring-preview-contract).
+For rename, `plannedChange` contains `operation: "rename"`, `targetType`, `from`, `to`,
+`overrideStrategy`, and `relatedRenamingStrategy`. `canApply` is false when discovery is incomplete,
+the target/scope is read-only, an interactive-only plan cannot be represented exactly, or conflicts
+were found. The preview performs no refactoring/source write, document save, or undo registration.
 
 **Example Request (Java):**
 
@@ -1887,7 +2091,15 @@ Renames a symbol or file and updates all references across the project. This too
     "src/test/java/com/example/UserServiceTest.java"
   ],
   "changesCount": 3,
-  "message": "Successfully renamed 'findUser' to 'findUserById' (also renamed 2 related element(s))"
+  "message": "Successfully renamed 'findUser' to 'findUserById' (also renamed 2 related element(s))",
+  "updatedSymbol": {
+    "symbolId": "sym_opaque-handle",
+    "name": "findUserById",
+    "file": "src/main/java/com/example/UserService.java",
+    "line": 15,
+    "column": 17,
+    "language": "Java"
+  }
 }
 ```
 
@@ -2139,6 +2351,12 @@ When `replacePattern` is omitted, the tool performs search-only and returns matc
 
 Replace an entire member declaration (signature + body) with new content. The tool locates the member by name, optional parameter count, and optional line number, then replaces the complete declaration.
 
+Replacement must contain one syntactically valid declaration of the original category, optionally
+surrounded by comments. Names/signatures may change, and nested declarations are allowed. Invalid
+or ambiguous content is rejected before editing; use `ide_refactor_safe_delete` for deletion.
+`updatedSymbol` identifies only the exact replacement, never its containing class. If the handle
+cannot be restored after an applied edit, it is invalidated and the response asks for rediscovery.
+
 **Languages:** Java, Kotlin.
 
 **Use when:**
@@ -2150,9 +2368,13 @@ Replace an entire member declaration (signature + body) with new content. The to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | Yes | Path to the file relative to project root |
+| `target` | object | Conditional | Exactly one nested selector: `{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`. Do not combine it with `symbolId`, `language`+`symbol`, `file`, `class`, `member`, `parameterCount`, or `line`. |
+| `symbolId` | string | Conditional | Exact member handle. Omit `file`, `class`, `member`, `parameterCount`, and `line`. |
+| `language` | string | Conditional | Legacy semantic lookup language; provide together with `symbol` and omit all other selectors. |
+| `symbol` | string | Conditional | Legacy qualified member name; provide together with `language` and omit all other selectors. |
+| `file` | string | Conditional | Path to the file relative to project root. Required when `symbolId` is omitted. |
 | `class` | string | No | Class name to scope the search (required for inner classes or when the member name is ambiguous) |
-| `member` | string | Yes | Name of the member to replace |
+| `member` | string | Conditional | Name of the member to replace. Required when `symbolId` is omitted. |
 | `parameterCount` | integer | No | Number of parameters to disambiguate overloaded methods |
 | `line` | integer | No | 1-based line number to disambiguate when multiple members share the same name |
 | `content` | string | Yes | The full replacement declaration (signature + body) |
@@ -2183,7 +2405,15 @@ Replace an entire member declaration (signature + body) with new content. The to
   "file": "src/main/java/com/example/UserService.java",
   "message": "Replaced method 'findUser' entirely",
   "startLine": 15,
-  "endLine": 18
+  "endLine": 18,
+  "updatedSymbol": {
+    "symbolId": "sym_opaque-handle",
+    "name": "findUser",
+    "file": "src/main/java/com/example/UserService.java",
+    "line": 15,
+    "column": 17,
+    "language": "Java"
+  }
 }
 ```
 
@@ -2207,14 +2437,19 @@ Change a method's signature — name, return type, visibility, and parameters �
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | Yes | Path to the file containing the method, relative to project root |
-| `line` | integer | Yes | 1-based line number of the method |
-| `column` | integer | Yes | 1-based column number of the method name |
+| `target` | object | Conditional | Structured method selector containing exactly one of `symbolId`, `position: {file, line, column}`, or `qualifiedName` + `language`. Mutually exclusive with legacy top-level selectors. |
+| `symbolId` | string | Conditional | Exact method handle. Omit `file`, `line`, and `column`. |
+| `file` | string | Conditional | Path to the file containing the method, relative to project root. Required for legacy position lookup. |
+| `line` | integer | Conditional | 1-based line number of the method for legacy position lookup. |
+| `column` | integer | Conditional | 1-based column number of the method name for legacy position lookup. |
+| `language` | string | Conditional | Legacy qualified-name selector language; requires `symbol` and is mutually exclusive with other target selectors. |
+| `symbol` | string | Conditional | Legacy qualified method name; requires `language` and is mutually exclusive with other target selectors. |
 | `newName` | string | No | New method name (unchanged if omitted) |
 | `newReturnType` | string | No | New return type (unchanged if omitted) |
 | `newVisibility` | string | No | New visibility: `"public"`, `"protected"`, `"private"`, or `"package-private"` (unchanged if omitted; `"package-local"` is accepted as a legacy alias) |
 | `newParameters` | array | No | Array of parameter objects defining the new parameter list. Each object: `{ oldIndex, name, type, defaultValue }`. Use `oldIndex: -1` for new parameters. |
 | `generateDelegate` | boolean | No | Generate a delegate method with the old signature that calls the new one (default: false) |
+| `dryRun` | boolean | No | Resolve and validate the method, discover callers/conflicts, and return a preview without changing or saving files (default: `false`) |
 
 **`newParameters` object fields:**
 
@@ -2263,6 +2498,33 @@ Change a method's signature — name, return type, visibility, and parameters �
 }
 ```
 
+**Example Request (preview):**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_change_signature",
+    "arguments": {
+      "target": { "symbolId": "sym_opaque-handle" },
+      "newName": "findUserById",
+      "newParameters": [
+        { "oldIndex": 0, "name": "id", "type": "String" },
+        { "oldIndex": -1, "name": "includeDeleted", "type": "boolean", "defaultValue": "false" }
+      ],
+      "dryRun": true
+    }
+  }
+}
+```
+
+The common preview response is described in [Refactoring Preview Contract](#refactoring-preview-contract).
+For change signature, `plannedChange` contains `operation: "changeSignature"`, the current
+signature in `before`, and the requested name/return type/visibility/parameters/delegate options in
+`requested`. `canApply` is false when discovery is incomplete, a target or affected file is
+read-only, or conflicts were found. Preview does not invoke the refactoring processor's write
+phase, save documents, or register undo.
+
 **Example Response:**
 
 ```json
@@ -2275,7 +2537,15 @@ Change a method's signature — name, return type, visibility, and parameters �
     "src/main/java/com/example/UserController.java",
     "src/test/java/com/example/UserServiceTest.java"
   ],
-  "changesCount": 5
+  "changesCount": 5,
+  "updatedSymbol": {
+    "symbolId": "sym_opaque-handle",
+    "name": "findUserById",
+    "file": "src/main/java/com/example/UserService.java",
+    "line": 15,
+    "column": 17,
+    "language": "Java"
+  }
 }
 ```
 
@@ -2472,9 +2742,13 @@ Replace only the body of a method or the initializer of a field, preserving the 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | Yes | Path to the file relative to project root |
+| `target` | object | Conditional | Exactly one nested selector: `{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`. Do not combine it with `symbolId`, `language`+`symbol`, `file`, `class`, `member`, `parameterCount`, or `line`. |
+| `symbolId` | string | Conditional | Exact member handle. Omit `file`, `class`, `member`, `parameterCount`, and `line`. |
+| `language` | string | Conditional | Legacy semantic lookup language; provide together with `symbol` and omit all other selectors. |
+| `symbol` | string | Conditional | Legacy qualified member name; provide together with `language` and omit all other selectors. |
+| `file` | string | Conditional | Path to the file relative to project root. Required when `symbolId` is omitted. |
 | `class` | string | No | Class name to scope the search (required for inner classes or when the member name is ambiguous) |
-| `member` | string | Yes | Name of the member whose body/initializer to replace |
+| `member` | string | Conditional | Name of the member whose body/initializer to replace. Required when `symbolId` is omitted. |
 | `parameterCount` | integer | No | Number of parameters to disambiguate overloaded methods |
 | `line` | integer | No | 1-based line number to disambiguate when multiple members share the same name |
 | `content` | string | Yes | The new method body (without braces) or field initializer (without `=` sign) |
@@ -2505,7 +2779,15 @@ Replace only the body of a method or the initializer of a field, preserving the 
   "file": "src/main/java/com/example/UserService.java",
   "message": "Replaced body of method 'findUser'",
   "startLine": 16,
-  "endLine": 18
+  "endLine": 18,
+  "updatedSymbol": {
+    "symbolId": "sym_opaque-handle",
+    "name": "findUser",
+    "file": "src/main/java/com/example/UserService.java",
+    "line": 15,
+    "column": 17,
+    "language": "Java"
+  }
 }
 ```
 
@@ -2526,7 +2808,7 @@ Navigation tools appear according to installed language plugins. PHP file struct
 
 ### ide_type_hierarchy
 
-Retrieves the complete type hierarchy for a class or interface.
+Retrieves a type hierarchy for a class or interface as bounded, deterministic breadth-first pages.
 
 **Use when:**
 - Exploring class inheritance chains
@@ -2538,14 +2820,20 @@ Retrieves the complete type hierarchy for a class or interface.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | No* | Exact type handle returned by a semantic result. |
 | `file` | string | No* | Path to the file relative to project root |
 | `line` | integer | No* | 1-based line number |
 | `column` | integer | No* | 1-based column number |
 | `className` | string | No* | Fully qualified class name (alternative to position) |
+| `language` | string | No* | Language for a qualified semantic target; must have an installed symbol-reference handler |
+| `symbol` | string | No* | Fully qualified symbol reference used with `language` |
+| `maxNodes` | integer | No | Maximum nodes returned and expanded on this page (default: 100, max: 500) |
+| `cursor` | string | No | Opaque continuation from a previous page. When present, target/search options are ignored; `maxNodes` may set the next page size |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `includeGenerated` | boolean | No | Include supertypes/subtypes in generated sources (KSP/Dagger/annotation-processor output). Default: true — keeps generated types in the hierarchy |
 
-*Either `file`/`line`/`column` OR `className` must be provided.
+*Provide exactly one nested `target` variant, or one legacy target: `symbolId`,
+`file`/`line`/`column`, `language`/`symbol`, or `className`.
 
 **Rust note:** `className` is not supported for Rust — use `file` + `line` + `column` instead.
 
@@ -2599,6 +2887,7 @@ Retrieves the complete type hierarchy for a class or interface.
 ```json
 {
   "element": {
+    "symbolId": "sym_user-service-impl",
     "name": "com.example.UserServiceImpl",
     "file": "src/main/java/com/example/UserServiceImpl.java",
     "kind": "CLASS",
@@ -2606,12 +2895,14 @@ Retrieves the complete type hierarchy for a class or interface.
   },
   "supertypes": [
     {
+      "symbolId": "sym_user-service",
       "name": "com.example.UserService",
       "file": "src/main/java/com/example/UserService.java",
       "kind": "INTERFACE",
       "language": "Java"
     },
     {
+      "symbolId": "sym_base-service",
       "name": "com.example.BaseService",
       "file": "src/main/java/com/example/BaseService.java",
       "kind": "ABSTRACT_CLASS",
@@ -2620,14 +2911,71 @@ Retrieves the complete type hierarchy for a class or interface.
   ],
   "subtypes": [
     {
+      "symbolId": "sym_admin-user-service-impl",
       "name": "com.example.AdminUserServiceImpl",
       "file": "src/main/java/com/example/AdminUserServiceImpl.java",
       "kind": "CLASS",
       "language": "Java"
     }
-  ]
+  ],
+  "traversal": [
+    {
+      "direction": "supertype",
+      "element": {
+        "symbolId": "sym_user-service",
+        "name": "com.example.UserService",
+        "file": "src/main/java/com/example/UserService.java",
+        "kind": "INTERFACE",
+        "language": "Java"
+      }
+    },
+    {
+      "direction": "supertype",
+      "element": {
+        "symbolId": "sym_base-service",
+        "name": "com.example.BaseService",
+        "file": "src/main/java/com/example/BaseService.java",
+        "kind": "ABSTRACT_CLASS",
+        "language": "Java"
+      }
+    },
+    {
+      "direction": "subtype",
+      "element": {
+        "symbolId": "sym_admin-user-service-impl",
+        "name": "com.example.AdminUserServiceImpl",
+        "file": "src/main/java/com/example/AdminUserServiceImpl.java",
+        "kind": "CLASS",
+        "language": "Java"
+      }
+    }
+  ],
+  "returnedNodes": 3,
+  "truncated": false,
+  "elapsedMs": 14,
+  "hasMore": false,
+  "cursor": null
 }
 ```
+
+`returnedNodes` counts hierarchy nodes in this page, equals `traversal.size`, and excludes the
+repeated root `element`. `truncated` mirrors `hasMore`; when true, pass `cursor` to the same tool to
+continue. `traversal` is the exact combined breadth-first wire order, with each entry identifying
+the `supertype` or `subtype` direction. The legacy `supertypes` and `subtypes` arrays remain as
+direction-filtered views for backward compatibility; concatenating them cannot reconstruct an
+interleaved combined order. All three lists are flat page slices rather than a fully materialized
+nested graph. `maxNodes` bounds both returned nodes and expansion work during traversal.
+
+Hierarchy cursors store the remaining PSI frontier as smart pointers and are scoped to the exact
+project and MCP session. The independent cache keeps at most 128 snapshots and ten per traversal,
+expires entries after ten minutes without access, and enforces aggregate pointer/text budgets.
+Eviction prefers old replay snapshots to the latest frontier; replay retention is bounded, not
+guaranteed for an entire traversal. Repeating a live cursor with the same page size and PSI version
+reuses its retained successor cursor. Returned handles are rebound on each page independently of
+cursor TTL, so symbol-cache eviction cannot leave stale IDs in an otherwise valid page.
+An expired, evicted, wrong-project, wrong-tool, or invalidated cursor must
+restart the query without `cursor`. The Streamable HTTP transport is stateless between requests and
+does not reliably deliver live progress; page metadata is the progress contract.
 
 **Kind Values:**
 - `CLASS` - Concrete class
@@ -2649,19 +2997,22 @@ Analyzes method call relationships to find callers or callees.
 - Analyzing impact of method changes
 - Debugging to understand how a method is reached
 
-**Target (mutually exclusive):** `file` + `line` + `column` OR `language` + `symbol`
+**Target (mutually exclusive):** `symbolId` OR `file` + `line` + `column` OR `language` + `symbol`
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | Conditional | Exact callable handle. Omit coordinates and name selectors. |
 | `file` | string | Conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | Conditional | 1-based line number. Required for position-based lookup. |
 | `column` | integer | Conditional | 1-based column number. Required for position-based lookup. |
 | `language` | string | Conditional | Language of the symbol (e.g., `"Java"`). Required for symbol-based lookup. |
 | `symbol` | string | Conditional | Fully qualified symbol reference. Required for symbol-based lookup. |
 | `direction` | string | Yes | `"callers"` or `"callees"` |
-| `depth` | integer | No | How deep to traverse (default: 3, max: 5) |
+| `depth` | integer | No | How deep to traverse across all pages (default: 3, max: 5) |
+| `maxNodes` | integer | No | Maximum nodes returned and expanded on this page (default: 20 on a fresh call, 100 on continuation; max: 500) |
+| `cursor` | string | No | Opaque continuation from a previous page. When present, target/search options are ignored; `maxNodes` may set the next page size |
 | `scope` | string | No | Built-in search scope. One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `includeGenerated` | boolean | No | Include callers/callees in generated sources (KSP/Dagger/annotation-processor output). Default: true |
 
@@ -2704,6 +3055,7 @@ Analyzes method call relationships to find callers or callees.
 ```json
 {
   "element": {
+    "symbolId": "sym_validate-user",
     "name": "UserService.validateUser(String)",
     "file": "src/main/java/com/example/UserService.java",
     "line": 20,
@@ -2712,6 +3064,7 @@ Analyzes method call relationships to find callers or callees.
   },
   "calls": [
     {
+      "symbolId": "sym_create-user",
       "name": "UserController.createUser(UserRequest)",
       "file": "src/main/java/com/example/UserController.java",
       "line": 45,
@@ -2719,15 +3072,27 @@ Analyzes method call relationships to find callers or callees.
       "language": "Java"
     },
     {
+      "symbolId": "sym_update-user",
       "name": "UserController.updateUser(String, UserRequest)",
       "file": "src/main/java/com/example/UserController.java",
       "line": 62,
       "column": 17,
       "language": "Java"
     }
-  ]
+  ],
+  "returnedNodes": 2,
+  "truncated": true,
+  "elapsedMs": 22,
+  "hasMore": true,
+  "cursor": "hier_opaque-continuation"
 }
 ```
+
+`calls` is a flat deterministic breadth-first page; `returnedNodes` excludes the repeated root
+`element`. `truncated` mirrors `hasMore`. Continue with the returned `cursor` until `hasMore` is
+false. `maxNodes` is enforced during traversal, so the server never gathers an unbounded call graph
+and trims it afterwards. Cursor scope, TTL/LRU, invalidation, and the no-live-progress transport
+contract are the same as for [`ide_type_hierarchy`](#ide_type_hierarchy).
 
 ---
 
@@ -2742,12 +3107,13 @@ Finds all concrete implementations of an interface, abstract class, or abstract 
 - Finding classes that extend an abstract class
 - Finding all overriding methods for polymorphic behavior analysis
 
-**Target (mutually exclusive):** `file` + `line` + `column` OR `language` + `symbol`
+**Target (mutually exclusive):** `symbolId` OR `file` + `line` + `column` OR `language` + `symbol`
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | Conditional | Exact type/method handle. Omit coordinates and name selectors. |
 | `file` | string | Conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | Conditional | 1-based line number. Required for position-based lookup. |
 | `column` | integer | Conditional | 1-based column number. Required for position-based lookup. |
@@ -2796,6 +3162,7 @@ Finds all concrete implementations of an interface, abstract class, or abstract 
 {
   "implementations": [
     {
+      "symbolId": "sym-jpa-user-repository",
       "name": "com.example.JpaUserRepository",
       "file": "src/main/java/com/example/JpaUserRepository.java",
       "line": 12,
@@ -2803,6 +3170,7 @@ Finds all concrete implementations of an interface, abstract class, or abstract 
       "kind": "CLASS"
     },
     {
+      "symbolId": "sym-in-memory-user-repository",
       "name": "com.example.InMemoryUserRepository",
       "file": "src/main/java/com/example/InMemoryUserRepository.java",
       "line": 8,
@@ -2836,12 +3204,13 @@ Finds the complete inheritance hierarchy for a method - all parent methods it ov
 
 **Position flexibility:** The position (line/column) can be anywhere within the method - on the name, inside the body, or on the @Override annotation. The tool automatically finds the enclosing method.
 
-**Target (mutually exclusive):** `file` + `line` + `column` OR `language` + `symbol`
+**Target (mutually exclusive):** `symbolId` OR `file` + `line` + `column` OR `language` + `symbol`
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | Conditional | Exact method handle. Omit coordinates and name selectors. |
 | `file` | string | Conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | Conditional | 1-based line number (any line within the method). Required for position-based lookup. |
 | `column` | integer | Conditional | 1-based column number (any position within the method). Required for position-based lookup. |
@@ -2884,6 +3253,7 @@ Finds the complete inheritance hierarchy for a method - all parent methods it ov
 ```json
 {
   "method": {
+    "symbolId": "sym-find-user-impl",
     "name": "findUser",
     "signature": "findUser(String id): User",
     "containingClass": "com.example.UserServiceImpl",
@@ -2893,6 +3263,7 @@ Finds the complete inheritance hierarchy for a method - all parent methods it ov
   },
   "hierarchy": [
     {
+      "symbolId": "sym-find-user-base",
       "name": "findUser",
       "signature": "findUser(String id): User",
       "containingClass": "com.example.AbstractUserService",
@@ -2904,6 +3275,7 @@ Finds the complete inheritance hierarchy for a method - all parent methods it ov
       "depth": 1
     },
     {
+      "symbolId": "sym-find-user-interface",
       "name": "findUser",
       "signature": "findUser(String id): User",
       "containingClass": "com.example.UserService",
@@ -2972,11 +3344,49 @@ PHP support requires the PHP plugin and is available in PhpStorm or IntelliJ IDE
 {
   "file": "src/main/kotlin/com/example/UserService.kt",
   "language": "Kotlin",
-  "structure": "interface UserService (lines 15-18)\n  fun findUser(id: String): User (line 16)\n  fun deleteUser(id: String) (line 17)\n\nclass UserServiceImpl (lines 20-42)\n  val repository: UserRepository (line 21)\n  override fun findUser(id: String): User (lines 23-29)\n  override fun deleteUser(id: String) (lines 30-35)\n  private fun validate(id: String) (lines 37-41)"
+  "structure": "interface UserService (lines 15-18)\n  fun findUser(id: String): User (line 16)\n  fun deleteUser(id: String) (line 17)\n\nclass UserServiceImpl (lines 20-42)\n  val repository: UserRepository (line 21)\n  override fun findUser(id: String): User (lines 23-29)\n  override fun deleteUser(id: String) (lines 30-35)\n  private fun validate(id: String) (lines 37-41)",
+  "nodes": [
+    {
+      "name": "UserService",
+      "kind": "INTERFACE",
+      "modifiers": ["public"],
+      "signature": "interface UserService",
+      "line": 15,
+      "endLine": 18,
+      "symbolId": "sym_user-service",
+      "children": [
+        {
+          "name": "findUser",
+          "kind": "METHOD",
+          "modifiers": [],
+          "signature": "fun findUser(id: String): User",
+          "line": 16,
+          "endLine": 16,
+          "symbolId": "sym_find-user",
+          "children": []
+        }
+      ]
+    }
+  ]
 }
 ```
 
-**Note:** Each element in the structure output includes both start and end line numbers (e.g., `(lines 42-65)` for multi-line elements, `(line 42)` for single-line elements), making it easy to identify the full extent of each declaration.
+**Compatibility:** `structure` remains the original human-readable tree. `nodes` is an additive
+structured representation of the same hierarchy. Every node has `name`, `kind`, `signature`
+(nullable), `modifiers`, 1-based `line`, nullable `endLine`, `children`, and nullable `symbolId`.
+The ID is created from the exact PSI element while the structure is extracted; it is not recovered
+later from a line number.
+
+All nodes remain present even for large outlines. Only the first 500 eligible nodes in preorder
+receive handles in one response, preventing an outline from evicting its own early IDs.
+`symbolIdsTruncated` reports whether this budget was hit; `symbolIdsOmitted` counts eligible nodes
+left without a handle. Use a targeted semantic query for a node without an ID. The ordinary
+session/TTL/LRU rules still apply to returned handles.
+
+Each element in `structure` still includes both start and end line numbers (for example,
+`(lines 42-65)` for multi-line elements and `(line 42)` for single-line elements). Kotlin nodes use
+semantic kinds (`INTERFACE`, `CLASS`, `ENUM`, `ANNOTATION`, `OBJECT`) instead of inferring the kind
+from the common `KtClass` implementation type.
 
 ---
 
@@ -3134,13 +3544,32 @@ Safely deletes an element, first checking for usages.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | Yes | Path to the file |
+| `target` | object | Conditional | Structured symbol selector containing exactly one of `symbolId`, `position: {file, line, column}`, or `qualifiedName` + `language`. Mutually exclusive with legacy top-level selectors. |
+| `symbolId` | string | Conditional | Exact symbol handle. Use only with `target_type: "symbol"` and omit coordinates. |
+| `file` | string | Conditional | Path to the file. Required for position-based symbol deletion and file deletion. |
+| `language` | string | Conditional | Legacy qualified-name selector language; requires `symbol` and is mutually exclusive with other target selectors. |
+| `symbol` | string | Conditional | Legacy qualified symbol name; requires `language` and is mutually exclusive with other target selectors. |
 | `target_type` | string | No | What to delete: `"symbol"` (default) or `"file"` (deletes the entire file if no symbol has external usages) |
 | `line` | integer | Conditional | 1-based line number. Required when `target_type` is `"symbol"` (the default) |
 | `column` | integer | Conditional | 1-based column number. Required when `target_type` is `"symbol"` (the default) |
 | `force` | boolean | No | Force deletion even if usages exist (default: false) |
+| `dryRun` | boolean | No | Resolve the target and discover usages/blockers without deleting or saving anything (default: `false`) |
 
 **Example Request:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_refactor_safe_delete",
+    "arguments": {
+      "symbolId": "sym_opaque-handle"
+    }
+  }
+}
+```
+
+**Example Request (position-based):**
 
 ```json
 {
@@ -3155,6 +3584,28 @@ Safely deletes an element, first checking for usages.
   }
 }
 ```
+
+**Example Request (preview):**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "ide_refactor_safe_delete",
+    "arguments": {
+      "target": { "symbolId": "sym_opaque-handle" },
+      "dryRun": true
+    }
+  }
+}
+```
+
+The common preview response is described in [Refactoring Preview Contract](#refactoring-preview-contract).
+For safe delete, `plannedChange` contains `operation: "safeDelete"`, `targetType`, `name`, and
+`force`. External usages contribute to both `usageCount` and `conflictCount`; `canApply` is false
+when usages exist and `force` is false, discovery was incomplete, or the target is not writable.
+Preview never invokes deletion, saves documents, or registers undo, and it does not invalidate the
+target's `symbolId`.
 
 **Example Request (delete an entire file):**
 
@@ -3176,7 +3627,8 @@ Safely deletes an element, first checking for usages.
 ```json
 {
   "success": true,
-  "message": "Successfully deleted 'LegacyHelper'"
+  "message": "Successfully deleted 'LegacyHelper'",
+  "invalidatedSymbolId": "sym_opaque-handle"
 }
 ```
 
@@ -3203,6 +3655,10 @@ Safely deletes an element, first checking for usages.
 ### Tool-Level Errors
 
 Tool failures (file not found, symbol not found, IDE indexing, refactoring conflicts, etc.) are reported as a normal `tools/call` result with `isError: true` and a human-readable message in `content`, per the MCP specification — never as JSON-RPC errors with custom codes.
+
+An invalid semantic handle is reported with the stable message prefix `SYMBOL_ID_EXPIRED`.
+Rediscover the symbol and retry with its new `symbolId`; do not reuse saved coordinates as a
+fallback because they may now identify a different declaration.
 
 ### Example Error Response
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
     implementation(libs.mcp.kotlin.sdk.server) { excludePlatformProvided() }
 
     implementation(libs.jtoon)
+    // Persistent hierarchy histories share unchanged storage across retriable cursor pages.
+    implementation(libs.kotlinx.collections.immutable) { excludePlatformProvided() }
 
     // Ktor engine. ktor-server-core arrives transitively from the SDK at the version the SDK was
     // compiled against, which is exactly what we want. CORS is not a dependency: the plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ opentest4j = "1.3.0"
 mcpKotlinSdk = "0.10.0"
 ktor = "3.2.3"
 kotlinxCoroutines = "1.9.0"
+kotlinxCollectionsImmutable = "0.4.0"
 jtoon = "1.0.9"
 
 # Testing
@@ -43,6 +44,7 @@ jtoon = { group = "dev.toonformat", name = "jtoon", version.ref = "jtoon" }
 
 # Kotlinx Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable-jvm", version.ref = "kotlinxCollectionsImmutable" }
 
 # Ktor. ktor-server-core arrives transitively via the MCP SDK; CIO is the engine. Content
 # negotiation is ours because kotlin-sdk 0.10.0 does not install it (see build.gradle.kts).

--- a/smoke-tests/mcp-protocol.md
+++ b/smoke-tests/mcp-protocol.md
@@ -12,7 +12,9 @@ build works before committing or raising a PR.
 Most tools this protocol exercises are **disabled by default** and hidden from `tools/list`:
 `ide_set_power_save_mode`, `ide_open_project`, `ide_close_project`, `ide_install_plugin`,
 `ide_restart`, `ide_set_lifecycle_log_file`, and every lifecycle tool except
-`ide_project_status` (see `DEFAULT_DISABLED_TOOLS` in `McpSettings.kt`). Enable them first in
+`ide_project_status` (see `DEFAULT_DISABLED_TOOLS` in `McpSettings.kt`). The contract checks below
+also need `ide_symbol_info`, `ide_find_symbol`, `ide_file_structure`, and `ide_change_signature`.
+Enable them first in
 Settings → Tools → Index MCP Server → Exposed Tools, or every affected step fails with a
 disabled-tool error on a fresh install.
 
@@ -176,6 +178,144 @@ PP=/path/to/jetbrains-index-mcp-plugin   # adjust to actual path
   timestamped entry within 15s
 - FAIL: response received but no `restarter.log` entry — likely a save-dialog prompt
   intercepted the restart. Fix: `saveAll()` before `restart(true)`, called via `edtAction {}`
+
+---
+
+## Semantic contract smoke tests
+
+Use a disposable project opened in the installed IDE. Include Java fixtures with overloaded
+methods, a local variable, callers, a small inheritance chain, and a call chain longer than two
+nodes. Include this physical Kotlin source (or an equivalent one) in a Kotlin-enabled module:
+
+```kotlin
+package smoke
+
+interface Contract
+class Implementation : Contract
+enum class State { READY }
+annotation class Marker
+object Singleton
+
+fun anonymous(): Contract = object : Contract {}
+```
+
+The Kotlin checks must run against the **installed IDE and its bundled Kotlin plugin**. The Gradle
+test fixture cannot load that plugin reliably and is not a substitute for this smoke test.
+
+### S1. Fresh `initialize` → `tools/list` schema
+
+1. Discard the MCP connection that existed before plugin install/restart. MCP clients such as
+   Codex cache `ALL_TOOLS`; reconnect or restart the client before judging the schema.
+2. Send a fresh initialize request:
+
+   ```json
+   {
+     "jsonrpc": "2.0",
+     "id": 1,
+     "method": "initialize",
+     "params": {
+       "protocolVersion": "2025-06-18",
+       "capabilities": {},
+       "clientInfo": { "name": "index-mcp-smoke", "version": "1" }
+     }
+   }
+   ```
+
+3. On that fresh connection, call `tools/list`.
+4. PASS: `capabilities.tools.listChanged` is absent or `false`, never `true`.
+5. PASS: semantic/refactoring schemas expose `symbolId` and structured `target`; the `target`
+   object exposes `symbolId`, `position`, `qualifiedName`, and `language` properties.
+6. PASS: `ide_refactor_rename`, `ide_refactor_safe_delete`, and `ide_change_signature` each expose
+   boolean `dryRun`.
+7. FAIL: only a pre-update schema is visible until the client reconnects. That is stale client
+   state, not a reason to advertise `listChanged: true`; the server does not yet send/serve that
+   notification on every transport.
+
+### S2. `symbolId`, unified targets, overloads, locals, and line shifts
+
+1. Discover an overloaded Java method and a local variable through semantic search/definition.
+2. PASS: results include opaque `sym_...` handles and each handle resolves the exact overload/local
+   through `ide_symbol_info` with `{ "target": { "symbolId": "..." } }`.
+3. Resolve the same declaration twice. PASS: both handles are valid even if they are unequal; do
+   not interpret ID equality as symbol equality.
+4. Insert lines above the declaration outside the IDE, call `ide_sync_files` for the changed file,
+   and reuse the original handle. PASS: it resolves at the new line.
+5. Preview and then apply a rename through that handle. PASS: references update and
+   `updatedSymbol.symbolId` resolves the renamed declaration with current metadata.
+6. Exercise all three nested variants — `target.symbolId`, `target.position`, and
+   `target.qualifiedName` + `language`. PASS: each resolves; mixing nested `target` with any legacy
+   top-level selector returns an error.
+7. Restart the MCP server and retry the old handle. PASS: `SYMBOL_ID_EXPIRED`; rediscovery is
+   required and the server does not fall back to saved coordinates.
+
+### S3. Refactoring previews are byte-for-byte non-mutating
+
+For each of `ide_refactor_rename`, `ide_refactor_safe_delete`, and `ide_change_signature`:
+
+1. Record SHA-256 for every file in the disposable fixture (for example with
+   `find <fixture> -type f -exec shasum -a 256 {} + | sort`).
+2. Call the refactoring with `dryRun: true`. Include a Java overloaded method/caller case; for safe
+   delete, cover both a referenced symbol (`canApply: false` without `force`) and an unused symbol.
+3. PASS: the response has `dryRun: true`, `canApply`, populated current `target`, an
+   operation-specific `plannedChange`, `affectedFiles`, `usageCount`, `conflictCount`, `warnings`,
+   and `elapsedMs`.
+4. Recompute SHA-256. PASS: the checksum list is byte-for-byte identical; no file appeared,
+   disappeared, or changed, no document was saved, and Undo has no preview command.
+5. Send the same request without `dryRun`. PASS: rename/change signature updates the exact overload
+   and its callers; safe delete removes the selected symbol/file and invalidates its handle.
+
+### S4. Kotlin metadata and structured file outline
+
+1. Run `ide_find_class`, `ide_find_symbol`, `ide_symbol_info`, and `ide_file_structure` against the
+   physical Kotlin fixture above.
+2. PASS: `Contract`, `Implementation`, `State`, `Marker`, and `Singleton` are classified as
+   `INTERFACE`, `CLASS`, `ENUM`, `ANNOTATION`, and `OBJECT` respectively where class-kind metadata
+   is returned.
+3. PASS: named declarations use `smoke.*` qualified names from Kotlin PSI.
+4. PASS: the object expression is named like
+   `<anonymous implementation of Contract at <file>:<line>>` and has `qualifiedName: null`.
+5. PASS: `ide_file_structure` retains the formatted `structure` string and adds `nodes`; every node
+   contains `name`, `kind`, nullable `signature`, `modifiers`, 1-based `line`, nullable `endLine`,
+   `children`, and nullable `symbolId`.
+6. Reuse a child node's ID with `ide_symbol_info`. PASS: it resolves that exact PSI declaration,
+   including when two declarations are placed on nearby lines.
+
+### S5. Hierarchy bounds and continuation
+
+1. Call `ide_type_hierarchy` on the Java hierarchy with `maxNodes: 2`.
+2. PASS: at most two non-root nodes are returned and expanded; `returnedNodes` matches the page,
+   `returnedNodes == traversal.length`, `truncated == hasMore`, `elapsedMs` is present, and
+   `cursor` is non-null when `hasMore` is true. Every traversal entry has direction `supertype` or
+   `subtype` and an `element` matching the corresponding legacy direction array.
+3. Continue with `{ "cursor": "...", "maxNodes": 2 }` until `hasMore: false`.
+4. PASS: concatenated `traversal` pages contain no duplicate nodes and preserve the observable
+   combined breadth-first order. Repeating the fresh query produces the same traversal order.
+   `supertypes` and `subtypes` remain backward-compatible filtered views; do not concatenate them
+   to verify combined order because that loses interleaving.
+5. Repeat for `ide_call_hierarchy` in both directions with a depth that spans multiple pages.
+   PASS: `calls` is a flat BFS page and never exceeds `maxNodes`.
+6. PASS: using a type cursor with the call tool, using a cursor through another project instance,
+   or reusing it after MCP restart returns an explicit cursor error and asks for a fresh query.
+7. Do not wait for push/live progress: stateless HTTP exposes progress only through page metadata.
+
+### S6. Multi-file diagnostics and deleted-path sync
+
+1. Call `ide_diagnostics` with two files, one containing a known error.
+2. PASS: `problems` is one aggregate list and `fileAnalyses` contains one entry per requested path
+   with `file`, `mode`, `fresh`, `timedOut`, and optional `message`.
+3. PASS: `file` + `files` together is rejected. `line`, `column`, `startLine`, or `endLine` with
+   `files` is rejected. A single `file` still returns the legacy top-level analysis metadata and
+   supports intentions/range filtering.
+4. Include enough slow files to exhaust the configured diagnostics timeout. PASS: the call uses one
+   overall budget and marks remaining file analyses timed out; it does not wait a new full timeout
+   per file.
+5. Create and externally delete a nested fixture path, then call `ide_sync_files` with that deleted
+   relative path.
+6. PASS: `requestedPaths` echoes it, `deletedPaths` contains it, and `refreshedRoots` names the
+   nearest existing parent actually refreshed. A following semantic search no longer sees the
+   deleted declaration.
+7. PASS: an absolute path, a `..` path, a symlink escape, or a `project_path` outside the selected
+   project/content roots is rejected before any member of the batch is refreshed.
 
 ---
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ErrorMessages.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ErrorMessages.kt
@@ -21,8 +21,12 @@ object ErrorMessages {
     // Symbol resolution errors
     const val SYMBOL_AND_POSITION_EXCLUSIVE =
         "Cannot specify both language+symbol and file+line+column. Use one or the other."
+    const val SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE =
+        "Cannot specify symbolId together with another target selector. Use symbolId by itself."
     const val SYMBOL_OR_POSITION_REQUIRED =
-        "Must specify either file+line+column or language+symbol to identify the target element."
+        "Must specify symbolId, file+line+column, or language+symbol to identify the target element."
+    fun symbolIdExpired(symbolId: String) =
+        "SYMBOL_ID_EXPIRED: symbolId '$symbolId' is unknown, expired, belongs to a different project instance, or its PSI element can no longer be restored. Discover the symbol again to obtain a new symbolId."
     fun missingParamForSymbol(param: String) =
         "Missing required parameter: $param (required when using symbol)"
     fun missingParamForPosition(param: String, others: String) =

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/constants/ParamNames.kt
@@ -24,6 +24,7 @@ object ParamNames {
     const val TARGET_DIRECTORY = "targetDirectory"
     const val REPLACE_ALL = "replaceAll"
     const val FORCE = "force"
+    const val DRY_RUN = "dryRun"
     const val TARGET_TYPE_CAMEL = "targetType"
     const val TARGET_TYPE = "target_type"
     const val OPTIMIZE_IMPORTS = "optimizeImports"
@@ -43,6 +44,7 @@ object ParamNames {
 
     // Symbol reference parameter
     const val SYMBOL = "symbol"
+    const val SYMBOL_ID = "symbolId"
 
     // Symbol search parameters
     const val QUERY = "query"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/LanguageHandler.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/LanguageHandler.kt
@@ -91,7 +91,10 @@ interface TypeHierarchyHandler : LanguageHandler<TypeHierarchyData> {
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES,
-        excludeGenerated: Boolean = false
+        excludeGenerated: Boolean = false,
+        directOnly: Boolean = false,
+        direction: TypeHierarchyDirection? = null,
+        page: HierarchyPageRequest? = null
     ): TypeHierarchyData?
 }
 
@@ -137,7 +140,8 @@ interface CallHierarchyHandler : LanguageHandler<CallHierarchyData> {
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope = BuiltInSearchScope.PROJECT_FILES,
-        excludeGenerated: Boolean = false
+        excludeGenerated: Boolean = false,
+        page: HierarchyPageRequest? = null
     ): CallHierarchyData?
 }
 
@@ -165,8 +169,47 @@ interface SuperMethodsHandler : LanguageHandler<SuperMethodsData> {
 data class TypeHierarchyData(
     val element: TypeElementData,
     val supertypes: List<TypeElementData>,
-    val subtypes: List<TypeElementData>
+    val subtypes: List<TypeElementData>,
+    /** Raw offset for the next direct-neighbour page, or null when this direction is complete. */
+    val nextOffset: Int? = null
 )
+
+enum class TypeHierarchyDirection { SUPERTYPE, SUBTYPE }
+
+/**
+ * Bounded direct-neighbour request used by hierarchy tools.
+ *
+ * Offset is deliberately server-side continuation state rather than a wire parameter. A handler
+ * may have to re-run an index query, but it must preserve that query's encounter order while the
+ * project is unchanged and must not silently apply its historical per-level cap while [page] is
+ * present. Tools may request an expanding prefix (`offset = 0`) so smart-pointer identity, rather
+ * than a mutable raw offset, decides what is new.
+ *
+ * Deterministic hierarchy order means breadth-first level order plus stable bounded discovery order
+ * for siblings. It does not mean globally sorting an entire direct-neighbour level: an index query
+ * may be unordered and exhausting it solely to sort all siblings would violate the bounded contract.
+ */
+data class HierarchyPageRequest(val offset: Int, val limit: Int) {
+    init {
+        require(offset >= 0) { "Hierarchy page offset must not be negative" }
+        require(limit >= 0) { "Hierarchy page limit must not be negative" }
+    }
+
+    /** One look-ahead item lets a handler prove whether another page exists. */
+    val collectionLimit: Int
+        get() = (offset.toLong() + limit.toLong() + 1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+}
+
+internal fun <T> List<T>.applyHierarchyPage(request: HierarchyPageRequest?): Pair<List<T>, Int?> {
+    if (request == null) return this to null
+    if (request.limit == 0) {
+        return emptyList<T>() to if (isNotEmpty()) request.offset else null
+    }
+    val from = request.offset.coerceAtMost(size)
+    val to = (from.toLong() + request.limit.toLong()).coerceAtMost(size.toLong()).toInt()
+    val result = subList(from, to)
+    return result to if (size > to) to else null
+}
 
 /**
  * Represents a type element in a hierarchy.
@@ -178,7 +221,8 @@ data class TypeElementData(
     val line: Int?,
     val kind: String,
     val language: String,
-    val supertypes: List<TypeElementData>? = null
+    val supertypes: List<TypeElementData>? = null,
+    val pointerTarget: PsiElement? = null
 )
 
 /**
@@ -190,7 +234,9 @@ data class ImplementationData(
     val line: Int,
     val column: Int,
     val kind: String,
-    val language: String
+    val language: String,
+    val qualifiedName: String? = null,
+    val pointerTarget: PsiElement? = null
 )
 
 /**
@@ -198,7 +244,9 @@ data class ImplementationData(
  */
 data class CallHierarchyData(
     val element: CallElementData,
-    val calls: List<CallElementData>
+    val calls: List<CallElementData>,
+    /** Raw offset for the next direct-neighbour page, or null when this level is complete. */
+    val nextOffset: Int? = null
 )
 
 /**
@@ -210,7 +258,8 @@ data class CallElementData(
     val line: Int,
     val column: Int,
     val language: String,
-    val children: List<CallElementData>? = null
+    val children: List<CallElementData>? = null,
+    val pointerTarget: PsiElement? = null
 )
 
 /**
@@ -224,7 +273,8 @@ data class SymbolData(
     val line: Int,
     val column: Int,
     val containerName: String?,
-    val language: String
+    val language: String,
+    val pointerTarget: PsiElement
 )
 
 /**
@@ -245,7 +295,8 @@ data class MethodData(
     val file: String,
     val line: Int,
     val column: Int,
-    val language: String
+    val language: String,
+    val pointerTarget: PsiElement? = null
 )
 
 /**
@@ -261,7 +312,8 @@ data class SuperMethodData(
     val column: Int?,
     val isInterface: Boolean,
     val depth: Int,
-    val language: String
+    val language: String,
+    val pointerTarget: PsiElement? = null
 )
 
 /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/OptimizedSymbolSearch.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/OptimizedSymbolSearch.kt
@@ -3,6 +3,7 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.java.JavaHierarchyMethodComplement
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.ChooseByNameContributorEx
 import com.intellij.navigation.NavigationItem
@@ -11,7 +12,6 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.codeStyle.MinusculeMatcher
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FindSymbolParameters
@@ -276,25 +276,14 @@ object OptimizedSymbolSearch {
         if (!scope.contains(file)) return null
         val relativePath = ProjectUtils.getToolFilePath(project, file)
 
-        val name = when (targetElement) {
-            is PsiNamedElement -> targetElement.name
-            else -> {
-                try {
-                    val method = targetElement.javaClass.getMethod("getName")
-                    method.invoke(targetElement) as? String
-                } catch (e: Exception) {
-                    null
-                }
-            }
-        } ?: return null
+        val name = PsiUtils.classDisplayName(project, targetElement) ?: return null
 
-        val directQualifiedName = try {
-            val method = targetElement.javaClass.getMethod("getQualifiedName")
-            method.invoke(targetElement) as? String
-        } catch (e: Exception) {
-            null
-        }
-        val qualifiedName = directQualifiedName ?: buildQualifiedNameFromContainer(targetElement, name)
+        val qualifiedName = PsiUtils.qualifiedName(targetElement)
+            ?: if (name.startsWith("<anonymous implementation of ")) {
+                null
+            } else {
+                buildQualifiedNameFromContainer(targetElement, name)
+            }
 
         val line = getLineNumber(project, targetElement) ?: 1
         val kind = determineKind(targetElement)
@@ -308,7 +297,8 @@ object OptimizedSymbolSearch {
             line = line,
             column = getColumnNumber(project, targetElement) ?: 1,
             containerName = containerName,
-            language = language
+            language = language,
+            pointerTarget = targetElement
         )
     }
 
@@ -316,14 +306,9 @@ object OptimizedSymbolSearch {
         var parent = element.parent
 
         while (parent != null) {
-            try {
-                val method = parent.javaClass.getMethod("getQualifiedName")
-                val parentQualifiedName = method.invoke(parent) as? String
-                if (!parentQualifiedName.isNullOrBlank()) {
-                    return "$parentQualifiedName.$name"
-                }
-            } catch (_: Exception) {
-                // Ignore and continue walking up the PSI tree.
+            val parentQualifiedName = PsiUtils.qualifiedName(parent)
+            if (!parentQualifiedName.isNullOrBlank()) {
+                return "$parentQualifiedName.$name"
             }
             parent = parent.parent
         }
@@ -366,6 +351,8 @@ object OptimizedSymbolSearch {
     }
 
     private fun determineKind(element: PsiElement): String {
+        PsiUtils.kotlinClassKind(element)?.let { return it }
+
         val className = element.javaClass.simpleName.lowercase()
         return when {
             // Rust types

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/go/GoHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/go/GoHandlers.kt
@@ -4,6 +4,8 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.*
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -12,6 +14,7 @@ import com.intellij.psi.search.searches.DefinitionsScopedSearch
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
+import kotlinx.coroutines.CancellationException
 
 /**
  * Registration entry point for Go language handlers.
@@ -354,15 +357,30 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        directOnly: Boolean,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
     ): TypeHierarchyData? {
         val goType = findContainingGoType(element) ?: return null
         LOG.debug("Getting type hierarchy for Go type: ${getName(goType)}")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val specType = getSpecType(goType)
-        val supertypes = getSupertypes(project, goType, specType, searchScope = searchScope)
-        val subtypes = getSubtypes(project, goType, specType, searchScope)
+        val collectionLimit = page?.collectionLimit ?: 100
+        val rawSupertypes = if (direction != TypeHierarchyDirection.SUBTYPE) {
+            getSupertypes(project, goType, specType, searchScope = searchScope, directOnly = directOnly)
+                .take(collectionLimit)
+        } else emptyList()
+        val rawSubtypes = if (direction != TypeHierarchyDirection.SUPERTYPE) {
+            getSubtypes(project, goType, specType, searchScope, collectionLimit)
+        } else emptyList()
+        val (supertypes, superNext) = if (direction == TypeHierarchyDirection.SUPERTYPE) {
+            rawSupertypes.applyHierarchyPage(page)
+        } else rawSupertypes to null
+        val (subtypes, subtypeNext) = if (direction == TypeHierarchyDirection.SUBTYPE) {
+            rawSubtypes.applyHierarchyPage(page)
+        } else rawSubtypes to null
 
         LOG.debug("Found ${supertypes.size} supertypes and ${subtypes.size} subtypes")
 
@@ -373,10 +391,12 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
                 file = goType.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, goType),
                 kind = determineTypeKind(goType),
-                language = "Go"
+                language = "Go",
+                pointerTarget = goType
             ),
             supertypes = supertypes,
-            subtypes = subtypes
+            subtypes = subtypes,
+            nextOffset = superNext ?: subtypeNext
         )
     }
 
@@ -386,7 +406,8 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
         specType: PsiElement?,
         visited: MutableSet<String> = mutableSetOf(),
         depth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false
     ): List<TypeElementData> {
         if (depth > MAX_HIERARCHY_DEPTH) return emptyList()
 
@@ -400,11 +421,11 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
             when {
                 specType != null && isGoStructType(specType) -> {
                     // For structs, look for embedded types
-                    supertypes.addAll(getEmbeddedTypes(project, specType, visited, depth, searchScope))
+                    supertypes.addAll(getEmbeddedTypes(project, specType, visited, depth, searchScope, directOnly))
                 }
                 specType != null && isGoInterfaceType(specType) -> {
                     // For interfaces, look for embedded interfaces
-                    supertypes.addAll(getEmbeddedInterfaces(project, specType, visited, depth, searchScope))
+                    supertypes.addAll(getEmbeddedInterfaces(project, specType, visited, depth, searchScope, directOnly))
                 }
             }
         } catch (e: Exception) {
@@ -419,7 +440,8 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
         structType: PsiElement,
         visited: MutableSet<String>,
         depth: Int,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean
     ): List<TypeElementData> {
         val embeddedTypes = mutableListOf<TypeElementData>()
 
@@ -443,13 +465,14 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
                                 isGoTypeSpec(resolvedType) &&
                                 shouldIncludeNavigationElement(searchScope, resolvedType)
                             ) {
-                                val superSupertypes = getSupertypes(
+                                val superSupertypes = if (directOnly) emptyList() else getSupertypes(
                                     project,
                                     resolvedType,
                                     getSpecType(resolvedType),
                                     visited,
                                     depth + 1,
-                                    searchScope
+                                    searchScope,
+                                    directOnly = false
                                 )
                                 embeddedTypes.add(TypeElementData(
                                     name = getQualifiedName(resolvedType) ?: embeddedTypeName,
@@ -458,7 +481,8 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
                                     line = getLineNumber(project, resolvedType),
                                     kind = determineTypeKind(resolvedType),
                                     language = "Go",
-                                    supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                                    supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                                    pointerTarget = resolvedType
                                 ))
                             }
                         }
@@ -479,7 +503,8 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
         interfaceType: PsiElement,
         visited: MutableSet<String>,
         depth: Int,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean
     ): List<TypeElementData> {
         val embeddedInterfaces = mutableListOf<TypeElementData>()
 
@@ -502,13 +527,14 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
                             isGoTypeSpec(resolvedType) &&
                             shouldIncludeNavigationElement(searchScope, resolvedType)
                         ) {
-                            val superSupertypes = getSupertypes(
+                            val superSupertypes = if (directOnly) emptyList() else getSupertypes(
                                 project,
                                 resolvedType,
                                 getSpecType(resolvedType),
                                 visited,
                                 depth + 1,
-                                searchScope
+                                searchScope,
+                                directOnly = false
                             )
                             embeddedInterfaces.add(TypeElementData(
                                 name = getQualifiedName(resolvedType) ?: embeddedName,
@@ -517,7 +543,8 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
                                 line = getLineNumber(project, resolvedType),
                                 kind = "INTERFACE",
                                 language = "Go",
-                                supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                                supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                                pointerTarget = resolvedType
                             ))
                         }
                     }
@@ -546,7 +573,8 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
         project: Project,
         goType: PsiElement,
         specType: PsiElement?,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<TypeElementData> {
         // Use DefinitionsScopedSearch for finding implementing types
         try {
@@ -560,10 +588,11 @@ class GoTypeHierarchyHandler : BaseGoHandler<TypeHierarchyData>(), TypeHierarchy
                         file = definition.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, definition),
                         kind = determineTypeKind(definition),
-                        language = "Go"
+                        language = "Go",
+                        pointerTarget = definition
                     ))
                 }
-                results.size < 100
+                results.size < maxResults
             })
 
             LOG.debug("Found ${results.size} subtypes via DefinitionsScopedSearch")
@@ -645,7 +674,8 @@ class GoImplementationsHandler : BaseGoHandler<List<ImplementationData>>(), Impl
                             line = getLineNumber(project, definition) ?: 0,
                             column = getColumnNumber(project, definition) ?: 0,
                             kind = kind,
-                            language = "Go"
+                            language = "Go",
+                            pointerTarget = definition
                         ))
                     }
                 }
@@ -679,7 +709,8 @@ class GoImplementationsHandler : BaseGoHandler<List<ImplementationData>>(), Impl
                             line = getLineNumber(project, definition) ?: 0,
                             column = getColumnNumber(project, definition) ?: 0,
                             kind = determineTypeKind(definition),
-                            language = "Go"
+                            language = "Go",
+                            pointerTarget = definition
                         ))
                     }
                 }
@@ -719,24 +750,28 @@ class GoCallHierarchyHandler : BaseGoHandler<CallHierarchyData>(), CallHierarchy
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        page: HierarchyPageRequest?
     ): CallHierarchyData? {
         val goFunction = findContainingGoFunction(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(goFunction)}, direction=$direction, depth=$depth")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
-        val calls = if (direction == "callers") {
-            findCallersRecursive(project, goFunction, depth, visited, searchScope = searchScope)
+        val maxResults = page?.collectionLimit ?: MAX_RESULTS_PER_LEVEL
+        val rawCalls = if (direction == "callers") {
+            findCallersRecursive(project, goFunction, depth, visited, searchScope = searchScope, maxResults = maxResults)
         } else {
-            findCalleesRecursive(project, goFunction, depth, visited, searchScope = searchScope)
+            findCalleesRecursive(project, goFunction, depth, visited, searchScope = searchScope, maxResults = maxResults)
         }
+        val (calls, nextOffset) = rawCalls.applyHierarchyPage(page)
 
         LOG.debug("Found ${calls.size} $direction")
 
         return CallHierarchyData(
             element = createCallElement(project, goFunction),
-            calls = calls
+            calls = calls,
+            nextOffset = nextOffset
         )
     }
 
@@ -746,42 +781,65 @@ class GoCallHierarchyHandler : BaseGoHandler<CallHierarchyData>(), CallHierarchy
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val functionKey = getFunctionKey(goFunction)
         if (functionKey in visited) return emptyList()
         visited.add(functionKey)
 
         return try {
-            // Use platform ReferencesSearch API with Processor pattern
-            val references = mutableListOf<com.intellij.psi.PsiReference>()
+            val results = mutableListOf<CallElementData>()
+            val seenCallers = mutableSetOf<String>()
+            val seenResults = mutableSetOf<String>()
 
             ReferencesSearch.search(goFunction, searchScope).forEach(Processor { reference ->
-                references.add(reference)
-                references.size < MAX_RESULTS_PER_LEVEL * 2
-            })
-
-            LOG.debug("Found ${references.size} references for ${getName(goFunction)}")
-
-            val results = mutableListOf<CallElementData>()
-            for (reference in references) {
-                if (results.size >= MAX_RESULTS_PER_LEVEL) break
                 val refElement = reference.element
                 val containingFunction = findContainingGoFunction(refElement)
                 if (containingFunction != null && containingFunction != goFunction) {
-                    val children = if (depth > 1) {
-                        findCallersRecursive(project, containingFunction, depth - 1, visited, stackDepth + 1, searchScope)
-                    } else null
-                    if (shouldIncludeNavigationElement(searchScope, containingFunction)) {
-                        results.add(createCallElement(project, containingFunction, children))
-                    } else if (children != null) {
-                        results.addAll(children)
+                    val callerPath = containingFunction.containingFile?.virtualFile?.path.orEmpty()
+                    val callerIdentity =
+                        "$callerPath:${containingFunction.textOffset}:${getFunctionKey(containingFunction)}"
+                    if (seenCallers.add(callerIdentity)) {
+                        val children = if (depth > 1) {
+                            findCallersRecursive(
+                                project,
+                                containingFunction,
+                                depth - 1,
+                                visited,
+                                stackDepth + 1,
+                                searchScope,
+                                maxResults
+                            )
+                        } else null
+                        val candidates = if (shouldIncludeNavigationElement(searchScope, containingFunction)) {
+                            listOf(createCallElement(project, containingFunction, children))
+                        } else {
+                            children.orEmpty()
+                        }
+                        for (candidate in candidates) {
+                            if (results.size >= maxResults) break
+                            val resultIdentity = "${candidate.name}:${candidate.file}:${candidate.line}"
+                            if (seenResults.add(resultIdentity)) {
+                                results.add(candidate)
+                            }
+                        }
                     }
                 }
-            }
-            results.distinctBy { it.name + it.file + it.line }.take(MAX_RESULTS_PER_LEVEL)
+                results.size < maxResults
+            })
+
+            LOG.debug("Found ${results.size} callers for ${getName(goFunction)}")
+            results
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IndexNotReadyException) {
+            throw e
         } catch (e: Exception) {
             LOG.warn("Error finding callers: ${e.message}")
             emptyList()
@@ -794,7 +852,8 @@ class GoCallHierarchyHandler : BaseGoHandler<CallHierarchyData>(), CallHierarchy
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
 
@@ -808,11 +867,14 @@ class GoCallHierarchyHandler : BaseGoHandler<CallHierarchyData>(), CallHierarchy
             @Suppress("UNCHECKED_CAST")
             val callExpressions = PsiTreeUtil.findChildrenOfType(goFunction, goCallExpr as Class<out PsiElement>)
 
-            callExpressions.take(MAX_RESULTS_PER_LEVEL).forEach { callExpr ->
+            for (callExpr in callExpressions) {
+                if (callees.size >= maxResults) break
                 val calledFunction = resolveCallExpression(callExpr)
                 if (calledFunction != null && (isGoFunction(calledFunction) || isGoMethod(calledFunction))) {
                     val children = if (depth > 1) {
-                        findCalleesRecursive(project, calledFunction, depth - 1, visited, stackDepth + 1, searchScope)
+                        findCalleesRecursive(
+                            project, calledFunction, depth - 1, visited, stackDepth + 1, searchScope, maxResults
+                        )
                     } else null
                     if (shouldIncludeNavigationElement(searchScope, calledFunction)) {
                         val element = createCallElement(project, calledFunction, children)
@@ -879,7 +941,8 @@ class GoCallHierarchyHandler : BaseGoHandler<CallHierarchyData>(), CallHierarchy
             line = getLineNumber(project, goFunction) ?: 0,
             column = getColumnNumber(project, goFunction) ?: 0,
             language = "Go",
-            children = children?.takeIf { it.isNotEmpty() }
+            children = children?.takeIf { it.isNotEmpty() },
+            pointerTarget = goFunction
         )
     }
 
@@ -933,7 +996,8 @@ class GoSuperMethodsHandler : BaseGoHandler<SuperMethodsData>(), SuperMethodsHan
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, goFunction) ?: 0,
             column = getColumnNumber(project, goFunction) ?: 0,
-            language = "Go"
+            language = "Go",
+            pointerTarget = goFunction
         )
 
         val hierarchy = buildHierarchy(project, goFunction)
@@ -1013,7 +1077,8 @@ class GoSuperMethodsHandler : BaseGoHandler<SuperMethodsData>(), SuperMethodsHan
                                         column = getColumnNumber(project, embeddedMethod),
                                         isInterface = false,
                                         depth = depth,
-                                        language = "Go"
+                                        language = "Go",
+                                        pointerTarget = embeddedMethod
                                     ))
 
                                     // Recursively find in embedded types of the embedded type

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaHandlers.kt
@@ -11,6 +11,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiSourcePosition
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
@@ -132,15 +133,29 @@ abstract class BaseJavaHandler<T> : LanguageHandler<T> {
     }
 
     protected fun getClassKind(psiClass: PsiClass): String {
+        PsiUtils.kotlinClassKind(psiClass.navigationElement)?.let { return it }
+
         return when {
-            psiClass.isInterface -> "INTERFACE"
-            psiClass.isEnum -> "ENUM"
             psiClass.isAnnotationType -> "ANNOTATION"
             psiClass.isRecord -> "RECORD"
+            psiClass.isEnum -> "ENUM"
+            psiClass.isInterface -> "INTERFACE"
             psiClass.hasModifierProperty("abstract") -> "ABSTRACT_CLASS"
             else -> "CLASS"
         }
     }
+
+    /** Prefer the physical declaration so Kotlin `getFqName()` participates in metadata. */
+    protected fun getQualifiedClassName(psiClass: PsiClass): String? =
+        PsiUtils.qualifiedName(psiClass.navigationElement)
+            ?: PsiUtils.qualifiedName(psiClass)
+
+    protected fun getClassDisplayName(project: Project, psiClass: PsiClass): String =
+        getQualifiedClassName(psiClass)
+            ?: psiClass.name
+            ?: PsiUtils.classDisplayName(project, psiClass.navigationElement)
+            ?: PsiUtils.classDisplayName(project, psiClass)
+            ?: "unknown"
 
     protected fun findContainingClass(element: PsiElement): PsiClass? {
         if (element is PsiClass) return element
@@ -325,15 +340,35 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        directOnly: Boolean,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
     ): TypeHierarchyData? {
         // Use reference-aware resolution: if cursor is on a type reference,
         // resolve to the actual class being referenced
         val psiClass = resolveClass(element) ?: return null
 
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
-        val supertypes = getSupertypes(project, psiClass, searchScope = searchScope)
-        val subtypes = getSubtypes(project, psiClass, searchScope)
+        val collectionLimit = page?.collectionLimit ?: 100
+        val rawSupertypes = if (direction != TypeHierarchyDirection.SUBTYPE) {
+            getSupertypes(
+                project,
+                psiClass,
+                searchScope = searchScope,
+                directOnly = directOnly,
+                maxResults = collectionLimit
+            )
+        } else emptyList()
+        val rawSubtypes = if (direction != TypeHierarchyDirection.SUPERTYPE) {
+            getSubtypes(project, psiClass, searchScope, directOnly, collectionLimit)
+        } else emptyList()
+        val (supertypes, superNext) = if (direction == TypeHierarchyDirection.SUPERTYPE) {
+            rawSupertypes.applyHierarchyPage(page)
+        } else rawSupertypes to null
+        val (subtypes, subtypeNext) = if (direction == TypeHierarchyDirection.SUBTYPE) {
+            rawSubtypes.applyHierarchyPage(page)
+        } else rawSubtypes to null
 
         // Detect language from the navigation element (original source), not the light class wrapper.
         // What a light class reports for getLanguage() varies by platform version; navigationElement
@@ -342,15 +377,17 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
 
         return TypeHierarchyData(
             element = TypeElementData(
-                name = psiClass.qualifiedName ?: psiClass.name ?: "unknown",
-                qualifiedName = psiClass.qualifiedName,
+                name = getClassDisplayName(project, psiClass),
+                qualifiedName = getQualifiedClassName(psiClass),
                 file = psiClass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, psiClass),
                 kind = getClassKind(psiClass),
-                language = language
+                language = language,
+                pointerTarget = psiClass
             ),
             supertypes = supertypes,
-            subtypes = subtypes
+            subtypes = subtypes,
+            nextOffset = superNext ?: subtypeNext
         )
     }
 
@@ -359,11 +396,16 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
         psiClass: PsiClass,
         visited: MutableSet<String> = mutableSetOf(),
         depth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false,
+        maxResults: Int = 100
     ): List<TypeElementData> {
-        if (depth > MAX_HIERARCHY_DEPTH) return emptyList()
+        if (depth > MAX_HIERARCHY_DEPTH || maxResults <= 0) return emptyList()
 
-        val className = psiClass.qualifiedName ?: psiClass.name ?: return emptyList()
+        val className = getQualifiedClassName(psiClass)
+            ?: psiClass.name
+            ?: PsiUtils.classDisplayName(project, psiClass)
+            ?: return emptyList()
         if (className in visited) return emptyList()
         visited.add(className)
 
@@ -381,41 +423,45 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
         val superClass = psiClass.superClass
         if (superClass != null && superClass.qualifiedName != "java.lang.Object") {
             if (shouldIncludeNavigationElement(searchScope, superClass)) {
-                val superSupertypes = getSupertypes(
-                    project,
-                    superClass,
-                    visited,
-                    depth + 1,
-                    searchScope
+                val superSupertypes = if (directOnly) emptyList() else getSupertypes(
+                    project, superClass, visited, depth + 1, searchScope, directOnly = false
                 )
                 supertypes.add(TypeElementData(
-                    name = superClass.qualifiedName ?: superClass.name ?: "unknown",
-                    qualifiedName = superClass.qualifiedName,
+                    name = getClassDisplayName(project, superClass),
+                    qualifiedName = getQualifiedClassName(superClass),
                     file = superClass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                     line = getLineNumber(project, superClass),
                     kind = getClassKind(superClass),
                     language = if (superClass.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
-                    supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                    supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                    pointerTarget = superClass
                 ))
             }
         } else {
             // Fallback: check unresolved extends list (when type resolution fails)
-            psiClass.extendsList?.referenceElements?.forEach { ref ->
+            for (ref in psiClass.extendsList?.referenceElements.orEmpty()) {
+                ProgressManager.checkCanceled()
+                if (supertypes.size >= maxResults) break
                 val resolved = ref.resolve() as? PsiClass
-                if (resolved != null &&
-                    resolved.qualifiedName != "java.lang.Object" &&
-                    shouldIncludeNavigationElement(searchScope, resolved)
-                ) {
-                    val superSupertypes = getSupertypes(project, resolved, visited, depth + 1, searchScope)
-                    (resolved.qualifiedName ?: resolved.name)?.let { fallbackAdded.add(it) }
+                if (resolved != null) {
+                    // An excluded resolved declaration is not an unresolved fallback. Count the
+                    // limit only after filtering, or an early library/generated prefix hides
+                    // later project supertypes and falsely reports the hierarchy as exhausted.
+                    if (resolved.qualifiedName == "java.lang.Object" ||
+                        !shouldIncludeNavigationElement(searchScope, resolved)
+                    ) continue
+                    val superSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, resolved, visited, depth + 1, searchScope, directOnly = false)
+                    (getQualifiedClassName(resolved) ?: resolved.name)?.let { fallbackAdded.add(it) }
                     supertypes.add(TypeElementData(
-                        name = resolved.qualifiedName ?: resolved.name ?: "unknown",
-                        qualifiedName = resolved.qualifiedName,
+                        name = getClassDisplayName(project, resolved),
+                        qualifiedName = getQualifiedClassName(resolved),
                         file = resolved.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, resolved),
                         kind = getClassKind(resolved),
                         language = if (resolved.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
-                        supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = resolved
                     ))
                 } else {
                     // Can't resolve, but report the declared type name
@@ -438,37 +484,46 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
         val interfaces = psiClass.interfaces
         if (interfaces.isNotEmpty()) {
             for (iface in interfaces) {
+                ProgressManager.checkCanceled()
+                if (supertypes.size >= maxResults) break
                 // Skip interfaces the extends-list fallback already reported (interface-extends-
                 // interface case) — the fallback entry carries the transitive supertype chain.
-                val ifaceKey = iface.qualifiedName ?: iface.name
+                val ifaceKey = getQualifiedClassName(iface) ?: iface.name
                 if (ifaceKey != null && ifaceKey in fallbackAdded) continue
                 if (shouldIncludeNavigationElement(searchScope, iface)) {
-                    val ifaceSupertypes = getSupertypes(project, iface, visited, depth + 1, searchScope)
+                    val ifaceSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, iface, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
-                        name = iface.qualifiedName ?: iface.name ?: "unknown",
-                        qualifiedName = iface.qualifiedName,
+                        name = getClassDisplayName(project, iface),
+                        qualifiedName = getQualifiedClassName(iface),
                         file = iface.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, iface),
                         kind = "INTERFACE",
                         language = if (iface.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
-                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = iface
                     ))
                 }
             }
         } else {
             // Fallback: check unresolved implements list (when type resolution fails)
-            psiClass.implementsList?.referenceElements?.forEach { ref ->
+            for (ref in psiClass.implementsList?.referenceElements.orEmpty()) {
+                ProgressManager.checkCanceled()
+                if (supertypes.size >= maxResults) break
                 val resolved = ref.resolve() as? PsiClass
-                if (resolved != null && shouldIncludeNavigationElement(searchScope, resolved)) {
-                    val ifaceSupertypes = getSupertypes(project, resolved, visited, depth + 1, searchScope)
+                if (resolved != null) {
+                    if (!shouldIncludeNavigationElement(searchScope, resolved)) continue
+                    val ifaceSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, resolved, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
-                        name = resolved.qualifiedName ?: resolved.name ?: "unknown",
-                        qualifiedName = resolved.qualifiedName,
+                        name = getClassDisplayName(project, resolved),
+                        qualifiedName = getQualifiedClassName(resolved),
                         file = resolved.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, resolved),
                         kind = "INTERFACE",
                         language = if (resolved.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
-                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = resolved
                     ))
                 } else {
                     // Can't resolve, but report the declared type name
@@ -485,28 +540,31 @@ class JavaTypeHierarchyHandler : BaseJavaHandler<TypeHierarchyData>(), TypeHiera
             }
         }
 
-        return supertypes
+        return supertypes.take(maxResults)
     }
 
     private fun getSubtypes(
         project: Project,
         psiClass: PsiClass,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false,
+        maxResults: Int = 100
     ): List<TypeElementData> {
         val results = mutableListOf<TypeElementData>()
         try {
-            ClassInheritorsSearch.search(psiClass, searchScope, true).forEach(Processor { subClass ->
+            ClassInheritorsSearch.search(psiClass, searchScope, !directOnly).forEach(Processor { subClass ->
                 if (shouldIncludeNavigationElement(searchScope, subClass)) {
                     results.add(TypeElementData(
-                        name = subClass.qualifiedName ?: subClass.name ?: "unknown",
-                        qualifiedName = subClass.qualifiedName,
+                        name = getClassDisplayName(project, subClass),
+                        qualifiedName = getQualifiedClassName(subClass),
                         file = subClass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, subClass),
                         kind = getClassKind(subClass),
-                        language = if (subClass.language.id == "kotlin") "Kotlin" else "Java"
+                        language = if (subClass.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
+                        pointerTarget = subClass
                     ))
                 }
-                results.size < 100
+                results.size < maxResults
             })
         } catch (e: ProcessCanceledException) {
             // Cancellation and dumb-mode must propagate — swallowing them would report a
@@ -574,7 +632,9 @@ class JavaImplementationsHandler : BaseJavaHandler<List<ImplementationData>>(), 
                         line = getLineNumber(project, overridingMethod) ?: 0,
                         column = getColumnNumber(project, overridingMethod) ?: 0,
                         kind = "METHOD",
-                        language = if (overridingMethod.language.id == "kotlin") "Kotlin" else "Java"
+                        language = if (overridingMethod.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
+                        qualifiedName = null,
+                        pointerTarget = overridingMethod
                     ))
                 }
                 results.size < MAX_COLLECTED_NAVIGATION_RESULTS
@@ -604,12 +664,14 @@ class JavaImplementationsHandler : BaseJavaHandler<List<ImplementationData>>(), 
                 val file = inheritor.containingFile?.virtualFile
                 if (file != null && shouldIncludeNavigationElement(searchScope, inheritor)) {
                     results.add(ImplementationData(
-                        name = inheritor.qualifiedName ?: inheritor.name ?: "unknown",
+                        name = getClassDisplayName(project, inheritor),
                         file = getRelativePath(project, file),
                         line = getLineNumber(project, inheritor) ?: 0,
                         column = getColumnNumber(project, inheritor) ?: 0,
                         kind = getClassKind(inheritor),
-                        language = if (inheritor.language.id == "kotlin") "Kotlin" else "Java"
+                        language = if (inheritor.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
+                        qualifiedName = getQualifiedClassName(inheritor),
+                        pointerTarget = inheritor
                     ))
                 }
                 results.size < MAX_COLLECTED_NAVIGATION_RESULTS
@@ -666,7 +728,8 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        page: HierarchyPageRequest?
     ): CallHierarchyData? {
         // Use reference-aware resolution: if cursor is on a method call,
         // resolve to the actual method being called
@@ -674,15 +737,18 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         val visited = mutableSetOf<String>()
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
-        val calls = if (direction == "callers") {
-            findCallersRecursive(project, method, depth, visited, searchScope = searchScope)
+        val collectionLimit = page?.collectionLimit ?: MAX_RESULTS_PER_LEVEL
+        val rawCalls = if (direction == "callers") {
+            findCallersRecursive(project, method, depth, visited, searchScope = searchScope, maxResults = collectionLimit)
         } else {
-            findCalleesRecursive(project, method, depth, visited, searchScope = searchScope)
+            findCalleesRecursive(project, method, depth, visited, searchScope = searchScope, maxResults = collectionLimit)
         }
+        val (calls, nextOffset) = rawCalls.applyHierarchyPage(page)
 
         return CallHierarchyData(
             element = createCallElement(project, method),
-            calls = calls
+            calls = calls,
+            nextOffset = nextOffset
         )
     }
 
@@ -692,9 +758,11 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val methodKey = getMethodKey(method)
         if (methodKey in visited) return emptyList()
@@ -704,18 +772,58 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
             val methodsToSearch = mutableSetOf(method)
             methodsToSearch.addAll(method.findDeepestSuperMethods().take(10))
 
-            val allReferences = mutableListOf<PsiElement>()
-            // Dedup key includes file path — textOffset alone is not globally unique across files
-            val seenKeys = mutableSetOf<String>()
+            val results = mutableListOf<CallElementData>()
+            val seenCallers = mutableSetOf<String>()
+            val seenResults = mutableSetOf<String>()
+
+            fun collectCaller(refElement: PsiElement): Boolean {
+                if (results.size >= maxResults) return false
+
+                val containingMethod = PsiTreeUtil.getParentOfType(refElement, PsiMethod::class.java)
+                    ?: resolveKotlinMethod(refElement)
+                if (
+                    containingMethod == null ||
+                    containingMethod == method ||
+                    methodsToSearch.contains(containingMethod)
+                ) {
+                    return true
+                }
+
+                val callerPath = containingMethod.containingFile?.virtualFile?.path.orEmpty()
+                val callerIdentity = "$callerPath:${containingMethod.textOffset}:${getMethodKey(containingMethod)}"
+                if (!seenCallers.add(callerIdentity)) return true
+
+                val children = if (depth > 1) {
+                    findCallersRecursive(
+                        project,
+                        containingMethod,
+                        depth - 1,
+                        visited,
+                        stackDepth + 1,
+                        searchScope,
+                        maxResults
+                    )
+                } else null
+                val candidates = if (shouldIncludeNavigationElement(searchScope, containingMethod)) {
+                    listOf(createCallElement(project, containingMethod, children))
+                } else {
+                    children.orEmpty()
+                }
+                for (candidate in candidates) {
+                    if (results.size >= maxResults) break
+                    val resultIdentity = callElementKey(candidate)
+                    if (seenResults.add(resultIdentity)) {
+                        results.add(candidate)
+                    }
+                }
+                return results.size < maxResults
+            }
+
             for (methodToSearch in methodsToSearch) {
-                if (allReferences.size >= MAX_RESULTS_PER_LEVEL * 2) break
+                if (results.size >= maxResults) break
                 MethodReferencesSearch.search(methodToSearch, searchScope, true)
                     .forEach(Processor { reference ->
-                        val file = reference.element.containingFile?.virtualFile?.path ?: ""
-                        if (seenKeys.add("$file:${reference.element.textOffset}")) {
-                            allReferences.add(reference.element)
-                        }
-                        allReferences.size < MAX_RESULTS_PER_LEVEL * 2
+                        collectCaller(reference.element)
                     })
             }
 
@@ -725,49 +833,21 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
             // sites. This causes MethodReferencesSearch to miss all callers of suspend funs in
             // concrete classes. ReferencesSearch on the KtNamedFunction resolves this — it is the
             // same approach used by ide_find_references (FindUsagesTool), which always works.
-            // Deduplication via seenKeys prevents double-counting when both searches find the same ref.
-            // Note: do NOT guard this with `if (allReferences.isEmpty())`. That original guard caused
+            // Semantic caller deduplication prevents double-counting when both searches find the same ref.
+            // Note: do NOT guard this with `if (results.isEmpty())`. That original guard caused
             // the fix to be silently skipped whenever MethodReferencesSearch returned any result
             // (even declaration-site or annotation references that later get filtered out).
             for (methodToSearch in methodsToSearch) {
-                if (allReferences.size >= MAX_RESULTS_PER_LEVEL * 2) break
+                if (results.size >= maxResults) break
                 val navElement = methodToSearch.navigationElement ?: continue
                 if (navElement.language.id != "kotlin") continue
                 // Use element.useScope (no explicit scope arg) — matches FindUsagesTool behaviour
                 ReferencesSearch.search(navElement, searchScope)
                     .forEach(Processor { reference ->
-                        val file = reference.element.containingFile?.virtualFile?.path ?: ""
-                        if (seenKeys.add("$file:${reference.element.textOffset}")) {
-                            allReferences.add(reference.element)
-                        }
-                        allReferences.size < MAX_RESULTS_PER_LEVEL * 2
+                        collectCaller(reference.element)
                     })
             }
-
-            val results = mutableListOf<CallElementData>()
-            for (refElement in allReferences) {
-                if (results.size >= MAX_RESULTS_PER_LEVEL) break
-                val containingMethod = PsiTreeUtil.getParentOfType(refElement, PsiMethod::class.java)
-                    ?: resolveKotlinMethod(refElement)
-                if (containingMethod != null && containingMethod != method && !methodsToSearch.contains(containingMethod)) {
-                    val children = if (depth > 1) {
-                        findCallersRecursive(
-                            project,
-                            containingMethod,
-                            depth - 1,
-                            visited,
-                            stackDepth + 1,
-                            searchScope
-                        )
-                    } else null
-                    if (shouldIncludeNavigationElement(searchScope, containingMethod)) {
-                        results.add(createCallElement(project, containingMethod, children))
-                    } else if (children != null) {
-                        results.addAll(children)
-                    }
-                }
-            }
-            results.distinctBy { it.name + it.file + it.line }.take(MAX_RESULTS_PER_LEVEL)
+            results
         } catch (e: ProcessCanceledException) {
             // Cancellation and dumb-mode must propagate — swallowing them would report a
             // truncated result set as a complete success.
@@ -787,7 +867,8 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
 
@@ -799,22 +880,25 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         try {
             // Try Java PSI first (works for Java methods that have a body)
             method.body?.let { body ->
-                PsiTreeUtil.findChildrenOfType(body, PsiMethodCallExpression::class.java)
-                    .take(MAX_RESULTS_PER_LEVEL)
-                    .forEach { methodCall ->
+                for (methodCall in PsiTreeUtil.findChildrenOfType(body, PsiMethodCallExpression::class.java)) {
+                    if (callees.size >= maxResults) break
                         val calledMethod = methodCall.resolveMethod()
                         if (calledMethod != null) {
                             val children = if (depth > 1) {
-                                findCalleesRecursive(project, calledMethod, depth - 1, visited, stackDepth + 1, searchScope)
+                                findCalleesRecursive(
+                                    project, calledMethod, depth - 1, visited, stackDepth + 1, searchScope, maxResults
+                                )
                             } else null
                             if (shouldIncludeNavigationElement(searchScope, calledMethod)) {
                                 val element = createCallElement(project, calledMethod, children)
-                                if (callees.none { it.name == element.name && it.file == element.file }) {
+                                if (callees.none { callElementKey(it) == callElementKey(element) }) {
                                     callees.add(element)
                                 }
                             } else if (children != null) {
                                 children.forEach { child ->
-                                    if (callees.none { it.name == child.name && it.file == child.file }) {
+                                    if (callees.size < maxResults &&
+                                        callees.none { callElementKey(it) == callElementKey(child) }
+                                    ) {
                                         callees.add(child)
                                     }
                                 }
@@ -834,12 +918,12 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
                                 callees.add(unresolvedElement)
                             }
                         }
-                    }
+                }
             }
 
             // For Kotlin light methods, the body is null — find callees from the original Kotlin PSI
             if (callees.isEmpty()) {
-                findKotlinCallees(project, method, depth, visited, stackDepth, callees, searchScope)
+                findKotlinCallees(project, method, depth, visited, stackDepth, callees, searchScope, maxResults)
             }
         } catch (e: ProcessCanceledException) {
             // Cancellation and dumb-mode must propagate — swallowing them would report a
@@ -866,7 +950,8 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         visited: MutableSet<String>,
         stackDepth: Int,
         callees: MutableList<CallElementData>,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ) {
         val callExprClass = ktCallExpressionClass ?: return
 
@@ -877,10 +962,9 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
         // Find all call expressions in the Kotlin function body via reflection
         @Suppress("UNCHECKED_CAST")
         val callExpressions = PsiTreeUtil.findChildrenOfType(navigationElement, callExprClass as Class<PsiElement>)
-            .take(MAX_RESULTS_PER_LEVEL)
 
         for (callExpr in callExpressions) {
-            if (callees.size >= MAX_RESULTS_PER_LEVEL) break
+            if (callees.size >= maxResults) break
 
             // Resolve the call expression's reference to find the called method
             val calledMethod = callExpr.references
@@ -895,16 +979,20 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
 
             if (calledMethod != null) {
                 val children = if (depth > 1) {
-                    findCalleesRecursive(project, calledMethod, depth - 1, visited, stackDepth + 1, searchScope)
+                    findCalleesRecursive(
+                        project, calledMethod, depth - 1, visited, stackDepth + 1, searchScope, maxResults
+                    )
                 } else null
                 if (shouldIncludeNavigationElement(searchScope, calledMethod)) {
                     val element = createCallElement(project, calledMethod, children)
-                    if (callees.none { it.name == element.name && it.file == element.file }) {
+                    if (callees.none { callElementKey(it) == callElementKey(element) }) {
                         callees.add(element)
                     }
                 } else if (children != null) {
                     children.forEach { child ->
-                        if (callees.none { it.name == child.name && it.file == child.file }) {
+                        if (callees.size < maxResults &&
+                            callees.none { callElementKey(it) == callElementKey(child) }
+                        ) {
                             callees.add(child)
                         }
                     }
@@ -940,11 +1028,22 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
     }
 
     private fun getMethodKey(method: PsiMethod): String {
+        val target = PsiUtils.resolveNavigationTarget(method)
+        target.containingFile?.virtualFile?.let { file ->
+            return "${file.url}|${target.textOffset}"
+        }
         val className = method.containingClass?.qualifiedName ?: ""
         val params = method.parameterList.parameters.joinToString(",") {
             try { it.type.canonicalText } catch (e: Exception) { "?" }
         }
         return "$className.${method.name}($params)"
+    }
+
+    private fun callElementKey(element: CallElementData): String {
+        val target = element.pointerTarget?.let(PsiUtils::resolveNavigationTarget)
+        val file = target?.containingFile?.virtualFile
+        if (target != null && file != null) return "${file.url}|${target.textOffset}"
+        return "${element.file}|${element.line}|${element.column}|${element.name}"
     }
 
     private fun createCallElement(project: Project, method: PsiMethod, children: List<CallElementData>? = null): CallElementData {
@@ -964,7 +1063,8 @@ class JavaCallHierarchyHandler : BaseJavaHandler<CallHierarchyData>(), CallHiera
             line = getLineNumber(project, method) ?: 0,
             column = getColumnNumber(project, method) ?: 0,
             language = if (method.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
-            children = children?.takeIf { it.isNotEmpty() }
+            children = children?.takeIf { it.isNotEmpty() },
+            pointerTarget = method
         )
     }
 }
@@ -996,7 +1096,8 @@ class JavaSuperMethodsHandler : BaseJavaHandler<SuperMethodsData>(), SuperMethod
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, method) ?: 0,
             column = getColumnNumber(project, method) ?: 0,
-            language = if (method.language.id == "kotlin") "Kotlin" else "Java"
+            language = if (method.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
+            pointerTarget = method
         )
 
         val hierarchy = buildHierarchy(project, method)
@@ -1033,7 +1134,8 @@ class JavaSuperMethodsHandler : BaseJavaHandler<SuperMethodsData>(), SuperMethod
                 column = getColumnNumber(project, superMethod),
                 isInterface = containingClass?.isInterface == true,
                 depth = depth,
-                language = if (superMethod.language.id == "kotlin") "Kotlin" else "Java"
+                language = if (superMethod.navigationElement.language.id == "kotlin") "Kotlin" else "Java",
+                pointerTarget = superMethod
             ))
 
             hierarchy.addAll(buildHierarchy(project, superMethod, visited, depth + 1))
@@ -1129,12 +1231,12 @@ class JavaStructureHandler : BaseJavaHandler<List<StructureNode>>(), StructureHa
         }
 
         return StructureNode(
-            name = psiClass.name ?: "anonymous",
+            name = PsiUtils.classDisplayName(project, psiClass) ?: "anonymous",
             kind = when {
-                psiClass.isInterface -> StructureKind.INTERFACE
-                psiClass.isEnum -> StructureKind.ENUM
                 psiClass.isAnnotationType -> StructureKind.ANNOTATION
                 psiClass.isRecord -> StructureKind.RECORD
+                psiClass.isEnum -> StructureKind.ENUM
+                psiClass.isInterface -> StructureKind.INTERFACE
                 psiClass.hasModifierProperty("abstract") -> StructureKind.CLASS
                 else -> StructureKind.CLASS
             },
@@ -1142,7 +1244,8 @@ class JavaStructureHandler : BaseJavaHandler<List<StructureNode>>(), StructureHa
             signature = buildClassSignature(psiClass),
             line = line,
             endLine = endLine,
-            children = children.sortedBy { it.line }
+            children = children.sortedBy { it.line },
+            pointerTarget = psiClass
         )
     }
 
@@ -1155,7 +1258,8 @@ class JavaStructureHandler : BaseJavaHandler<List<StructureNode>>(), StructureHa
             modifiers = extractModifiers(field.modifierList),
             signature = field.type.presentableText,
             line = line,
-            endLine = endLine
+            endLine = endLine,
+            pointerTarget = field
         )
     }
 
@@ -1168,7 +1272,8 @@ class JavaStructureHandler : BaseJavaHandler<List<StructureNode>>(), StructureHa
             modifiers = extractModifiers(method.modifierList),
             signature = buildMethodSignature(method),
             line = line,
-            endLine = endLine
+            endLine = endLine,
+            pointerTarget = method
         )
     }
 
@@ -1402,7 +1507,8 @@ class KotlinStructureHandler : BaseJavaHandler<List<StructureNode>>(), Structure
                 endLine = getEndLineNumber(project, callExpr),
                 signature = name,
                 modifiers = emptyList(),
-                children = emptyList()
+                children = emptyList(),
+                pointerTarget = callExpr
             )
         } catch (_: Exception) {
             null
@@ -1458,7 +1564,8 @@ class KotlinStructureHandler : BaseJavaHandler<List<StructureNode>>(), Structure
             signature = buildKotlinClassSignature(ktClass),
             line = getLineNumber(project, ktClass) ?: 0,
             endLine = getEndLineNumber(project, ktClass),
-            children = children.sortedBy { it.line }
+            children = children.sortedBy { it.line },
+            pointerTarget = ktClass
         )
     }
 
@@ -1469,7 +1576,8 @@ class KotlinStructureHandler : BaseJavaHandler<List<StructureNode>>(), Structure
             modifiers = getKotlinModifiers(function),
             signature = buildKotlinFunctionSignature(function),
             line = getLineNumber(project, function) ?: 0,
-            endLine = getEndLineNumber(project, function)
+            endLine = getEndLineNumber(project, function),
+            pointerTarget = function
         )
     }
 
@@ -1480,7 +1588,8 @@ class KotlinStructureHandler : BaseJavaHandler<List<StructureNode>>(), Structure
             modifiers = getKotlinModifiers(property),
             signature = buildKotlinPropertySignature(property),
             line = getLineNumber(project, property) ?: 0,
-            endLine = getEndLineNumber(project, property)
+            endLine = getEndLineNumber(project, property),
+            pointerTarget = property
         )
     }
 
@@ -1491,7 +1600,8 @@ class KotlinStructureHandler : BaseJavaHandler<List<StructureNode>>(), Structure
             modifiers = getKotlinModifiers(obj),
             signature = "",
             line = getLineNumber(project, obj) ?: 0,
-            endLine = getEndLineNumber(project, obj)
+            endLine = getEndLineNumber(project, obj),
+            pointerTarget = obj
         )
     }
 
@@ -1507,6 +1617,8 @@ class KotlinStructureHandler : BaseJavaHandler<List<StructureNode>>(), Structure
     }
 
     private fun getClassKind(ktClass: PsiElement): StructureKind {
+        PsiUtils.kotlinClassKind(ktClass)?.let { return StructureKind.valueOf(it) }
+
         return try {
             val isInterfaceMethod = ktClass.javaClass.getMethod("isInterface")
             val isInterface = isInterfaceMethod.invoke(ktClass) as? Boolean == true

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/javascript/JavaScriptHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/javascript/JavaScriptHandlers.kt
@@ -9,6 +9,8 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureNode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -20,6 +22,7 @@ import com.intellij.psi.search.searches.DefinitionsScopedSearch
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
+import kotlinx.coroutines.CancellationException
 
 /**
  * Registration entry point for JavaScript/TypeScript language handlers.
@@ -1140,14 +1143,28 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        directOnly: Boolean,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
     ): TypeHierarchyData? {
         val jsClass = findContainingJSClass(element) ?: return null
         LOG.debug("Getting type hierarchy for JS class: ${getName(jsClass)}")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
-        val supertypes = getSupertypes(project, jsClass, searchScope = searchScope)
-        val subtypes = getSubtypes(project, jsClass, searchScope)
+        val collectionLimit = page?.collectionLimit ?: 100
+        val rawSupertypes = if (direction != TypeHierarchyDirection.SUBTYPE) {
+            getSupertypes(project, jsClass, searchScope = searchScope, directOnly = directOnly).take(collectionLimit)
+        } else emptyList()
+        val rawSubtypes = if (direction != TypeHierarchyDirection.SUPERTYPE) {
+            getSubtypes(project, jsClass, searchScope, directOnly, collectionLimit)
+        } else emptyList()
+        val (supertypes, superNext) = if (direction == TypeHierarchyDirection.SUPERTYPE) {
+            rawSupertypes.applyHierarchyPage(page)
+        } else rawSupertypes to null
+        val (subtypes, subtypeNext) = if (direction == TypeHierarchyDirection.SUBTYPE) {
+            rawSubtypes.applyHierarchyPage(page)
+        } else rawSubtypes to null
 
         LOG.debug("Found ${supertypes.size} supertypes and ${subtypes.size} subtypes")
 
@@ -1158,10 +1175,12 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
                 file = jsClass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, jsClass),
                 kind = getClassKind(jsClass),
-                language = getLanguageName(jsClass)
+                language = getLanguageName(jsClass),
+                pointerTarget = jsClass
             ),
             supertypes = supertypes,
-            subtypes = subtypes
+            subtypes = subtypes,
+            nextOffset = superNext ?: subtypeNext
         )
     }
 
@@ -1170,7 +1189,8 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
         jsClass: PsiElement,
         visited: MutableSet<String> = mutableSetOf(),
         depth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false
     ): List<TypeElementData> {
         if (depth > MAX_HIERARCHY_DEPTH) return emptyList()
 
@@ -1186,7 +1206,8 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
             superClasses?.filterIsInstance<PsiElement>()?.forEach { superClass ->
                 val superName = getQualifiedName(superClass) ?: getName(superClass)
                 if (superName != null && shouldIncludeNavigationElement(searchScope, superClass)) {
-                    val superSupertypes = getSupertypes(project, superClass, visited, depth + 1, searchScope)
+                    val superSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, superClass, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
                         name = superName,
                         qualifiedName = getQualifiedName(superClass),
@@ -1194,7 +1215,8 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
                         line = getLineNumber(project, superClass),
                         kind = getClassKind(superClass),
                         language = getLanguageName(superClass),
-                        supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = superClass
                     ))
                 }
             }
@@ -1208,7 +1230,8 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
                     ifaceName !in visited &&
                     shouldIncludeNavigationElement(searchScope, iface)
                 ) {
-                    val ifaceSupertypes = getSupertypes(project, iface, visited, depth + 1, searchScope)
+                    val ifaceSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, iface, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
                         name = ifaceName,
                         qualifiedName = getQualifiedName(iface),
@@ -1216,7 +1239,8 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
                         line = getLineNumber(project, iface),
                         kind = "INTERFACE",
                         language = getLanguageName(iface),
-                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = iface
                     ))
                 }
             }
@@ -1227,14 +1251,27 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
         return supertypes
     }
 
+    private fun isDirectSubtypeOf(candidate: PsiElement, expectedParent: PsiElement): Boolean {
+        val expectedName = getQualifiedName(expectedParent) ?: getName(expectedParent) ?: return false
+        val directParents = buildList {
+            getSuperClasses(candidate)?.filterIsInstance<PsiElement>()?.let(::addAll)
+            getImplementedInterfaces(candidate)?.filterIsInstance<PsiElement>()?.let(::addAll)
+        }
+        return directParents.any { parent ->
+            parent === expectedParent || (getQualifiedName(parent) ?: getName(parent)) == expectedName
+        }
+    }
+
     private fun getSubtypes(
         project: Project,
         jsClass: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean,
+        maxResults: Int
     ): List<TypeElementData> {
         // Strategy 1: Try JSInheritorsSearch (JavaScript plugin API)
         try {
-            val result = searchUsingJSInheritorsSearch(project, jsClass, searchScope)
+            val result = searchUsingJSInheritorsSearch(project, jsClass, searchScope, directOnly, maxResults)
             if (result.isNotEmpty()) {
                 LOG.debug("Found ${result.size} subtypes via JSInheritorsSearch")
                 return result
@@ -1245,7 +1282,9 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
 
         // Strategy 2: Try DefinitionsScopedSearch (Platform API)
         try {
-            val result = searchSubtypesUsingDefinitionsScopedSearch(project, jsClass, searchScope)
+            val result = searchSubtypesUsingDefinitionsScopedSearch(
+                project, jsClass, searchScope, directOnly, maxResults
+            )
             if (result.isNotEmpty()) {
                 LOG.debug("Found ${result.size} subtypes via DefinitionsScopedSearch")
                 return result
@@ -1261,7 +1300,9 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
     private fun searchUsingJSInheritorsSearch(
         project: Project,
         jsClass: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean,
+        maxResults: Int
     ): List<TypeElementData> {
         val searchClass = Class.forName("com.intellij.lang.javascript.psi.resolve.JSInheritorsSearch")
         val searchMethod = searchClass.getMethod("search", jsClassClass)
@@ -1270,17 +1311,22 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
         val results = mutableListOf<TypeElementData>()
         val forEachMethod = query.javaClass.getMethod("forEach", Processor::class.java)
         forEachMethod.invoke(query, Processor<Any> { inheritor ->
-            if (inheritor is PsiElement && shouldIncludeNavigationElement(searchScope, inheritor)) {
+            if (
+                inheritor is PsiElement &&
+                shouldIncludeNavigationElement(searchScope, inheritor) &&
+                (!directOnly || isDirectSubtypeOf(inheritor, jsClass))
+            ) {
                 results.add(TypeElementData(
                     name = getQualifiedName(inheritor) ?: getName(inheritor) ?: "unknown",
                     qualifiedName = getQualifiedName(inheritor),
                     file = inheritor.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                     line = getLineNumber(project, inheritor),
                     kind = getClassKind(inheritor),
-                    language = getLanguageName(inheritor)
+                    language = getLanguageName(inheritor),
+                    pointerTarget = inheritor
                 ))
             }
-            results.size < 100
+            results.size < maxResults
         })
 
         return results
@@ -1289,22 +1335,30 @@ class JavaScriptTypeHierarchyHandler : BaseJavaScriptHandler<TypeHierarchyData>(
     private fun searchSubtypesUsingDefinitionsScopedSearch(
         project: Project,
         jsClass: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean,
+        maxResults: Int
     ): List<TypeElementData> {
         val results = mutableListOf<TypeElementData>()
 
         DefinitionsScopedSearch.search(jsClass, searchScope).forEach(Processor { definition ->
-            if (definition != jsClass && isJSClass(definition) && shouldIncludeNavigationElement(searchScope, definition)) {
+            if (
+                definition != jsClass &&
+                isJSClass(definition) &&
+                shouldIncludeNavigationElement(searchScope, definition) &&
+                (!directOnly || isDirectSubtypeOf(definition, jsClass))
+            ) {
                 results.add(TypeElementData(
                     name = getQualifiedName(definition) ?: getName(definition) ?: "unknown",
                     qualifiedName = getQualifiedName(definition),
                     file = definition.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                     line = getLineNumber(project, definition),
                     kind = getClassKind(definition),
-                    language = getLanguageName(definition)
+                    language = getLanguageName(definition),
+                    pointerTarget = definition
                 ))
             }
-            results.size < 100
+            results.size < maxResults
         })
 
         return results
@@ -1406,7 +1460,8 @@ class JavaScriptImplementationsHandler : BaseJavaScriptHandler<List<Implementati
                         line = getLineNumber(project, overridingMethod) ?: 0,
                         column = getColumnNumber(project, overridingMethod) ?: 0,
                         kind = "METHOD",
-                        language = getLanguageName(overridingMethod)
+                        language = getLanguageName(overridingMethod),
+                        pointerTarget = overridingMethod
                     ))
                 }
             }
@@ -1468,7 +1523,8 @@ class JavaScriptImplementationsHandler : BaseJavaScriptHandler<List<Implementati
                         line = getLineNumber(project, inheritor) ?: 0,
                         column = getColumnNumber(project, inheritor) ?: 0,
                         kind = getClassKind(inheritor),
-                        language = getLanguageName(inheritor)
+                        language = getLanguageName(inheritor),
+                        pointerTarget = inheritor
                     ))
                 }
             }
@@ -1500,7 +1556,8 @@ class JavaScriptImplementationsHandler : BaseJavaScriptHandler<List<Implementati
                         line = getLineNumber(project, definition) ?: 0,
                         column = getColumnNumber(project, definition) ?: 0,
                         kind = kind,
-                        language = getLanguageName(definition)
+                        language = getLanguageName(definition),
+                        pointerTarget = definition
                     ))
                 }
             }
@@ -1538,7 +1595,6 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         // Keep breadth-first traversal bounded, but leave enough headroom for real-world
         // directory barrels that co-export multiple names before the caller import hop.
         private const val MAX_BARREL_SYMBOLS_TO_TRAVERSE = 40
-        private const val MAX_BARREL_REFERENCES_TO_COLLECT = 120
     }
 
     override val languageId = "JavaScript"
@@ -1555,25 +1611,33 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        page: HierarchyPageRequest?
     ): CallHierarchyData? {
         val jsFunction = findContainingJSFunction(resolveJsTsCallHierarchySeed(element)) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(jsFunction)}, direction=$direction, depth=$depth")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
-        val calls = if (direction == "callers") {
-            findCallersRecursive(project, jsFunction, depth, visited, searchScope = searchScope)
+        val maxResults = page?.collectionLimit ?: MAX_RESULTS_PER_LEVEL
+        val rawCalls = if (direction == "callers") {
+            findCallersRecursive(
+                project, jsFunction, depth, visited, searchScope = searchScope, maxResults = maxResults
+            )
                 .map(PrioritizedCallerResult::call)
         } else {
-            findCalleesRecursive(project, jsFunction, depth, visited, searchScope = searchScope)
+            findCalleesRecursive(
+                project, jsFunction, depth, visited, searchScope = searchScope, maxResults = maxResults
+            )
         }
+        val (calls, nextOffset) = rawCalls.applyHierarchyPage(page)
 
         LOG.debug("Found ${calls.size} ${direction}")
 
         return CallHierarchyData(
             element = createCallElement(project, jsFunction),
-            calls = calls
+            calls = calls,
+            nextOffset = nextOffset
         )
     }
 
@@ -1627,9 +1691,11 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<PrioritizedCallerResult> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val functionKey = getFunctionKey(jsFunction)
         if (functionKey in visited) return emptyList()
@@ -1640,38 +1706,87 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
             val methodsToSearch = mutableSetOf(jsFunction)
             methodsToSearch.addAll(findAllSuperMethods(project, jsFunction))
 
+            val directResultsByKey = LinkedHashMap<String, CallElementData>()
+            val barrelResultsByKey = LinkedHashMap<String, CallElementData>()
+            val processedCallerSources = mutableSetOf<String>()
+            var processedReferences = 0
+
             // Traverse direct references first, then follow named re-exports / export-star
-            // barrels in a bounded breadth-first way. This keeps caller discovery aligned
-            // with reference-search behavior without treating unrelated symbols from the same
-            // barrel as callers.
-            val allReferences = collectCallerReferences(methodsToSearch, searchScope)
-
-            LOG.debug("Found ${allReferences.size} references for ${getName(jsFunction)}")
-
-            val resultsByKey = LinkedHashMap<String, PrioritizedCallerResult>()
-            for (reference in allReferences) {
+            // barrels in a bounded breadth-first way. References are converted as they stream;
+            // repeated sites in one callable therefore cannot consume the semantic result budget.
+            collectCallerReferences(
+                methodsToSearch = methodsToSearch,
+                searchScope = searchScope,
+                shouldStop = { barrelResultsByKey.size >= maxResults }
+            ) { reference ->
+                processedReferences++
                 val refElement = reference.reference.element
                 val containingFunction = findContainingCallable(refElement)
                 if (containingFunction != null && containingFunction != jsFunction && !methodsToSearch.contains(containingFunction)) {
-                    val children = if (depth > 1) {
-                        findCallersRecursive(project, containingFunction, depth - 1, visited, stackDepth + 1, searchScope)
-                    } else null
                     if (shouldIncludeNavigationElement(searchScope, containingFunction)) {
                         putCallerResult(
-                            resultsByKey,
+                            directResultsByKey,
+                            barrelResultsByKey,
                             getFunctionKey(containingFunction),
-                            createCallElement(project, containingFunction, children?.map(PrioritizedCallerResult::call)),
-                            reference.source
-                        )
-                    } else if (children != null) {
-                        children.forEach { child ->
-                            putCallerResult(resultsByKey, getCallElementKey(child.call), child.call, child.source)
+                            reference.source,
+                            maxResults
+                        ) {
+                            val children = if (depth > 1) {
+                                findCallersRecursive(
+                                    project,
+                                    containingFunction,
+                                    depth - 1,
+                                    visited,
+                                    stackDepth + 1,
+                                    searchScope,
+                                    maxResults
+                                )
+                            } else null
+                            createCallElement(
+                                project,
+                                containingFunction,
+                                children?.map(PrioritizedCallerResult::call)
+                            )
+                        }
+                    } else {
+                        val callerSourceKey = "${getFunctionKey(containingFunction)}:${reference.source}"
+                        if (!processedCallerSources.add(callerSourceKey)) return@collectCallerReferences
+                        val children = if (depth > 1) {
+                            findCallersRecursive(
+                                project,
+                                containingFunction,
+                                depth - 1,
+                                visited,
+                                stackDepth + 1,
+                                searchScope,
+                                maxResults
+                            )
+                        } else null
+                        children.orEmpty().forEach { child ->
+                            putCallerResult(
+                                directResultsByKey,
+                                barrelResultsByKey,
+                                getCallElementKey(child.call),
+                                child.source,
+                                maxResults
+                            ) { child.call }
                         }
                     }
                 }
             }
 
-            buildVisibleCallerResults(resultsByKey)
+            LOG.debug(
+                "Found ${directResultsByKey.keys.union(barrelResultsByKey.keys).size} semantic callers after " +
+                    "processing $processedReferences references " +
+                    "for ${getName(jsFunction)}"
+            )
+            buildVisibleCallerResults(directResultsByKey, barrelResultsByKey, maxResults)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IndexNotReadyException) {
+            throw e
         } catch (e: Exception) {
             LOG.warn("Error finding callers: ${e.message}")
             emptyList()
@@ -1679,34 +1794,61 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
     }
 
     private fun putCallerResult(
-        resultsByKey: MutableMap<String, PrioritizedCallerResult>,
+        directResultsByKey: MutableMap<String, CallElementData>,
+        barrelResultsByKey: MutableMap<String, CallElementData>,
         key: String,
-        call: CallElementData,
-        source: CallerReferenceSource
+        source: CallerReferenceSource,
+        maxResults: Int,
+        createCall: () -> CallElementData
     ) {
-        val existing = resultsByKey[key]
-        if (existing == null || source == CallerReferenceSource.BARREL_TRAVERSAL && existing.source != CallerReferenceSource.BARREL_TRAVERSAL) {
-            resultsByKey[key] = PrioritizedCallerResult(call, source)
+        when (source) {
+            CallerReferenceSource.BARREL_TRAVERSAL -> {
+                if (key in barrelResultsByKey || barrelResultsByKey.size >= maxResults) return
+                barrelResultsByKey[key] = directResultsByKey[key] ?: createCall()
+            }
+            CallerReferenceSource.DIRECT -> {
+                if (key in directResultsByKey || key in barrelResultsByKey) return
+                // A later barrel reference can promote an earlier direct caller. Keep one extra
+                // semantic page of direct callers so those promotions cannot leave the page short.
+                val retentionLimit = (maxResults.toLong() * 2L)
+                    .coerceAtMost(Int.MAX_VALUE.toLong())
+                    .toInt()
+                if (directResultsByKey.size < retentionLimit) {
+                    directResultsByKey[key] = createCall()
+                }
+            }
         }
     }
 
-    private fun buildVisibleCallerResults(resultsByKey: LinkedHashMap<String, PrioritizedCallerResult>): List<PrioritizedCallerResult> {
-        val prioritized = resultsByKey.values.filter { it.source == CallerReferenceSource.BARREL_TRAVERSAL }
-        if (prioritized.size >= MAX_RESULTS_PER_LEVEL) {
-            return prioritized.take(MAX_RESULTS_PER_LEVEL)
+    private fun buildVisibleCallerResults(
+        directResultsByKey: LinkedHashMap<String, CallElementData>,
+        barrelResultsByKey: LinkedHashMap<String, CallElementData>,
+        maxResults: Int
+    ): List<PrioritizedCallerResult> {
+        val prioritized = barrelResultsByKey.values.map {
+            PrioritizedCallerResult(it, CallerReferenceSource.BARREL_TRAVERSAL)
+        }
+        if (prioritized.size >= maxResults) {
+            return prioritized.take(maxResults)
         }
 
-        val direct = resultsByKey.values.filter { it.source == CallerReferenceSource.DIRECT }
-        return buildList(MAX_RESULTS_PER_LEVEL) {
+        val direct = directResultsByKey
+            .asSequence()
+            .filter { (key, _) -> key !in barrelResultsByKey }
+            .map { (_, call) -> PrioritizedCallerResult(call, CallerReferenceSource.DIRECT) }
+            .toList()
+        return buildList(maxResults) {
             addAll(prioritized)
-            addAll(direct.take(MAX_RESULTS_PER_LEVEL - size))
+            addAll(direct.take(maxResults - size))
         }
     }
 
     private fun collectCallerReferences(
         methodsToSearch: Set<PsiElement>,
-        searchScope: GlobalSearchScope
-    ): List<CollectedCallerReference> {
+        searchScope: GlobalSearchScope,
+        shouldStop: () -> Boolean,
+        consume: (CollectedCallerReference) -> Unit
+    ) {
         val pendingSymbols = ArrayDeque<PsiNamedElement>()
         methodsToSearch
             .asSequence()
@@ -1717,12 +1859,11 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         val rootSymbolKeys = pendingSymbols.mapTo(hashSetOf()) { getPsiTraversalKey(it) }
         val visitedSymbols = linkedSetOf<String>()
         val queuedSymbols = pendingSymbols.mapTo(linkedSetOf()) { getPsiTraversalKey(it) }
-        val referencesByKey = linkedMapOf<String, CollectedCallerReference>()
 
         while (
             pendingSymbols.isNotEmpty() &&
             visitedSymbols.size < MAX_BARREL_SYMBOLS_TO_TRAVERSE &&
-            referencesByKey.size < MAX_BARREL_REFERENCES_TO_COLLECT
+            !shouldStop()
         ) {
             val symbol = pendingSymbols.removeFirst()
             val symbolKey = getPsiTraversalKey(symbol)
@@ -1735,55 +1876,25 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
                 CallerReferenceSource.BARREL_TRAVERSAL
             }
 
-            ReferencesSearch.search(symbol, searchScope).forEach(Processor { reference ->
-                val referenceKey = buildReferenceKey(reference)
-                if (putCollectedReference(referencesByKey, referenceKey, reference, referenceSource)) {
-                    enqueueBarrelTraversalCandidates(
-                        pendingSymbols,
-                        queuedSymbols,
-                        visitedSymbols,
-                        findBarrelTraversalCandidates(reference.element, methodsToSearch, symbol)
-                    )
-                }
-                referencesByKey.size < MAX_BARREL_REFERENCES_TO_COLLECT
-            })
+            fun consumeReference(reference: com.intellij.psi.PsiReference): Boolean {
+                consume(CollectedCallerReference(reference, referenceSource))
+                enqueueBarrelTraversalCandidates(
+                    pendingSymbols,
+                    queuedSymbols,
+                    visitedSymbols,
+                    findBarrelTraversalCandidates(reference.element, methodsToSearch, symbol)
+                )
+                return !shouldStop()
+            }
 
+            ReferencesSearch.search(symbol, searchScope).forEach(Processor(::consumeReference))
+
+            if (shouldStop()) break
             val containingFile = symbol.containingFile
             if (containingFile != null && !symbol.name.isNullOrBlank()) {
-                ReferencesSearch.search(containingFile, searchScope).forEach(Processor { reference ->
-                    val referenceKey = buildReferenceKey(reference)
-                    if (putCollectedReference(referencesByKey, referenceKey, reference, referenceSource)) {
-                        enqueueBarrelTraversalCandidates(
-                            pendingSymbols,
-                            queuedSymbols,
-                            visitedSymbols,
-                            findBarrelTraversalCandidates(reference.element, methodsToSearch, symbol)
-                        )
-                    }
-                    referencesByKey.size < MAX_BARREL_REFERENCES_TO_COLLECT
-                })
+                ReferencesSearch.search(containingFile, searchScope).forEach(Processor(::consumeReference))
             }
         }
-
-        return referencesByKey.values.toList()
-    }
-
-    private fun putCollectedReference(
-        referencesByKey: MutableMap<String, CollectedCallerReference>,
-        referenceKey: String,
-        reference: com.intellij.psi.PsiReference,
-        source: CallerReferenceSource
-    ): Boolean {
-        val existing = referencesByKey[referenceKey]
-        if (existing == null) {
-            referencesByKey[referenceKey] = CollectedCallerReference(reference, source)
-            return true
-        }
-
-        if (source == CallerReferenceSource.BARREL_TRAVERSAL && existing.source != CallerReferenceSource.BARREL_TRAVERSAL) {
-            referencesByKey[referenceKey] = CollectedCallerReference(reference, source)
-        }
-        return false
     }
 
     private fun enqueueBarrelTraversalCandidates(
@@ -2011,13 +2122,6 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         return exports.values.toList()
     }
 
-    private fun buildReferenceKey(reference: com.intellij.psi.PsiReference): String {
-        val element = reference.element
-        val range = element.textRange
-        val path = element.containingFile?.virtualFile?.path ?: ""
-        return "$path:${range?.startOffset ?: -1}:${range?.endOffset ?: -1}:${element.text}"
-    }
-
     private fun getPsiTraversalKey(element: PsiElement): String {
         val path = element.containingFile?.virtualFile?.path ?: ""
         val range = element.textRange
@@ -2047,7 +2151,8 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
 
@@ -2061,11 +2166,14 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
             @Suppress("UNCHECKED_CAST")
             val callExpressions = PsiTreeUtil.findChildrenOfType(jsFunction, jsCallExpr as Class<out PsiElement>)
 
-            callExpressions.take(MAX_RESULTS_PER_LEVEL).forEach { callExpr ->
+            for (callExpr in callExpressions) {
+                if (callees.size >= maxResults) break
                 val calledFunction = resolveCallExpression(callExpr)
                 if (calledFunction != null && isJSFunction(calledFunction)) {
                     val children = if (depth > 1) {
-                        findCalleesRecursive(project, calledFunction, depth - 1, visited, stackDepth + 1, searchScope)
+                        findCalleesRecursive(
+                            project, calledFunction, depth - 1, visited, stackDepth + 1, searchScope, maxResults
+                        )
                     } else null
                     if (shouldIncludeNavigationElement(searchScope, calledFunction)) {
                         val element = createCallElement(project, calledFunction, children)
@@ -2105,7 +2213,9 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
         val className = containingClass?.let { getQualifiedName(it) ?: getName(it) } ?: ""
         val functionName = getName(jsFunction) ?: ""
         val file = jsFunction.containingFile?.virtualFile?.path ?: ""
-        return "$file:$className.$functionName"
+        // Nested/local functions may legitimately share a name and have no containing class.
+        // Declaration offset keeps semantic caller dedup from collapsing them before pagination.
+        return "$file:${jsFunction.textOffset}:$className.$functionName"
     }
 
     private fun getCallElementKey(element: CallElementData): String {
@@ -2126,7 +2236,8 @@ class JavaScriptCallHierarchyHandler : BaseJavaScriptHandler<CallHierarchyData>(
             line = getLineNumber(project, jsFunction) ?: 0,
             column = getColumnNumber(project, jsFunction) ?: 0,
             language = getLanguageName(jsFunction),
-            children = children?.takeIf { it.isNotEmpty() }
+            children = children?.takeIf { it.isNotEmpty() },
+            pointerTarget = jsFunction
         )
     }
 }
@@ -2158,7 +2269,8 @@ class JavaScriptSuperMethodsHandler : BaseJavaScriptHandler<SuperMethodsData>(),
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, jsFunction) ?: 0,
             column = getColumnNumber(project, jsFunction) ?: 0,
-            language = getLanguageName(jsFunction)
+            language = getLanguageName(jsFunction),
+            pointerTarget = jsFunction
         )
 
         val hierarchy = buildHierarchy(project, jsFunction)
@@ -2204,7 +2316,8 @@ class JavaScriptSuperMethodsHandler : BaseJavaScriptHandler<SuperMethodsData>(),
                         column = getColumnNumber(project, superMethod),
                         isInterface = getClassKind(superClass) == "INTERFACE",
                         depth = depth,
-                        language = getLanguageName(superMethod)
+                        language = getLanguageName(superMethod),
+                        pointerTarget = superMethod
                     ))
 
                     hierarchy.addAll(buildHierarchy(project, superMethod, visited, depth + 1))
@@ -2233,7 +2346,8 @@ class JavaScriptSuperMethodsHandler : BaseJavaScriptHandler<SuperMethodsData>(),
                         column = getColumnNumber(project, superMethod),
                         isInterface = true,
                         depth = depth,
-                        language = getLanguageName(superMethod)
+                        language = getLanguageName(superMethod),
+                        pointerTarget = superMethod
                     ))
                 }
             }
@@ -2459,7 +2573,8 @@ class JavaScriptStructureHandler : BaseJavaScriptHandler<List<StructureNode>>(),
             signature = buildClassSignature(jsClass),
             line = getLineNumber(project, jsClass) ?: 0,
             endLine = getEndLineNumber(project, jsClass),
-            children = children.sortedBy { it.line }
+            children = children.sortedBy { it.line },
+            pointerTarget = jsClass
         )
     }
 
@@ -2471,7 +2586,8 @@ class JavaScriptStructureHandler : BaseJavaScriptHandler<List<StructureNode>>(),
             modifiers = getJavaScriptModifiers(jsFunction),
             signature = buildFunctionSignature(jsFunction),
             line = getLineNumber(project, jsFunction) ?: 0,
-            endLine = getEndLineNumber(project, jsFunction)
+            endLine = getEndLineNumber(project, jsFunction),
+            pointerTarget = jsFunction
         )
     }
 
@@ -2483,7 +2599,8 @@ class JavaScriptStructureHandler : BaseJavaScriptHandler<List<StructureNode>>(),
             modifiers = getJavaScriptModifiers(jsFunction),
             signature = buildFunctionSignature(jsFunction),
             line = getLineNumber(project, jsFunction) ?: 0,
-            endLine = getEndLineNumber(project, jsFunction)
+            endLine = getEndLineNumber(project, jsFunction),
+            pointerTarget = jsFunction
         )
     }
 
@@ -2495,7 +2612,8 @@ class JavaScriptStructureHandler : BaseJavaScriptHandler<List<StructureNode>>(),
             modifiers = emptyList(),
             signature = null,
             line = getLineNumber(project, jsVariable) ?: 0,
-            endLine = getEndLineNumber(project, jsVariable)
+            endLine = getEndLineNumber(project, jsVariable),
+            pointerTarget = jsVariable
         )
     }
 
@@ -2507,7 +2625,8 @@ class JavaScriptStructureHandler : BaseJavaScriptHandler<List<StructureNode>>(),
             modifiers = getJavaScriptModifiers(field),
             signature = null,
             line = getLineNumber(project, field) ?: 0,
-            endLine = getEndLineNumber(project, field)
+            endLine = getEndLineNumber(project, field),
+            pointerTarget = field
         )
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/markdown/MarkdownHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/markdown/MarkdownHandlers.kt
@@ -96,7 +96,8 @@ class MarkdownStructureHandler : BaseMarkdownHandler<List<StructureNode>>(), Str
                 level = header.level,
                 name = headerName(header),
                 line = getLineNumber(project, header),
-                endLine = getEndLineNumber(project, header)
+                endLine = getEndLineNumber(project, header),
+                pointerTarget = header
             )
 
             while (stack.isNotEmpty() && stack.last().level >= node.level) {
@@ -120,6 +121,7 @@ class MarkdownStructureHandler : BaseMarkdownHandler<List<StructureNode>>(), Str
         val name: String,
         val line: Int,
         val endLine: Int? = null,
+        val pointerTarget: PsiElement,
         val children: MutableList<MutableHeadingNode> = mutableListOf()
     ) {
         fun toStructureNode(): StructureNode =
@@ -130,7 +132,8 @@ class MarkdownStructureHandler : BaseMarkdownHandler<List<StructureNode>>(), Str
                 signature = null,
                 line = line,
                 endLine = endLine,
-                children = children.map { it.toStructureNode() }
+                children = children.map { it.toStructureNode() },
+                pointerTarget = pointerTarget
             )
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/php/PhpHandlers.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.DefinitionsScopedSearch
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
@@ -766,7 +767,8 @@ class PhpStructureHandler : BasePhpHandler<List<StructureNode>>(), StructureHand
     private data class NamespaceRegion(
         val name: String,
         val line: Int,
-        val endLine: Int? = null
+        val endLine: Int? = null,
+        val pointerTarget: PsiElement
     )
 
     private inner class PhpStructureClassifier : IdeStructureViewExtractor.Classifier {
@@ -808,7 +810,8 @@ class PhpStructureHandler : BasePhpHandler<List<StructureNode>>(), StructureHand
                     modifiers = emptyList(),
                     signature = null,
                     line = namespace.line,
-                    endLine = namespace.endLine
+                    endLine = namespace.endLine,
+                    pointerTarget = namespace.pointerTarget
                 )
             }
         }
@@ -828,7 +831,8 @@ class PhpStructureHandler : BasePhpHandler<List<StructureNode>>(), StructureHand
                 signature = null,
                 line = namespace.line,
                 endLine = namespace.endLine,
-                children = namespaceChildren
+                children = namespaceChildren,
+                pointerTarget = namespace.pointerTarget
             )
         }
 
@@ -846,7 +850,12 @@ class PhpStructureHandler : BasePhpHandler<List<StructureNode>>(), StructureHand
                 val name = namespaceName(namespace) ?: return@mapNotNull null
                 val line = getLineNumber(project, namespace) ?: return@mapNotNull null
                 val endLine = getEndLineNumber(project, namespace)
-                NamespaceRegion(name = name, line = line, endLine = endLine)
+                NamespaceRegion(
+                    name = name,
+                    line = line,
+                    endLine = endLine,
+                    pointerTarget = namespace
+                )
             }
             .distinct()
             .sortedBy { it.line }
@@ -1216,14 +1225,35 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        directOnly: Boolean,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
     ): TypeHierarchyData? {
         val phpClass = findContainingPhpClass(element) ?: return null
         LOG.debug("Getting type hierarchy for PHP class: ${getName(phpClass)}")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
-        val supertypes = getSupertypes(project, phpClass, searchScope = searchScope)
-        val subtypes = getSubtypes(project, phpClass, searchScope)
+        val collectionLimit = page?.collectionLimit ?: 100
+        val rawSupertypes = if (direction != TypeHierarchyDirection.SUBTYPE) {
+            getSupertypes(project, phpClass, searchScope = searchScope, directOnly = directOnly).take(collectionLimit)
+        } else emptyList()
+        val rawSubtypes = if (direction != TypeHierarchyDirection.SUPERTYPE) {
+            getSubtypes(
+                project,
+                phpClass,
+                searchScope,
+                directOnly,
+                collectionLimit,
+                useBoundedSearch = page != null
+            )
+        } else emptyList()
+        val (supertypes, superNext) = if (direction == TypeHierarchyDirection.SUPERTYPE) {
+            rawSupertypes.applyHierarchyPage(page)
+        } else rawSupertypes to null
+        val (subtypes, subtypeNext) = if (direction == TypeHierarchyDirection.SUBTYPE) {
+            rawSubtypes.applyHierarchyPage(page)
+        } else rawSubtypes to null
 
         LOG.debug("Found ${supertypes.size} supertypes and ${subtypes.size} subtypes")
 
@@ -1234,10 +1264,12 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
                 file = phpClass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, phpClass),
                 kind = determineClassKind(phpClass),
-                language = "PHP"
+                language = "PHP",
+                pointerTarget = phpClass
             ),
             supertypes = supertypes,
-            subtypes = subtypes
+            subtypes = subtypes,
+            nextOffset = superNext ?: subtypeNext
         )
     }
 
@@ -1246,7 +1278,8 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
         phpClass: PsiElement,
         visited: MutableSet<String> = mutableSetOf(),
         depth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false
     ): List<TypeElementData> {
         if (depth > MAX_HIERARCHY_DEPTH) return emptyList()
 
@@ -1262,7 +1295,8 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
             if (superClass != null && shouldIncludeNavigationElement(searchScope, superClass)) {
                 val superName = getFQN(superClass) ?: getName(superClass)
                 if (superName != null && superName !in visited) {
-                    val superSupertypes = getSupertypes(project, superClass, visited, depth + 1, searchScope)
+                    val superSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, superClass, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
                         name = superName,
                         qualifiedName = getFQN(superClass),
@@ -1270,7 +1304,8 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
                         line = getLineNumber(project, superClass),
                         kind = determineClassKind(superClass),
                         language = "PHP",
-                        supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = superClass
                     ))
                 }
             }
@@ -1284,7 +1319,8 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
                     ifaceName !in visited &&
                     shouldIncludeNavigationElement(searchScope, iface)
                 ) {
-                    val ifaceSupertypes = getSupertypes(project, iface, visited, depth + 1, searchScope)
+                    val ifaceSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, iface, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
                         name = ifaceName,
                         qualifiedName = getFQN(iface),
@@ -1292,7 +1328,8 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
                         line = getLineNumber(project, iface),
                         kind = "INTERFACE",
                         language = "PHP",
-                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = ifaceSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = iface
                     ))
                 }
             }
@@ -1312,7 +1349,8 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
                         file = trait.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, trait),
                         kind = "TRAIT",
-                        language = "PHP"
+                        language = "PHP",
+                        pointerTarget = trait
                     ))
                 }
             }
@@ -1326,30 +1364,71 @@ class PhpTypeHierarchyHandler : BasePhpHandler<TypeHierarchyData>(), TypeHierarc
     private fun getSubtypes(
         project: Project,
         phpClass: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false,
+        maxResults: Int = 100,
+        useBoundedSearch: Boolean = false
     ): List<TypeElementData> {
+        if (maxResults <= 0) return emptyList()
+
         return try {
             val fqn = getFQN(phpClass) ?: return emptyList()
             val results = mutableListOf<TypeElementData>()
+            val expectedName = getFQN(phpClass) ?: getName(phpClass)
 
-            // Use PhpIndex.getAllSubclasses() - the correct API for finding PHP subclasses
-            val subclasses = getAllSubclasses(project, fqn)
+            fun isAccepted(subclass: PsiElement): Boolean {
+                if (
+                    subclass === phpClass ||
+                    !isPhpClass(subclass) ||
+                    !shouldIncludeNavigationElement(searchScope, subclass)
+                ) {
+                    return false
+                }
+                if (!directOnly || expectedName == null) return true
 
-            subclasses
-                .filter { shouldIncludeNavigationElement(searchScope, it) }
-                .take(100)
-                .forEach { subclass ->
+                val directParents = buildList {
+                    getSuperClass(subclass)?.let(::add)
+                    getImplementedInterfaces(subclass)?.filterIsInstance<PsiElement>()?.let(::addAll)
+                }
+                return directParents.any { parent ->
+                    parent === phpClass || (getFQN(parent) ?: getName(parent)) == expectedName
+                }
+            }
+
+            fun addSubtype(subclass: PsiElement) {
                 results.add(TypeElementData(
                     name = getFQN(subclass) ?: getName(subclass) ?: "unknown",
                     qualifiedName = getFQN(subclass),
                     file = subclass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                     line = getLineNumber(project, subclass),
                     kind = determineClassKind(subclass),
-                    language = "PHP"
+                    language = "PHP",
+                    pointerTarget = subclass
                 ))
             }
 
-            LOG.debug("Found ${results.size} subtypes for $fqn using PhpIndex")
+            if (useBoundedSearch) {
+                // DefinitionsScopedSearch exposes Query.forEach, so a hierarchy page can stop the
+                // underlying language query as soon as its look-ahead item has been collected.
+                DefinitionsScopedSearch.search(phpClass, searchScope).forEach(Processor { definition ->
+                    if (isAccepted(definition)) {
+                        addSubtype(definition)
+                    }
+                    results.size < maxResults
+                })
+            } else {
+                // Preserve the established PhpIndex semantics for legacy, unpaged callers. That
+                // API returns a materialized Collection and cannot be cancelled after N matches.
+                for (subclass in getAllSubclasses(project, fqn)) {
+                    if (isAccepted(subclass)) {
+                        addSubtype(subclass)
+                        if (results.size >= maxResults) break
+                    }
+                }
+            }
+
+            val searchApi = if (useBoundedSearch) "DefinitionsScopedSearch" else "PhpIndex"
+            LOG.debug("Found ${results.size} subtypes for $fqn using $searchApi")
             results
         } catch (e: Exception) {
             LOG.warn("Error getting subtypes: ${e.message}")
@@ -1434,7 +1513,8 @@ class PhpImplementationsHandler : BasePhpHandler<List<ImplementationData>>(), Im
                             line = getLineNumber(project, overridingMethod) ?: 0,
                             column = getColumnNumber(project, overridingMethod) ?: 0,
                             kind = "METHOD",
-                            language = "PHP"
+                            language = "PHP",
+                            pointerTarget = overridingMethod
                         ))
                     }
                 }
@@ -1472,7 +1552,8 @@ class PhpImplementationsHandler : BasePhpHandler<List<ImplementationData>>(), Im
                         line = getLineNumber(project, subclass) ?: 0,
                         column = getColumnNumber(project, subclass) ?: 0,
                         kind = determineClassKind(subclass),
-                        language = "PHP"
+                        language = "PHP",
+                        pointerTarget = subclass
                     ))
                 }
             }
@@ -1511,24 +1592,28 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        page: HierarchyPageRequest?
     ): CallHierarchyData? {
         val callable = findContainingCallable(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(callable)}, direction=$direction, depth=$depth")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
-        val calls = if (direction == "callers") {
-            findCallersRecursive(project, callable, depth, visited, searchScope = searchScope)
+        val maxResults = page?.collectionLimit ?: MAX_RESULTS_PER_LEVEL
+        val rawCalls = if (direction == "callers") {
+            findCallersRecursive(project, callable, depth, visited, searchScope = searchScope, maxResults = maxResults)
         } else {
-            findCalleesRecursive(project, callable, depth, visited, searchScope = searchScope)
+            findCalleesRecursive(project, callable, depth, visited, searchScope = searchScope, maxResults = maxResults)
         }
+        val (calls, nextOffset) = rawCalls.applyHierarchyPage(page)
 
         LOG.debug("Found ${calls.size} $direction")
 
         return CallHierarchyData(
             element = createCallElement(project, callable),
-            calls = calls
+            calls = calls,
+            nextOffset = nextOffset
         )
     }
 
@@ -1594,9 +1679,11 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val callableKey = getCallableKey(callable)
         if (callableKey in visited) return emptyList()
@@ -1609,34 +1696,58 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
                 methodsToSearch.addAll(findAllSuperMethods(project, callable))
             }
 
-            val allReferences = mutableListOf<com.intellij.psi.PsiReference>()
+            val results = mutableListOf<CallElementData>()
+            val seenCallers = mutableSetOf<String>()
+            val seenResults = mutableSetOf<String>()
+            var processedReferences = 0
 
             for (methodToSearch in methodsToSearch) {
+                if (results.size >= maxResults) break
                 ReferencesSearch.search(methodToSearch, searchScope).forEach(Processor { reference ->
-                    allReferences.add(reference)
-                    allReferences.size < MAX_RESULTS_PER_LEVEL * 2
+                    processedReferences++
+                    val containingCallable = findContainingCallable(reference.element)
+                    if (
+                        containingCallable != null &&
+                        containingCallable != callable &&
+                        containingCallable !in methodsToSearch
+                    ) {
+                        val callerPath = containingCallable.containingFile?.virtualFile?.path.orEmpty()
+                        val callerIdentity = "$callerPath:${containingCallable.textOffset}:${getCallableKey(containingCallable)}"
+                        if (seenCallers.add(callerIdentity)) {
+                            val children = if (depth > 1) {
+                                findCallersRecursive(
+                                    project,
+                                    containingCallable,
+                                    depth - 1,
+                                    visited,
+                                    stackDepth + 1,
+                                    searchScope,
+                                    maxResults
+                                )
+                            } else null
+
+                            val candidates = if (shouldIncludeNavigationElement(searchScope, containingCallable)) {
+                                listOf(createCallElement(project, containingCallable, children))
+                            } else {
+                                children.orEmpty()
+                            }
+                            for (candidate in candidates) {
+                                if (results.size >= maxResults) break
+                                val resultIdentity = "${candidate.name}:${candidate.file}:${candidate.line}"
+                                if (seenResults.add(resultIdentity)) {
+                                    results.add(candidate)
+                                }
+                            }
+                        }
+                    }
+                    results.size < maxResults
                 })
             }
 
-            LOG.debug("Found ${allReferences.size} references for ${getName(callable)}")
-
-            val results = mutableListOf<CallElementData>()
-            for (reference in allReferences) {
-                if (results.size >= MAX_RESULTS_PER_LEVEL) break
-                val refElement = reference.element
-                val containingCallable = findContainingCallable(refElement)
-                if (containingCallable != null && containingCallable != callable && containingCallable !in methodsToSearch) {
-                    val children = if (depth > 1) {
-                        findCallersRecursive(project, containingCallable, depth - 1, visited, stackDepth + 1, searchScope)
-                    } else null
-                    if (shouldIncludeNavigationElement(searchScope, containingCallable)) {
-                        results.add(createCallElement(project, containingCallable, children))
-                    } else if (children != null) {
-                        results.addAll(children)
-                    }
-                }
-            }
-            results.distinctBy { it.name + it.file + it.line }.take(MAX_RESULTS_PER_LEVEL)
+            LOG.debug(
+                "Found ${results.size} callers after processing $processedReferences references for ${getName(callable)}"
+            )
+            results
         } catch (e: Exception) {
             LOG.warn("Error finding callers: ${e.message}")
             emptyList()
@@ -1649,9 +1760,11 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val callableKey = getCallableKey(callable)
         if (callableKey in visited) return emptyList()
@@ -1663,54 +1776,47 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
             val methodRef = methodReferenceClass
             val functionRef = functionReferenceClass
 
-            if (methodRef != null) {
-                @Suppress("UNCHECKED_CAST")
-                val methodCalls = PsiTreeUtil.findChildrenOfType(callable, methodRef as Class<out PsiElement>)
-                methodCalls.take(MAX_RESULTS_PER_LEVEL).forEach { callExpr ->
-                    val calledMethod = resolveReference(callExpr)
-                    if (calledMethod != null && (isMethod(calledMethod) || isFunction(calledMethod))) {
-                        val children = if (depth > 1) {
-                            findCalleesRecursive(project, calledMethod, depth - 1, visited, stackDepth + 1, searchScope)
-                        } else null
-                        if (shouldIncludeNavigationElement(searchScope, calledMethod)) {
-                            val element = createCallElement(project, calledMethod, children)
-                            if (callees.none { it.name == element.name && it.file == element.file }) {
-                                callees.add(element)
-                            }
-                        } else if (children != null) {
-                            children.forEach { child ->
-                                if (callees.none { it.name == child.name && it.file == child.file }) {
-                                    callees.add(child)
-                                }
-                            }
-                        }
+            fun addResolvedCallee(called: PsiElement) {
+                val children = if (depth > 1) {
+                    findCalleesRecursive(
+                        project,
+                        called,
+                        depth - 1,
+                        visited,
+                        stackDepth + 1,
+                        searchScope,
+                        maxResults
+                    )
+                } else null
+                val candidates = if (shouldIncludeNavigationElement(searchScope, called)) {
+                    listOf(createCallElement(project, called, children))
+                } else {
+                    children.orEmpty()
+                }
+                for (candidate in candidates) {
+                    if (callees.size >= maxResults) break
+                    if (callees.none { it.name == candidate.name && it.file == candidate.file }) {
+                        callees.add(candidate)
                     }
                 }
             }
 
-            if (functionRef != null) {
-                @Suppress("UNCHECKED_CAST")
-                val functionCalls = PsiTreeUtil.findChildrenOfType(callable, functionRef as Class<out PsiElement>)
-                functionCalls.take(MAX_RESULTS_PER_LEVEL).forEach { callExpr ->
-                    val calledFunction = resolveReference(callExpr)
-                    if (calledFunction != null && isFunction(calledFunction)) {
-                        val children = if (depth > 1) {
-                            findCalleesRecursive(project, calledFunction, depth - 1, visited, stackDepth + 1, searchScope)
-                        } else null
-                        if (shouldIncludeNavigationElement(searchScope, calledFunction)) {
-                            val element = createCallElement(project, calledFunction, children)
-                            if (callees.none { it.name == element.name && it.file == element.file }) {
-                                callees.add(element)
-                            }
-                        } else if (children != null) {
-                            children.forEach { child ->
-                                if (callees.none { it.name == child.name && it.file == child.file }) {
-                                    callees.add(child)
-                                }
-                            }
+            PsiTreeUtil.processElements(callable) { candidate ->
+                when {
+                    methodRef?.isInstance(candidate) == true -> {
+                        val calledMethod = resolveReference(candidate)
+                        if (calledMethod != null && (isMethod(calledMethod) || isFunction(calledMethod))) {
+                            addResolvedCallee(calledMethod)
+                        }
+                    }
+                    functionRef?.isInstance(candidate) == true -> {
+                        val calledFunction = resolveReference(candidate)
+                        if (calledFunction != null && isFunction(calledFunction)) {
+                            addResolvedCallee(calledFunction)
                         }
                     }
                 }
+                callees.size < maxResults
             }
         } catch (e: Exception) {
             LOG.debug("Error finding callees: ${e.message}")
@@ -1752,7 +1858,8 @@ class PhpCallHierarchyHandler : BasePhpHandler<CallHierarchyData>(), CallHierarc
             line = getLineNumber(project, callable) ?: 0,
             column = getColumnNumber(project, callable) ?: 0,
             language = "PHP",
-            children = children?.takeIf { it.isNotEmpty() }
+            children = children?.takeIf { it.isNotEmpty() },
+            pointerTarget = callable
         )
     }
 }
@@ -1788,7 +1895,8 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, method) ?: 0,
             column = getColumnNumber(project, method) ?: 0,
-            language = "PHP"
+            language = "PHP",
+            pointerTarget = method
         )
 
         val hierarchy = buildHierarchy(project, method)
@@ -1837,7 +1945,8 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
                             column = getColumnNumber(project, superMethod),
                             isInterface = isInterface(declaringClass),
                             depth = depth,
-                            language = "PHP"
+                            language = "PHP",
+                            pointerTarget = superMethod
                         ))
 
                         hierarchy.addAll(buildHierarchy(project, superMethod, visited, depth + 1))
@@ -1870,7 +1979,8 @@ class PhpSuperMethodsHandler : BasePhpHandler<SuperMethodsData>(), SuperMethodsH
                             column = getColumnNumber(project, ifaceMethod),
                             isInterface = true,
                             depth = depth,
-                            language = "PHP"
+                            language = "PHP",
+                            pointerTarget = ifaceMethod
                         ))
 
                         // Interfaces can extend other interfaces

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonHandlers.kt
@@ -8,6 +8,9 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureKind
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureNode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -15,6 +18,10 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.Processor
+import com.intellij.util.Query
+import java.lang.reflect.InvocationTargetException
+import kotlinx.coroutines.CancellationException
 
 /**
  * Registration entry point for Python language handlers.
@@ -288,13 +295,27 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        directOnly: Boolean,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
     ): TypeHierarchyData? {
         val pyClass = findContainingPyClass(element) ?: return null
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
-        val supertypes = getSupertypes(project, pyClass, searchScope = searchScope)
-        val subtypes = getSubtypes(project, pyClass, searchScope)
+        val collectionLimit = page?.collectionLimit ?: 100
+        val rawSupertypes = if (direction != TypeHierarchyDirection.SUBTYPE) {
+            getSupertypes(project, pyClass, searchScope = searchScope, directOnly = directOnly).take(collectionLimit)
+        } else emptyList()
+        val rawSubtypes = if (direction != TypeHierarchyDirection.SUPERTYPE) {
+            getSubtypes(project, pyClass, searchScope, directOnly, collectionLimit)
+        } else emptyList()
+        val (supertypes, superNext) = if (direction == TypeHierarchyDirection.SUPERTYPE) {
+            rawSupertypes.applyHierarchyPage(page)
+        } else rawSupertypes to null
+        val (subtypes, subtypeNext) = if (direction == TypeHierarchyDirection.SUBTYPE) {
+            rawSubtypes.applyHierarchyPage(page)
+        } else rawSubtypes to null
 
         return TypeHierarchyData(
             element = TypeElementData(
@@ -303,10 +324,12 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
                 file = pyClass.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, pyClass),
                 kind = "CLASS",
-                language = "Python"
+                language = "Python",
+                pointerTarget = pyClass
             ),
             supertypes = supertypes,
-            subtypes = subtypes
+            subtypes = subtypes,
+            nextOffset = superNext ?: subtypeNext
         )
     }
 
@@ -315,7 +338,8 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
         pyClass: PsiElement,
         visited: MutableSet<String> = mutableSetOf(),
         depth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false
     ): List<TypeElementData> {
         if (depth > MAX_HIERARCHY_DEPTH) return emptyList()
 
@@ -334,7 +358,8 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
                     superName != "object" &&
                     shouldIncludeNavigationElement(searchScope, superClass)
                 ) {
-                    val superSupertypes = getSupertypes(project, superClass, visited, depth + 1, searchScope)
+                    val superSupertypes = if (directOnly) emptyList() else
+                        getSupertypes(project, superClass, visited, depth + 1, searchScope, directOnly = false)
                     supertypes.add(TypeElementData(
                         name = superName,
                         qualifiedName = getQualifiedName(superClass),
@@ -342,7 +367,8 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
                         line = getLineNumber(project, superClass),
                         kind = "CLASS",
                         language = "Python",
-                        supertypes = superSupertypes.takeIf { it.isNotEmpty() }
+                        supertypes = superSupertypes.takeIf { it.isNotEmpty() },
+                        pointerTarget = superClass
                     ))
                 }
             }
@@ -356,29 +382,36 @@ class PythonTypeHierarchyHandler : BasePythonHandler<TypeHierarchyData>(), TypeH
     private fun getSubtypes(
         project: Project,
         pyClass: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false,
+        maxResults: Int = 100
     ): List<TypeElementData> {
+        if (maxResults <= 0) return emptyList()
+
         return try {
             val searchClass = Class.forName("com.jetbrains.python.psi.search.PyClassInheritorsSearch")
             val searchMethod = searchClass.getMethod("search", pyClassClass, java.lang.Boolean.TYPE)
-            val query = searchMethod.invoke(null, pyClass, true)
+            val query = searchMethod.invoke(null, pyClass, !directOnly)
 
-            val findAllMethod = query.javaClass.getMethod("findAll")
-            val inheritors = findAllMethod.invoke(query) as? Collection<*> ?: return emptyList()
-
-            inheritors.filterIsInstance<PsiElement>()
-                .filter { shouldIncludeNavigationElement(searchScope, it) }
-                .take(100)
-                .map { inheritor ->
-                    TypeElementData(
+            @Suppress("UNCHECKED_CAST")
+            val inheritors = query as? Query<Any?> ?: return emptyList()
+            val results = mutableListOf<TypeElementData>()
+            inheritors.forEach(Processor { candidate ->
+                val inheritor = candidate as? PsiElement
+                if (inheritor != null && shouldIncludeNavigationElement(searchScope, inheritor)) {
+                    results.add(TypeElementData(
                         name = getQualifiedName(inheritor) ?: getName(inheritor) ?: "unknown",
                         qualifiedName = getQualifiedName(inheritor),
                         file = inheritor.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                         line = getLineNumber(project, inheritor),
                         kind = "CLASS",
-                        language = "Python"
-                    )
+                        language = "Python",
+                        pointerTarget = inheritor
+                    ))
                 }
+                results.size < maxResults
+            })
+            results
         } catch (e: Exception) {
             emptyList()
         }
@@ -445,7 +478,8 @@ class PythonImplementationsHandler : BasePythonHandler<List<ImplementationData>>
                         line = getLineNumber(project, overridingMethod) ?: 0,
                         column = getColumnNumber(project, overridingMethod) ?: 0,
                         kind = "METHOD",
-                        language = "Python"
+                        language = "Python",
+                        pointerTarget = overridingMethod
                     )
                 }
         } catch (e: Exception) {
@@ -477,7 +511,8 @@ class PythonImplementationsHandler : BasePythonHandler<List<ImplementationData>>
                         line = getLineNumber(project, inheritor) ?: 0,
                         column = getColumnNumber(project, inheritor) ?: 0,
                         kind = "CLASS",
-                        language = "Python"
+                        language = "Python",
+                        pointerTarget = inheritor
                     )
                 }
         } catch (e: Exception) {
@@ -512,21 +547,25 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        page: HierarchyPageRequest?
     ): CallHierarchyData? {
         val pyFunction = findContainingPyFunction(element) ?: return null
         val visited = mutableSetOf<String>()
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
-        val calls = if (direction == "callers") {
-            findCallersRecursive(project, pyFunction, depth, visited, searchScope = searchScope)
+        val maxResults = page?.collectionLimit ?: MAX_RESULTS_PER_LEVEL
+        val rawCalls = if (direction == "callers") {
+            findCallersRecursive(project, pyFunction, depth, visited, searchScope = searchScope, maxResults = maxResults)
         } else {
-            findCalleesRecursive(project, pyFunction, depth, visited, searchScope = searchScope)
+            findCalleesRecursive(project, pyFunction, depth, visited, searchScope = searchScope, maxResults = maxResults)
         }
+        val (calls, nextOffset) = rawCalls.applyHierarchyPage(page)
 
         return CallHierarchyData(
             element = createCallElement(project, pyFunction),
-            calls = calls
+            calls = calls,
+            nextOffset = nextOffset
         )
     }
 
@@ -572,39 +611,62 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val functionKey = getFunctionKey(pyFunction)
         if (functionKey in visited) return emptyList()
         visited.add(functionKey)
 
-        val callers = mutableListOf<CallElementData>()
-        findDirectCallers(pyFunction)
-            .take(MAX_RESULTS_PER_LEVEL * 2)
-            .forEach { directCaller ->
-                if (directCaller == pyFunction || callers.size >= MAX_RESULTS_PER_LEVEL) return@forEach
-
-                val children = if (depth > 1) {
-                    findCallersRecursive(project, directCaller, depth - 1, visited, stackDepth + 1, searchScope)
-                } else null
-
-                if (shouldIncludeNavigationElement(searchScope, directCaller)) {
-                    callers.add(createCallElement(project, directCaller, children))
-                } else if (children != null) {
-                    children.forEach { child ->
-                        if (callers.size < MAX_RESULTS_PER_LEVEL) {
-                            callers.add(child)
-                        }
-                    }
-                }
-            }
-
-        return callers.distinctBy { it.name + it.file + it.line }.take(MAX_RESULTS_PER_LEVEL)
+        return collectIncludedCallers(
+            project, findDirectCallers(pyFunction), depth, visited, stackDepth, searchScope, maxResults
+        )
     }
 
-    private fun findDirectCallers(pyFunction: PsiElement): List<PsiElement> {
+    /** Scope filtering and semantic counting are independent of the optional native API lookup. */
+    internal fun collectIncludedCallers(
+        project: Project,
+        directCallers: Sequence<PsiElement>,
+        depth: Int,
+        visited: MutableSet<String>,
+        stackDepth: Int,
+        searchScope: GlobalSearchScope,
+        maxResults: Int
+    ): List<CallElementData> {
+        val callers = mutableListOf<CallElementData>()
+        val includedKeys = mutableSetOf<String>()
+        // The native API already returns a map. Consume it lazily until enough unique included
+        // callers exist; an arbitrary raw prefix cannot prove that the filtered search is over.
+        for (directCaller in directCallers) {
+            ProgressManager.checkCanceled()
+            if (callers.size >= maxResults) break
+
+            val children = if (depth > 1) {
+                findCallersRecursive(
+                    project, directCaller, depth - 1, visited, stackDepth + 1, searchScope, maxResults
+                )
+            } else null
+
+            val candidates = if (shouldIncludeNavigationElement(searchScope, directCaller)) {
+                listOf(createCallElement(project, directCaller, children))
+            } else {
+                children.orEmpty()
+            }
+            for (candidate in candidates) {
+                if (callers.size >= maxResults) break
+                val key = candidate.pointerTarget?.let(::getFunctionKey)
+                    ?: "${candidate.file}|${candidate.line}|${candidate.column}|${candidate.name}"
+                if (includedKeys.add(key)) callers.add(candidate)
+            }
+        }
+
+        return callers
+    }
+
+    private fun findDirectCallers(pyFunction: PsiElement): Sequence<PsiElement> {
         return findCallersUsingPyStaticHierarchy(pyFunction)
     }
 
@@ -612,14 +674,15 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
      * Mirrors PyCharm's own Python caller hierarchy implementation when the API is available.
      * This uses Python-specific find-usages semantics rather than generic ReferencesSearch.
      */
-    private fun findCallersUsingPyStaticHierarchy(pyFunction: PsiElement): List<PsiElement> {
+    private fun findCallersUsingPyStaticHierarchy(pyFunction: PsiElement): Sequence<PsiElement> {
         return try {
             val pyElementClass = Class.forName("com.jetbrains.python.psi.PyElement")
             val hierarchyUtilClass = Class.forName("com.jetbrains.python.hierarchy.call.PyStaticCallHierarchyUtil")
             val getCallersMethod = hierarchyUtilClass.getMethod("getCallers", pyElementClass)
 
-            val callers = getCallersMethod.invoke(null, pyFunction) as? Map<*, *> ?: return emptyList()
+            val callers = getCallersMethod.invoke(null, pyFunction) as? Map<*, *> ?: return emptySequence()
             callers.keys.asSequence()
+                .onEach { ProgressManager.checkCanceled() }
                 .filterIsInstance<PsiElement>()
                 .mapNotNull { caller ->
                     when {
@@ -628,8 +691,6 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
                     }
                 }
                 .filter { it != pyFunction }
-                .distinctBy { getFunctionKey(it) }
-                .toList()
         } catch (e: ClassNotFoundException) {
             throw IllegalStateException(
                 "Python caller hierarchy requires PyCharm's call hierarchy API, but it is unavailable in this IDE/Python plugin build.",
@@ -647,6 +708,12 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
                 e
             )
         } catch (e: Exception) {
+            val cause = (e as? InvocationTargetException)?.targetException ?: e
+            when (cause) {
+                is ProcessCanceledException -> throw cause
+                is CancellationException -> throw cause
+                is IndexNotReadyException -> throw cause
+            }
             LOG.warn("Python call hierarchy API failed", e)
             throw IllegalStateException(
                 "Python caller hierarchy failed inside the IDE's Python call hierarchy API.",
@@ -661,40 +728,58 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val functionKey = getFunctionKey(pyFunction)
         if (functionKey in visited) return emptyList()
         visited.add(functionKey)
 
         val callees = mutableListOf<CallElementData>()
+        val includedKeys = mutableSetOf<String>()
         try {
             val pyCallExpr = pyCallExpressionClass ?: return emptyList()
-            @Suppress("UNCHECKED_CAST")
-            val callExpressions = PsiTreeUtil.findChildrenOfType(pyFunction, pyCallExpr as Class<out PsiElement>)
-
-            callExpressions.take(MAX_RESULTS_PER_LEVEL).forEach { callExpr ->
-                val calledFunction = resolveCallExpression(callExpr)
-                if (calledFunction != null && isPyFunction(calledFunction)) {
-                    val children = if (depth > 1) {
-                        findCalleesRecursive(project, calledFunction, depth - 1, visited, stackDepth + 1, searchScope)
-                    } else null
-                    if (shouldIncludeNavigationElement(searchScope, calledFunction)) {
-                        val element = createCallElement(project, calledFunction, children)
-                        if (callees.none { it.name == element.name && it.file == element.file }) {
-                            callees.add(element)
+            PsiTreeUtil.processElements(pyFunction) { candidate ->
+                if (pyCallExpr.isInstance(candidate)) {
+                    val calledFunction = resolveCallExpression(candidate)
+                    if (calledFunction != null && isPyFunction(calledFunction)) {
+                        val children = if (depth > 1) {
+                            findCalleesRecursive(
+                                project,
+                                calledFunction,
+                                depth - 1,
+                                visited,
+                                stackDepth + 1,
+                                searchScope,
+                                maxResults
+                            )
+                        } else null
+                        val candidates = if (shouldIncludeNavigationElement(searchScope, calledFunction)) {
+                            listOf(createCallElement(project, calledFunction, children))
+                        } else {
+                            children.orEmpty()
                         }
-                    } else if (children != null) {
-                        children.forEach { child ->
-                            if (callees.none { it.name == child.name && it.file == child.file }) {
-                                callees.add(child)
+                        for (callee in candidates) {
+                            if (callees.size >= maxResults) break
+                            val key = callee.pointerTarget?.let(::getFunctionKey)
+                                ?: "${callee.file}|${callee.line}|${callee.column}|${callee.name}"
+                            if (includedKeys.add(key)) {
+                                callees.add(callee)
                             }
                         }
                     }
                 }
+                callees.size < maxResults
             }
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IndexNotReadyException) {
+            throw e
         } catch (e: Exception) {
             // Handle gracefully
         }
@@ -716,10 +801,12 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
     }
 
     private fun getFunctionKey(pyFunction: PsiElement): String {
+        val file = pyFunction.containingFile?.virtualFile?.url
+        if (file != null) return "$file|${pyFunction.textOffset}"
         val containingClass = findContainingPyClass(pyFunction)
         val className = containingClass?.let { getQualifiedName(it) ?: getName(it) } ?: ""
         val functionName = getName(pyFunction) ?: ""
-        return "$className.$functionName"
+        return "$className.$functionName|${pyFunction.textOffset}"
     }
 
     private fun createCallElement(project: Project, pyFunction: PsiElement, children: List<CallElementData>? = null): CallElementData {
@@ -736,7 +823,8 @@ class PythonCallHierarchyHandler : BasePythonHandler<CallHierarchyData>(), CallH
             line = getLineNumber(project, pyFunction) ?: 0,
             column = getColumnNumber(project, pyFunction) ?: 0,
             language = "Python",
-            children = children?.takeIf { it.isNotEmpty() }
+            children = children?.takeIf { it.isNotEmpty() },
+            pointerTarget = pyFunction
         )
     }
 }
@@ -766,7 +854,8 @@ class PythonSuperMethodsHandler : BasePythonHandler<SuperMethodsData>(), SuperMe
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, pyFunction) ?: 0,
             column = getColumnNumber(project, pyFunction) ?: 0,
-            language = "Python"
+            language = "Python",
+            pointerTarget = pyFunction
         )
 
         val hierarchy = buildHierarchy(project, pyFunction)
@@ -812,7 +901,8 @@ class PythonSuperMethodsHandler : BasePythonHandler<SuperMethodsData>(), SuperMe
                         column = getColumnNumber(project, superMethod),
                         isInterface = false,
                         depth = depth,
-                        language = "Python"
+                        language = "Python",
+                        pointerTarget = superMethod
                     ))
 
                     hierarchy.addAll(buildHierarchy(project, superMethod, visited, depth + 1))
@@ -975,7 +1065,8 @@ class PythonStructureHandler : BasePythonHandler<List<StructureNode>>(), Structu
             signature = buildClassSignature(pyClass),
             line = getLineNumber(project, pyClass) ?: 0,
             endLine = getEndLineNumber(project, pyClass),
-            children = children.sortedBy { it.line }
+            children = children.sortedBy { it.line },
+            pointerTarget = pyClass
         )
     }
 
@@ -988,7 +1079,8 @@ class PythonStructureHandler : BasePythonHandler<List<StructureNode>>(), Structu
             modifiers = getPythonModifiers(pyFunction),
             signature = buildFunctionSignature(pyFunction),
             line = getLineNumber(project, pyFunction) ?: 0,
-            endLine = getEndLineNumber(project, pyFunction)
+            endLine = getEndLineNumber(project, pyFunction),
+            pointerTarget = pyFunction
         )
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/rust/RustHandlers.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/rust/RustHandlers.kt
@@ -4,6 +4,8 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.*
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -12,6 +14,7 @@ import com.intellij.psi.search.searches.DefinitionsScopedSearch
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
+import kotlinx.coroutines.CancellationException
 
 /**
  * Registration entry point for Rust language handlers.
@@ -401,37 +404,48 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
         element: PsiElement,
         project: Project,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        directOnly: Boolean,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
     ): TypeHierarchyData? {
         LOG.debug("Getting type hierarchy for Rust element at ${element.containingFile?.name}")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
+
+        val collectionLimit = page?.collectionLimit ?: 100
 
         // Handle traits
         val trait = findContainingRsTrait(element)
         if (trait != null) {
             LOG.debug("Getting hierarchy for trait: ${getName(trait)}")
-            return getTraitHierarchy(project, trait, searchScope)
+            return paginateTypeData(
+                getTraitHierarchy(project, trait, searchScope, directOnly, collectionLimit), direction, page
+            )
         }
 
         // Handle structs
         val struct = findContainingRsStruct(element)
         if (struct != null) {
             LOG.debug("Getting hierarchy for struct: ${getName(struct)}")
-            return getTypeImplHierarchy(project, struct, searchScope)
+            return paginateTypeData(
+                getTypeImplHierarchy(project, struct, searchScope, collectionLimit), direction, page
+            )
         }
 
         // Handle enums
         val enum = findContainingRsEnum(element)
         if (enum != null) {
             LOG.debug("Getting hierarchy for enum: ${getName(enum)}")
-            return getTypeImplHierarchy(project, enum, searchScope)
+            return paginateTypeData(
+                getTypeImplHierarchy(project, enum, searchScope, collectionLimit), direction, page
+            )
         }
 
         // Handle impl blocks
         val impl = findContainingRsImpl(element)
         if (impl != null) {
             LOG.debug("Getting hierarchy for impl block")
-            return getImplHierarchy(project, impl, searchScope)
+            return paginateTypeData(getImplHierarchy(project, impl, searchScope), direction, page)
         }
 
         return null
@@ -440,10 +454,14 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
     private fun getTraitHierarchy(
         project: Project,
         trait: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean,
+        maxResults: Int
     ): TypeHierarchyData {
-        val supertypes = getSupertraitHierarchy(project, trait, mutableSetOf(), searchScope = searchScope)
-        val subtypes = getImplementingTypes(project, trait, searchScope)
+        val supertypes = getSupertraitHierarchy(
+            project, trait, mutableSetOf(), searchScope = searchScope, directOnly = directOnly
+        )
+        val subtypes = getImplementingTypes(project, trait, searchScope, maxResults)
 
         LOG.debug("Found ${supertypes.size} supertraits and ${subtypes.size} implementing types")
 
@@ -454,7 +472,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                 file = trait.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, trait),
                 kind = "TRAIT",
-                language = "Rust"
+                language = "Rust",
+                pointerTarget = trait
             ),
             supertypes = supertypes,
             subtypes = subtypes
@@ -466,7 +485,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
         trait: PsiElement,
         visited: MutableSet<String>,
         depth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        directOnly: Boolean = false
     ): List<TypeElementData> {
         if (depth > MAX_HIERARCHY_DEPTH) return emptyList()
 
@@ -487,7 +507,10 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                 ) {
                     val resolvedName = getName(resolved) ?: continue
                     if (resolvedName !in visited) {
-                        val nestedSupertypes = getSupertraitHierarchy(project, resolved, visited, depth + 1, searchScope)
+                        val nestedSupertypes = if (directOnly) emptyList() else
+                            getSupertraitHierarchy(
+                                project, resolved, visited, depth + 1, searchScope, directOnly = false
+                            )
                         supertypes.add(TypeElementData(
                             name = resolvedName,
                             qualifiedName = getQualifiedName(resolved),
@@ -495,7 +518,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                             line = getLineNumber(project, resolved),
                             kind = "TRAIT",
                             language = "Rust",
-                            supertypes = nestedSupertypes.takeIf { it.isNotEmpty() }
+                            supertypes = nestedSupertypes.takeIf { it.isNotEmpty() },
+                            pointerTarget = resolved
                         ))
                     }
                 }
@@ -510,7 +534,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
     private fun getImplementingTypes(
         project: Project,
         trait: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<TypeElementData> {
         val results = mutableListOf<TypeElementData>()
 
@@ -534,12 +559,13 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                                 file = targetElement.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                                 line = getLineNumber(project, targetElement),
                                 kind = if (resolvedType != null) determineElementKind(resolvedType) else "IMPL",
-                                language = "Rust"
+                                language = "Rust",
+                                pointerTarget = targetElement
                             ))
                         }
                     }
                 }
-                results.size < 100
+                results.size < maxResults
             })
 
             LOG.debug("Found ${results.size} implementing types via DefinitionsScopedSearch")
@@ -553,9 +579,10 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
     private fun getTypeImplHierarchy(
         project: Project,
         type: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): TypeHierarchyData {
-        val implementedTraits = findImplementedTraits(project, type, searchScope)
+        val implementedTraits = findImplementedTraits(project, type, searchScope, maxResults)
 
         return TypeHierarchyData(
             element = TypeElementData(
@@ -564,7 +591,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                 file = type.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, type),
                 kind = determineElementKind(type),
-                language = "Rust"
+                language = "Rust",
+                pointerTarget = type
             ),
             supertypes = implementedTraits,  // Implemented traits shown as "supertypes"
             subtypes = emptyList()           // Rust has no type inheritance
@@ -574,7 +602,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
     private fun findImplementedTraits(
         project: Project,
         type: PsiElement,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<TypeElementData> {
         val results = mutableListOf<TypeElementData>()
 
@@ -607,12 +636,13 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                                 file = targetElement.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                                 line = getLineNumber(project, targetElement),
                                 kind = "TRAIT",
-                                language = "Rust"
+                                language = "Rust",
+                                pointerTarget = targetElement
                             ))
                         }
                     }
                 }
-                results.size < 100
+                results.size < maxResults
             })
         } catch (e: Exception) {
             LOG.debug("Error finding implemented traits: ${e.message}")
@@ -655,7 +685,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                     file = targetElement.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                     line = getLineNumber(project, targetElement),
                     kind = "TRAIT",
-                    language = "Rust"
+                    language = "Rust",
+                    pointerTarget = targetElement
                 ))
             }
         }
@@ -672,7 +703,8 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                     file = targetElement.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                     line = getLineNumber(project, targetElement),
                     kind = if (resolvedType != null) determineElementKind(resolvedType) else "TYPE",
-                    language = "Rust"
+                    language = "Rust",
+                    pointerTarget = targetElement
                 ))
             }
         }
@@ -686,11 +718,30 @@ class RustTypeHierarchyHandler : BaseRustHandler<TypeHierarchyData>(), TypeHiera
                 file = impl.containingFile?.virtualFile?.let { getRelativePath(project, it) },
                 line = getLineNumber(project, impl),
                 kind = "IMPL",
-                language = "Rust"
+                language = "Rust",
+                pointerTarget = impl
             ),
             supertypes = supertypes,
             subtypes = subtypes
         )
+    }
+
+    private fun paginateTypeData(
+        data: TypeHierarchyData,
+        direction: TypeHierarchyDirection?,
+        page: HierarchyPageRequest?
+    ): TypeHierarchyData {
+        if (direction == null || page == null) return data
+        return when (direction) {
+            TypeHierarchyDirection.SUPERTYPE -> {
+                val (items, next) = data.supertypes.applyHierarchyPage(page)
+                data.copy(supertypes = items, subtypes = emptyList(), nextOffset = next)
+            }
+            TypeHierarchyDirection.SUBTYPE -> {
+                val (items, next) = data.subtypes.applyHierarchyPage(page)
+                data.copy(supertypes = emptyList(), subtypes = items, nextOffset = next)
+            }
+        }
     }
 
     private fun buildImplName(traitRef: PsiElement?, typeRef: PsiElement?): String {
@@ -792,7 +843,8 @@ class RustImplementationsHandler : BaseRustHandler<List<ImplementationData>>(), 
                             line = getLineNumber(project, definition) ?: 0,
                             column = getColumnNumber(project, definition) ?: 0,
                             kind = "IMPL",
-                            language = "Rust"
+                            language = "Rust",
+                            pointerTarget = definition
                         ))
                     }
                 }
@@ -838,7 +890,8 @@ class RustImplementationsHandler : BaseRustHandler<List<ImplementationData>>(), 
                             line = getLineNumber(project, definition) ?: 0,
                             column = getColumnNumber(project, definition) ?: 0,
                             kind = "METHOD",
-                            language = "Rust"
+                            language = "Rust",
+                            pointerTarget = definition
                         ))
                     }
                 }
@@ -880,24 +933,28 @@ class RustCallHierarchyHandler : BaseRustHandler<CallHierarchyData>(), CallHiera
         direction: String,
         depth: Int,
         scope: BuiltInSearchScope,
-        excludeGenerated: Boolean
+        excludeGenerated: Boolean,
+        page: HierarchyPageRequest?
     ): CallHierarchyData? {
         val function = findContainingRsFunction(element) ?: return null
         LOG.debug("Getting call hierarchy for ${getName(function)}, direction=$direction, depth=$depth")
         val searchScope = createNavigationSearchScope(project, scope, excludeGenerated)
 
         val visited = mutableSetOf<String>()
-        val calls = if (direction == "callers") {
-            findCallersRecursive(project, function, depth, visited, searchScope = searchScope)
+        val maxResults = page?.collectionLimit ?: MAX_RESULTS_PER_LEVEL
+        val rawCalls = if (direction == "callers") {
+            findCallersRecursive(project, function, depth, visited, searchScope = searchScope, maxResults = maxResults)
         } else {
-            findCalleesRecursive(project, function, depth, visited, searchScope = searchScope)
+            findCalleesRecursive(project, function, depth, visited, searchScope = searchScope, maxResults = maxResults)
         }
+        val (calls, nextOffset) = rawCalls.applyHierarchyPage(page)
 
         LOG.debug("Found ${calls.size} $direction")
 
         return CallHierarchyData(
             element = createCallElement(project, function),
-            calls = calls
+            calls = calls,
+            nextOffset = nextOffset
         )
     }
 
@@ -907,41 +964,65 @@ class RustCallHierarchyHandler : BaseRustHandler<CallHierarchyData>(), CallHiera
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
+        if (maxResults <= 0) return emptyList()
 
         val key = getFunctionKey(function)
         if (key in visited) return emptyList()
         visited.add(key)
 
         return try {
-            val references = mutableListOf<com.intellij.psi.PsiReference>()
+            val results = mutableListOf<CallElementData>()
+            val seenCallers = mutableSetOf<String>()
+            val seenResults = mutableSetOf<String>()
 
             ReferencesSearch.search(function, searchScope).forEach(Processor { reference ->
-                references.add(reference)
-                references.size < MAX_RESULTS_PER_LEVEL * 2
-            })
-
-            LOG.debug("Found ${references.size} references for ${getName(function)}")
-
-            val results = mutableListOf<CallElementData>()
-            for (reference in references) {
-                if (results.size >= MAX_RESULTS_PER_LEVEL) break
                 val refElement = reference.element
                 val containingFunction = findContainingRsFunction(refElement)
                 if (containingFunction != null && containingFunction != function) {
-                    val children = if (depth > 1) {
-                        findCallersRecursive(project, containingFunction, depth - 1, visited, stackDepth + 1, searchScope)
-                    } else null
-                    if (shouldIncludeNavigationElement(searchScope, containingFunction)) {
-                        results.add(createCallElement(project, containingFunction, children))
-                    } else if (children != null) {
-                        results.addAll(children)
+                    val callerPath = containingFunction.containingFile?.virtualFile?.path.orEmpty()
+                    val callerIdentity =
+                        "$callerPath:${containingFunction.textOffset}:${getFunctionKey(containingFunction)}"
+                    if (seenCallers.add(callerIdentity)) {
+                        val children = if (depth > 1) {
+                            findCallersRecursive(
+                                project,
+                                containingFunction,
+                                depth - 1,
+                                visited,
+                                stackDepth + 1,
+                                searchScope,
+                                maxResults
+                            )
+                        } else null
+                        val candidates = if (shouldIncludeNavigationElement(searchScope, containingFunction)) {
+                            listOf(createCallElement(project, containingFunction, children))
+                        } else {
+                            children.orEmpty()
+                        }
+                        for (candidate in candidates) {
+                            if (results.size >= maxResults) break
+                            val resultIdentity = "${candidate.name}:${candidate.file}:${candidate.line}"
+                            if (seenResults.add(resultIdentity)) {
+                                results.add(candidate)
+                            }
+                        }
                     }
                 }
-            }
-            results.distinctBy { it.name + it.file + it.line }.take(MAX_RESULTS_PER_LEVEL)
+                results.size < maxResults
+            })
+
+            LOG.debug("Found ${results.size} callers for ${getName(function)}")
+            results
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IndexNotReadyException) {
+            throw e
         } catch (e: Exception) {
             LOG.warn("Error finding callers: ${e.message}")
             emptyList()
@@ -954,7 +1035,8 @@ class RustCallHierarchyHandler : BaseRustHandler<CallHierarchyData>(), CallHiera
         depth: Int,
         visited: MutableSet<String>,
         stackDepth: Int = 0,
-        searchScope: GlobalSearchScope
+        searchScope: GlobalSearchScope,
+        maxResults: Int
     ): List<CallElementData> {
         if (stackDepth > MAX_STACK_DEPTH || depth <= 0) return emptyList()
 
@@ -970,11 +1052,14 @@ class RustCallHierarchyHandler : BaseRustHandler<CallHierarchyData>(), CallHiera
                 @Suppress("UNCHECKED_CAST")
                 val calls = PsiTreeUtil.findChildrenOfType(function, callClass as Class<out PsiElement>)
 
-                calls.take(MAX_RESULTS_PER_LEVEL).forEach { callExpr ->
+                for (callExpr in calls) {
+                    if (callees.size >= maxResults) break
                     val resolved = resolveCallExpression(callExpr)
                     if (resolved != null && isRsFunction(resolved)) {
                         val children = if (depth > 1) {
-                            findCalleesRecursive(project, resolved, depth - 1, visited, stackDepth + 1, searchScope)
+                            findCalleesRecursive(
+                                project, resolved, depth - 1, visited, stackDepth + 1, searchScope, maxResults
+                            )
                         } else null
                         if (shouldIncludeNavigationElement(searchScope, resolved)) {
                             val element = createCallElement(project, resolved, children)
@@ -1088,7 +1173,8 @@ class RustCallHierarchyHandler : BaseRustHandler<CallHierarchyData>(), CallHiera
             line = getLineNumber(project, function) ?: 0,
             column = getColumnNumber(project, function) ?: 0,
             language = "Rust",
-            children = children?.takeIf { it.isNotEmpty() }
+            children = children?.takeIf { it.isNotEmpty() },
+            pointerTarget = function
         )
     }
 
@@ -1174,7 +1260,8 @@ class RustSuperMethodsHandler : BaseRustHandler<SuperMethodsData>(), SuperMethod
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, function) ?: 0,
             column = getColumnNumber(project, function) ?: 0,
-            language = "Rust"
+            language = "Rust",
+            pointerTarget = function
         )
 
         val hierarchy = buildHierarchy(project, trait, methodName, mutableSetOf())
@@ -1202,7 +1289,8 @@ class RustSuperMethodsHandler : BaseRustHandler<SuperMethodsData>(), SuperMethod
             file = file?.let { getRelativePath(project, it) } ?: "unknown",
             line = getLineNumber(project, function) ?: 0,
             column = getColumnNumber(project, function) ?: 0,
-            language = "Rust"
+            language = "Rust",
+            pointerTarget = function
         )
 
         // Find in supertraits
@@ -1249,7 +1337,8 @@ class RustSuperMethodsHandler : BaseRustHandler<SuperMethodsData>(), SuperMethod
                 column = getColumnNumber(project, traitMethod),
                 isInterface = true,  // Traits are like interfaces
                 depth = depth,
-                language = "Rust"
+                language = "Rust",
+                pointerTarget = traitMethod
             ))
         }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/CacheMaintenance.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/CacheMaintenance.kt
@@ -1,0 +1,77 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ProjectManagerListener
+import com.intellij.util.concurrency.AppExecutorUtil
+import java.util.concurrent.TimeUnit
+
+/** Releases idle/closed-project payloads even when nobody calls the owning cache again. */
+internal class CacheMaintenance(
+    owner: Disposable,
+    sweep: (() -> Unit)?,
+    removeProject: (Project) -> Unit
+) : Disposable {
+    private val connection = ApplicationManager.getApplication()?.messageBus?.connect(owner)?.also { connection ->
+        connection.subscribe(ProjectManager.TOPIC, object : ProjectManagerListener {
+            override fun projectClosed(project: Project) = removeProject(project)
+        })
+    }
+    private val future = if (connection == null || sweep == null) null else {
+        AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(
+            { sweep() },
+            PaginationService.SWEEP_INTERVAL_MINUTES,
+            PaginationService.SWEEP_INTERVAL_MINUTES,
+            TimeUnit.MINUTES
+        )
+    }
+
+    override fun dispose() {
+        future?.cancel(false)
+        connection?.disconnect()
+    }
+}
+
+internal enum class CacheEvictionReason {
+    TTL, LRU, PROJECT_CLOSED, SESSION_RESET, INVALIDATED, WEIGHT, REPLAY_LIMIT
+}
+
+/** Internal diagnostics only: a snapshot does not touch LRU order or refresh TTL. */
+internal data class CacheStats(
+    val entries: Int,
+    val hits: Long,
+    val misses: Long,
+    val insertions: Long,
+    val evictions: Map<CacheEvictionReason, Long>,
+    val storedPointers: Long = 0,
+    val storedKeyCharacters: Long = 0,
+    val storedTextCharacters: Long = 0,
+    val storedResults: Long = 0,
+    val maintenanceScans: Long = 0
+)
+
+/** Accessed only under the owning registry's monitor. */
+internal class CacheCounters {
+    var hits = 0L
+    var misses = 0L
+    var insertions = 0L
+    var maintenanceScans = 0L
+    private val evictions = mutableMapOf<CacheEvictionReason, Long>()
+
+    fun removed(reason: CacheEvictionReason, count: Int = 1) {
+        if (count > 0) evictions[reason] = (evictions[reason] ?: 0L) + count
+    }
+
+    fun snapshot(
+        entries: Int,
+        pointers: Long = 0,
+        keyCharacters: Long = 0,
+        textCharacters: Long = keyCharacters,
+        results: Long = 0
+    ) = CacheStats(
+        entries, hits, misses, insertions, evictions.toMap(), pointers, keyCharacters,
+        textCharacters, results, maintenanceScans
+    )
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/HierarchyContinuationRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/HierarchyContinuationRegistry.kt
@@ -1,0 +1,460 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyDirection
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallElement
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeElement
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import java.lang.ref.WeakReference
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.LinkedHashMap
+
+/** Session/project-bound continuation storage for deterministic hierarchy BFS pages. */
+@Service(Service.Level.APP)
+class HierarchyContinuationRegistry @JvmOverloads constructor(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val ttlMillis: Long = DEFAULT_TTL_MILLIS,
+    private val clock: () -> Long = { System.nanoTime() / 1_000_000L },
+    private val idGenerator: () -> String = Companion::newOpaqueCursor,
+    private val serverEpoch: McpServerEpoch = McpServerEpoch.shared,
+    private val maxTotalPointers: Long = MAX_TOTAL_POINTERS,
+    private val maxTotalCharacters: Long = MAX_TOTAL_CHARACTERS,
+    private val maxSnapshotsPerTraversal: Int = MAX_SNAPSHOTS_PER_TRAVERSAL
+) : Disposable {
+
+    internal sealed interface Continuation
+
+    internal sealed interface CallWork
+
+    /** Shared only by snapshots of the same exact declaration; synchronize when rebinding. */
+    internal class MaterializedSymbolHandle(var symbolId: String? = null)
+
+    internal data class PendingCallNode(
+        val pointer: SmartPsiElementPointer<PsiElement>?,
+        val snapshot: CallElement,
+        val depth: Int,
+        val modificationCount: Long = -1L,
+        val handle: MaterializedSymbolHandle = MaterializedSymbolHandle(snapshot.symbolId)
+    ) : CallWork
+
+    internal data class PendingCallExpansion(
+        val pointer: SmartPsiElementPointer<PsiElement>,
+        val depth: Int,
+        val offset: Int
+    ) : CallWork
+
+    internal data class CallContinuation(
+        val rootPointer: SmartPsiElementPointer<PsiElement>,
+        val root: CallElement,
+        val frontier: List<CallWork>,
+        val visited: Set<String>,
+        val visitedPointers: List<SmartPsiElementPointer<PsiElement>> = emptyList(),
+        val direction: String,
+        val maxDepth: Int,
+        val scope: BuiltInSearchScope,
+        val excludeGenerated: Boolean,
+        val rootModificationCount: Long = -1L,
+        val rootHandle: MaterializedSymbolHandle = MaterializedSymbolHandle(root.symbolId)
+    ) : Continuation
+
+    internal sealed interface TypeWork
+
+    internal data class PendingTypeNode(
+        val pointer: SmartPsiElementPointer<PsiElement>?,
+        val snapshot: TypeElement,
+        val direction: TypeHierarchyDirection,
+        val modificationCount: Long = -1L,
+        val handle: MaterializedSymbolHandle = MaterializedSymbolHandle(snapshot.symbolId)
+    ) : TypeWork
+
+    internal data class PendingTypeExpansion(
+        val pointer: SmartPsiElementPointer<PsiElement>,
+        val direction: TypeHierarchyDirection,
+        val offset: Int
+    ) : TypeWork
+
+    internal data class TypeContinuation(
+        val rootPointer: SmartPsiElementPointer<PsiElement>,
+        val root: TypeElement,
+        val frontier: List<TypeWork>,
+        val visited: Set<String>,
+        val visitedPointers: List<SmartPsiElementPointer<PsiElement>> = emptyList(),
+        val scope: BuiltInSearchScope,
+        val excludeGenerated: Boolean,
+        val rootModificationCount: Long = -1L,
+        val rootHandle: MaterializedSymbolHandle = MaterializedSymbolHandle(root.symbolId)
+    ) : Continuation
+
+    private data class Entry(
+        val project: WeakReference<Project>,
+        val continuation: Continuation,
+        val generation: Long,
+        var lastAccessMillis: Long,
+        val traversalId: String,
+        val sequence: Long,
+        val pointerCount: Long,
+        val keyCharacters: Long,
+        val characters: Long,
+        val parentCursor: String?,
+        val replayKey: String?
+    )
+
+    internal data class Lease(
+        val continuation: Continuation,
+        val generation: Long
+    )
+
+    private val entries = LinkedHashMap<String, Entry>()
+    private val latestByTraversal = mutableMapOf<String, String>()
+    private val counters = CacheCounters()
+    private var storedPointers = 0L
+    private var storedKeyCharacters = 0L
+    private var storedCharacters = 0L
+
+    init {
+        require(maxEntries > 0) { "maxEntries must be positive" }
+        require(ttlMillis > 0) { "ttlMillis must be positive" }
+        require(maxTotalPointers > 0) { "maxTotalPointers must be positive" }
+        require(maxTotalCharacters > 0) { "maxTotalCharacters must be positive" }
+        require(maxSnapshotsPerTraversal > 0) { "maxSnapshotsPerTraversal must be positive" }
+    }
+
+    private val maintenance = CacheMaintenance(this, ::sweepExpired, ::removeProject)
+
+    internal fun register(project: Project, continuation: Continuation): String {
+        return register(project, serverEpoch.expectedForCurrentRequest(), continuation).getOrThrow()
+    }
+
+    /**
+     * Registers only if the request still belongs to [expectedGeneration]. A hierarchy query can
+     * outlive stop/start while it is inside a read action; without this check it could publish an
+     * old-session cursor after [resetSession] had already cleared the registry.
+     */
+    internal fun register(
+        project: Project,
+        expectedGeneration: Long,
+        continuation: Continuation,
+        parentCursor: String? = null,
+        replayKey: String? = null
+    ): Result<String> = serverEpoch.ifCurrent(
+        expectedEpoch = expectedGeneration,
+        stale = ::staleGeneration
+    ) {
+        synchronized(this) {
+            require(!project.isDisposed) { "Cannot register a hierarchy cursor for a disposed project" }
+            val now = clock()
+            evictExpired(now)
+            val parent = if (parentCursor == null) null else {
+                entries[parentCursor]?.takeIf { it.project.get() === project && it.generation == expectedGeneration }
+                    ?: return@synchronized expired(parentCursor)
+            }
+            if (parentCursor != null && replayKey != null) {
+                val replay = entries.entries.firstOrNull {
+                    it.value.parentCursor == parentCursor && it.value.replayKey == replayKey &&
+                        it.value.project.get() === project && it.value.generation == expectedGeneration
+                }
+                if (replay != null) {
+                    val existingCursor = replay.key
+                    val existingEntry = replay.value
+                    entries.remove(existingCursor)
+                    existingEntry.lastAccessMillis = now
+                    entries[existingCursor] = existingEntry
+                    return@synchronized Result.success(existingCursor)
+                }
+            }
+            var cursor: String
+            do cursor = idGenerator() while (entries.containsKey(cursor))
+            val boundedContinuation = continuation.freeze()
+            if (boundedContinuation.visitedKeyBudgetExceeded()) {
+                return@synchronized Result.failure(
+                    IllegalStateException(
+                        "Hierarchy continuation exceeds the stable visited-key budget " +
+                            "($MAX_VISITED_KEYS_PER_CONTINUATION keys / $MAX_VISITED_KEY_CHARS_PER_CONTINUATION characters). " +
+                            "Narrow the scope or depth, or choose a more specific root, and start a new query."
+                    )
+                )
+            }
+            if (boundedContinuation.pointerCount() > MAX_POINTERS_PER_CONTINUATION) {
+                return@synchronized Result.failure(
+                    IllegalStateException(
+                        "Hierarchy continuation exceeds the $MAX_POINTERS_PER_CONTINUATION smart-pointer limit. " +
+                            "Narrow the scope or depth, or choose a more specific root, and start a new query."
+                    )
+                )
+            }
+            val pointers = boundedContinuation.pointerCount().toLong()
+            val keyCharacters = boundedContinuation.visitedKeys().sumOf { it.length.toLong() }
+            val characters = keyCharacters + boundedContinuation.snapshotCharacters()
+            if (pointers > maxTotalPointers || characters > maxTotalCharacters) {
+                return@synchronized Result.failure(IllegalStateException(
+                    "Hierarchy continuation exceeds the cache's aggregate pointer/text budget. " +
+                        "Narrow the hierarchy scope or depth and start a new query."
+                ))
+            }
+            val traversalId = parent?.traversalId ?: cursor
+            counters.insertions++
+            entries[cursor] = Entry(
+                WeakReference(project), boundedContinuation, expectedGeneration, now,
+                traversalId, counters.insertions, pointers, keyCharacters, characters, parentCursor, replayKey
+            )
+            latestByTraversal[traversalId] = cursor
+            storedPointers += pointers
+            storedKeyCharacters += keyCharacters
+            storedCharacters += characters
+            evictTraversalHistory(traversalId, cursor)
+            evictOverflow(cursor)
+            Result.success(cursor)
+        }
+    }
+
+    internal fun resolve(project: Project, cursor: String): Result<Continuation> {
+        return resolveLease(project, cursor).map { it.continuation }
+    }
+
+    internal fun resolveLease(project: Project, cursor: String): Result<Lease> {
+        val expectedGeneration = serverEpoch.expectedForCurrentRequest()
+        return serverEpoch.ifCurrent(expectedGeneration, stale = { expired(cursor) }) {
+            synchronized(this) {
+                val now = clock()
+                evictExpired(now)
+                val entry = entries[cursor] ?: return@synchronized expiredLookup(cursor)
+                val owner = entry.project.get()
+                if (owner == null || owner.isDisposed) {
+                    remove(cursor, CacheEvictionReason.PROJECT_CLOSED)
+                    return@synchronized expiredLookup(cursor)
+                }
+                if (owner !== project || project.isDisposed || entry.generation != expectedGeneration) {
+                    return@synchronized expiredLookup(cursor)
+                }
+                entries.remove(cursor)
+                entry.lastAccessMillis = now
+                entries[cursor] = entry
+                counters.hits++
+                Result.success(Lease(entry.continuation, entry.generation))
+            }
+        }
+    }
+
+    internal fun currentGeneration(): Long = serverEpoch.expectedForCurrentRequest()
+
+    internal fun isCurrentGeneration(expectedGeneration: Long): Boolean =
+        serverEpoch.isCurrent(expectedGeneration)
+
+    /** Advances the shared MCP epoch and drops hierarchy continuations from the old session. */
+    fun resetSession() {
+        serverEpoch.advanceAndReset(::clearForSessionReset)
+    }
+
+    @Synchronized
+    internal fun clearForSessionReset() {
+        counters.removed(CacheEvictionReason.SESSION_RESET, entries.size)
+        entries.clear()
+        latestByTraversal.clear()
+        storedPointers = 0
+        storedKeyCharacters = 0
+        storedCharacters = 0
+    }
+
+    @Synchronized
+    internal fun sizeForTest(): Int {
+        evictExpired(clock())
+        return entries.size
+    }
+
+    override fun dispose() {
+        maintenance.dispose()
+        resetSession()
+    }
+
+    @Synchronized
+    internal fun stats(): CacheStats =
+        counters.snapshot(entries.size, storedPointers, storedKeyCharacters, storedCharacters)
+
+    @Synchronized
+    internal fun removeProject(project: Project) {
+        entries.filterValues { it.project.get() === project }.keys.toList().forEach {
+            remove(it, CacheEvictionReason.PROJECT_CLOSED)
+        }
+    }
+
+    @Synchronized
+    internal fun sweepExpired() {
+        counters.maintenanceScans++
+        evictExpired(clock())
+    }
+
+    private fun evictExpired(now: Long) {
+        val expired = entries.mapNotNull { (cursor, entry) ->
+            when {
+                entry.project.get()?.isDisposed != false -> cursor to CacheEvictionReason.PROJECT_CLOSED
+                now - entry.lastAccessMillis >= ttlMillis -> cursor to CacheEvictionReason.TTL
+                else -> null
+            }
+        }
+        expired.forEach { (cursor, reason) -> remove(cursor, reason) }
+    }
+
+    private fun evictTraversalHistory(traversalId: String, protectedCursor: String) {
+        while (entries.values.count { it.traversalId == traversalId } > maxSnapshotsPerTraversal) {
+            val oldest = entries.entries
+                .filter { it.value.traversalId == traversalId && it.key != protectedCursor }
+                .minByOrNull { it.value.sequence } ?: return
+            remove(oldest.key, CacheEvictionReason.REPLAY_LIMIT)
+        }
+    }
+
+    private fun evictOverflow(protectedCursor: String) {
+        while (entries.size > maxEntries || storedPointers > maxTotalPointers || storedCharacters > maxTotalCharacters) {
+            // Prefer obsolete replay snapshots to another traversal's newest frontier.
+            val candidate = entries.entries.firstOrNull {
+                it.key != protectedCursor && latestByTraversal[it.value.traversalId] != it.key
+            } ?: entries.entries.firstOrNull { it.key != protectedCursor } ?: return
+            val reason = if (storedPointers > maxTotalPointers || storedCharacters > maxTotalCharacters) {
+                CacheEvictionReason.WEIGHT
+            } else CacheEvictionReason.LRU
+            remove(candidate.key, reason)
+        }
+    }
+
+    private fun remove(cursor: String, reason: CacheEvictionReason) {
+        val removed = entries.remove(cursor) ?: return
+        counters.removed(reason)
+        storedPointers -= removed.pointerCount
+        storedKeyCharacters -= removed.keyCharacters
+        storedCharacters -= removed.characters
+        if (latestByTraversal[removed.traversalId] == cursor) {
+            val replacement = entries.entries.filter { it.value.traversalId == removed.traversalId }
+                .maxByOrNull { it.value.sequence }
+            if (replacement == null) latestByTraversal.remove(removed.traversalId)
+            else latestByTraversal[removed.traversalId] = replacement.key
+        }
+    }
+
+    /**
+     * Keep exact pointer identity for the whole accepted traversal. Silently dropping old
+     * pointers would make rename/line shifts turn previously visited declarations into new ones.
+     * Persistent collections share unchanged history between immutable page snapshots.
+     */
+    private fun Continuation.freeze(): Continuation = when (this) {
+        is TypeContinuation -> copy(
+            frontier = frontier.toPersistentList(), visited = visited.toPersistentSet(),
+            visitedPointers = visitedPointers.toPersistentList()
+        )
+        is CallContinuation -> copy(
+            frontier = frontier.toPersistentList(), visited = visited.toPersistentSet(),
+            visitedPointers = visitedPointers.toPersistentList()
+        )
+    }
+
+    private fun Continuation.visitedKeys(): Set<String> = when (this) {
+        is TypeContinuation -> visited
+        is CallContinuation -> visited
+    }
+
+    private fun TypeElement.characters(): Long = name.length.toLong() + (file?.length ?: 0) + kind.length +
+        (language?.length ?: 0) + (symbolId?.length ?: 0) + supertypes.orEmpty().sumOf { it.characters() }
+
+    private fun CallElement.characters(): Long = name.length.toLong() + file.length +
+        (language?.length ?: 0) + (symbolId?.length ?: 0) + children.orEmpty().sumOf { it.characters() }
+
+    private fun Continuation.snapshotCharacters(): Long = when (this) {
+        is TypeContinuation -> root.characters() + frontier.sumOf {
+            if (it is PendingTypeNode) it.snapshot.characters() else 0L
+        }
+        is CallContinuation -> root.characters() + frontier.sumOf {
+            if (it is PendingCallNode) it.snapshot.characters() else 0L
+        }
+    }
+
+    /**
+     * Stable keys preserve dedup when smart pointers are invalidated, so truncating them would
+     * reintroduce duplicates. Reject an oversized continuation instead of silently weakening the
+     * traversal invariant or retaining unbounded application-service memory.
+     */
+    private fun Continuation.visitedKeyBudgetExceeded(): Boolean {
+        val keys = when (this) {
+            is TypeContinuation -> visited
+            is CallContinuation -> visited
+        }
+        if (keys.size > MAX_VISITED_KEYS_PER_CONTINUATION) return true
+        var characters = 0L
+        for (key in keys) {
+            characters += key.length.toLong()
+            if (characters > MAX_VISITED_KEY_CHARS_PER_CONTINUATION) return true
+        }
+        return false
+    }
+
+    /** Includes the root, bounded historical identity, and every live work item in the frontier. */
+    private fun Continuation.pointerCount(): Int = when (this) {
+        is TypeContinuation -> 1 + visitedPointers.size + frontier.count { work ->
+            when (work) {
+                is PendingTypeNode -> work.pointer != null
+                is PendingTypeExpansion -> true
+            }
+        }
+        is CallContinuation -> 1 + visitedPointers.size + frontier.count { work ->
+            when (work) {
+                is PendingCallNode -> work.pointer != null
+                is PendingCallExpansion -> true
+            }
+        }
+    }
+
+    private fun <T> expired(cursor: String): Result<T> = Result.failure(
+        IllegalArgumentException(
+            "Hierarchy cursor '$cursor' expired, was evicted, or belongs to a different MCP session/project. " +
+                "Run the hierarchy query again without cursor."
+        )
+    )
+
+    @Synchronized
+    private fun <T> expiredLookup(cursor: String): Result<T> {
+        counters.misses++
+        return expired(cursor)
+    }
+
+    private fun <T> staleGeneration(): Result<T> = Result.failure(
+        IllegalStateException(
+            "The MCP server session changed while the hierarchy page was being computed. " +
+                "Run the hierarchy query again without cursor."
+        )
+    )
+
+    companion object {
+        const val DEFAULT_MAX_ENTRIES = 128
+        const val DEFAULT_TTL_MILLIS = 10 * 60 * 1_000L
+        internal const val MAX_POINTERS_PER_CONTINUATION = 8_192
+        internal const val MAX_VISITED_POINTERS_PER_CONTINUATION = MAX_POINTERS_PER_CONTINUATION - 1
+        internal const val MAX_VISITED_KEYS_PER_CONTINUATION = 8_192
+        internal const val MAX_VISITED_KEY_CHARS_PER_CONTINUATION = 256_000
+        // At most the same ten maximum-sized page windows as a flat 5,000-result search.
+        internal const val MAX_SNAPSHOTS_PER_TRAVERSAL =
+            PaginationService.MAX_CACHED_RESULTS_PER_CURSOR / PaginationService.MAX_PAGE_SIZE
+        // Retain at most the equivalent of twenty full contexts, even when 128 small pages fit.
+        internal const val MAX_TOTAL_POINTERS =
+            MAX_POINTERS_PER_CONTINUATION * 1L * PaginationService.MAX_CURSORS
+        internal const val MAX_TOTAL_CHARACTERS =
+            MAX_VISITED_KEY_CHARS_PER_CONTINUATION * 2L * PaginationService.MAX_CURSORS
+
+        private val secureRandom = SecureRandom()
+        private val base64Url = Base64.getUrlEncoder().withoutPadding()
+
+        fun getInstance(): HierarchyContinuationRegistry =
+            ApplicationManager.getApplication().getService(HierarchyContinuationRegistry::class.java)
+
+        private fun newOpaqueCursor(): String {
+            val bytes = ByteArray(18)
+            secureRandom.nextBytes(bytes)
+            return "hier_${base64Url.encodeToString(bytes)}"
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerEpoch.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerEpoch.kt
@@ -1,0 +1,53 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.asContextElement
+
+/**
+ * One lifecycle epoch shared by every server-side handle registry.
+ *
+ * A dispatcher captures the epoch once and installs it in the request coroutine. Registry
+ * mutations are checked under the same monitor as [advanceAndReset], so an old request cannot
+ * insert state after a restart boundary. Capturing a new request is also blocked until every
+ * registry supplied to [advanceAndReset] has been cleared.
+ */
+class McpServerEpoch {
+
+    private val monitor = Any()
+    private var epoch: Long = 0L
+    private val requestEpoch = ThreadLocal<Long?>()
+
+    internal fun capture(): Long = synchronized(monitor) { epoch }
+
+    internal fun requestContext(capturedEpoch: Long = capture()): ThreadContextElement<Long?> =
+        requestEpoch.asContextElement(capturedEpoch)
+
+    internal fun expectedForCurrentRequest(): Long = requestEpoch.get() ?: capture()
+
+    internal fun isCurrent(expectedEpoch: Long): Boolean = synchronized(monitor) {
+        epoch == expectedEpoch
+    }
+
+    /** Runs [action] only while [expectedEpoch] is still the active server epoch. */
+    internal fun <T> ifCurrent(
+        expectedEpoch: Long,
+        stale: () -> T,
+        action: () -> T
+    ): T = synchronized(monitor) {
+        if (epoch == expectedEpoch) action() else stale()
+    }
+
+    /**
+     * Advances the lifecycle boundary and clears all epoch-owned state as one atomic transition.
+     * No dispatcher can capture the new epoch until [reset] has completed.
+     */
+    internal fun advanceAndReset(reset: () -> Unit): Long = synchronized(monitor) {
+        epoch++
+        reset()
+        epoch
+    }
+
+    internal companion object {
+        val shared = McpServerEpoch()
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerService.kt
@@ -48,6 +48,12 @@ class McpServerService(
     private val toolRegistry: ToolRegistry = ToolRegistry()
     private val serverFactory: McpServerFactory
     private val legacySseTransports: LegacySseTransports = LegacySseTransports()
+    private val serverEpoch: McpServerEpoch = McpServerEpoch.shared
+    private val symbolIdRegistry: SymbolIdRegistry = SymbolIdRegistry.getInstance()
+    private val paginationService: PaginationService =
+        ApplicationManager.getApplication().getService(PaginationService::class.java)
+    private val hierarchyContinuationRegistry: HierarchyContinuationRegistry =
+        HierarchyContinuationRegistry.getInstance()
 
     // Written under the instance monitor (startServer/stopServer), read lock-free from
     // status accessors on arbitrary threads — hence @Volatile.
@@ -225,12 +231,19 @@ class McpServerService(
      * Stops the MCP server.
      *
      * Synchronized with [startServer] so a stop can never interleave with a concurrent
-     * restart's stop-then-start sequence.
+     * restart's stop-then-start sequence. All handle registries cross one atomic epoch boundary:
+     * old in-flight requests are rejected, and new requests cannot start until every cache is
+     * clear.
      */
     @Synchronized
     fun stopServer() {
         ktorServer?.stop()
         ktorServer = null
+        serverEpoch.advanceAndReset {
+            symbolIdRegistry.clearForSessionReset()
+            paginationService.clearForSessionReset()
+            hierarchyContinuationRegistry.clearForSessionReset()
+        }
     }
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/PaginationService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/PaginationService.kt
@@ -1,14 +1,21 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.PsiModificationTracker
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ThreadContextElement
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonElement
 import org.jetbrains.annotations.VisibleForTesting
+import java.lang.ref.WeakReference
 import java.time.Duration
 import java.time.Instant
 import java.util.Base64
@@ -17,7 +24,10 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 
 @Service(Service.Level.APP)
-class PaginationService(private val coroutineScope: CoroutineScope) : Disposable {
+class PaginationService @JvmOverloads constructor(
+    private val coroutineScope: CoroutineScope,
+    private val serverEpoch: McpServerEpoch = McpServerEpoch.shared
+) : Disposable {
 
     companion object {
         const val TTL_MINUTES = 10L
@@ -26,6 +36,12 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
         const val SWEEP_INTERVAL_MINUTES = 5L
         const val DEFAULT_OVERCOLLECT = 500
         const val MAX_PAGE_SIZE = 500
+        internal const val UNMATERIALIZED_SYMBOL_ID = "sym_unmaterialized"
+        private const val SESSION_CHANGED_MESSAGE =
+            "Search context invalidated because the MCP server session changed. Please re-search."
+
+        fun getInstance(): PaginationService =
+            ApplicationManager.getApplication().getService(PaginationService::class.java)
     }
 
     class CursorEntry(
@@ -35,14 +51,33 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
         val seenKeys: MutableSet<String>,
         val searchExtender: (suspend (Set<String>, Int) -> List<SerializedResult>)?,
         val psiModCount: Long,
+        val generation: Long,
         val projectBasePath: String,
+        val project: WeakReference<Project>?,
         val createdAt: Instant,
         @Volatile var lastAccessedAt: Instant,
         val metadata: Map<String, String> = emptyMap(),
+        val serializedMetadata: Map<String, SerializedResult> = emptyMap(),
+        var searchExhausted: Boolean = searchExtender == null,
+        var resultLimitReached: Boolean = false,
         val mutex: Mutex = Mutex()
-    )
+    ) {
+        @Volatile var cachedResultCount = results.size
+        @Volatile var cachedPointerCount = results.count { it.symbolPointer != null } +
+            serializedMetadata.values.count { it.symbolPointer != null }
+    }
 
-    data class SerializedResult(val key: String, val data: JsonElement)
+    /**
+     * Cached wire data plus an optional exact PSI target whose symbol handle is materialized only
+     * when this item is actually returned. Pre-binding every over-collected search result can evict
+     * handles that clients are still using before those cached results are ever visible.
+     */
+    data class SerializedResult(
+        val key: String,
+        val data: JsonElement,
+        val symbolPointer: SmartPsiElementPointer<PsiElement>? = null,
+        @Volatile var materializedSymbolId: String? = null
+    )
 
     data class PaginationPage(
         val items: List<JsonElement>,
@@ -52,7 +87,12 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
         val totalCollected: Int,
         val hasMore: Boolean,
         val stale: Boolean,
-        val metadata: Map<String, String> = emptyMap()
+        val metadata: Map<String, String> = emptyMap(),
+        internal val serializedItems: List<SerializedResult> = emptyList(),
+        internal val serializedMetadata: Map<String, SerializedResult> = emptyMap(),
+        internal val entryId: String? = null,
+        internal val generation: Long? = null,
+        internal val psiModCount: Long? = null
     )
 
     sealed interface GetPageResult {
@@ -65,10 +105,14 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
         EXPIRED,
         NOT_FOUND,
         WRONG_PROJECT,
+        WRONG_TOOL,
         SEARCH_INVALIDATED
     }
 
     private val cursors = ConcurrentHashMap<String, CursorEntry>()
+    private val counters = CacheCounters()
+    // The coroutine below already performs periodic sweeping; only add immediate project cleanup.
+    private val maintenance = CacheMaintenance(this, null, ::removeProject)
 
     init {
         coroutineScope.launch {
@@ -78,6 +122,15 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
             }
         }
     }
+
+    internal fun currentGeneration(): Long = serverEpoch.expectedForCurrentRequest()
+
+    /** Compatibility helper for focused registry tests; dispatchers use [McpServerEpoch] directly. */
+    internal fun generationContext(expectedGeneration: Long = serverEpoch.capture()): ThreadContextElement<Long?> =
+        serverEpoch.requestContext(expectedGeneration)
+
+    private fun expectedGenerationForCurrentRequest(): Long =
+        serverEpoch.expectedForCurrentRequest()
 
     data class DecodedCursor(val entryId: String, val offset: Int, val pageSize: Int? = null)
 
@@ -98,7 +151,7 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
             val afterLast = decoded.substring(lastColon + 1).toInt()
 
             val secondLastColon = beforeLast.lastIndexOf(':')
-            if (secondLastColon < 0) {
+            val cursor = if (secondLastColon < 0) {
                 // Legacy format: entryId:offset
                 DecodedCursor(beforeLast, afterLast)
             } else {
@@ -106,6 +159,11 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
                 val entryId = beforeLast.substring(0, secondLastColon)
                 val offset = beforeLast.substring(secondLastColon + 1).toInt()
                 DecodedCursor(entryId, offset, pageSize = afterLast)
+            }
+            cursor.takeIf {
+                it.entryId.isNotBlank() &&
+                    it.offset >= 0 &&
+                    (it.pageSize == null || it.pageSize in 1..MAX_PAGE_SIZE)
             }
         } catch (_: Exception) {
             null
@@ -119,39 +177,174 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
         searchExtender: (suspend (Set<String>, Int) -> List<SerializedResult>)?,
         psiModCount: Long,
         projectBasePath: String,
-        metadata: Map<String, String> = emptyMap()
+        metadata: Map<String, String> = emptyMap(),
+        serializedMetadata: Map<String, SerializedResult> = emptyMap()
+    ): String = createCursorInternal(
+        toolName = toolName,
+        results = results,
+        seenKeys = seenKeys,
+        searchExtender = searchExtender,
+        psiModCount = psiModCount,
+        projectBasePath = projectBasePath,
+        project = null,
+        metadata = metadata,
+        serializedMetadata = serializedMetadata,
+        expectedGeneration = expectedGenerationForCurrentRequest()
+    )
+
+    /** Production overload: cursors belong to one exact open [Project] instance, not its path. */
+    fun createCursor(
+        toolName: String,
+        results: List<SerializedResult>,
+        seenKeys: Set<String>,
+        searchExtender: (suspend (Set<String>, Int) -> List<SerializedResult>)?,
+        psiModCount: Long,
+        project: Project,
+        metadata: Map<String, String> = emptyMap(),
+        serializedMetadata: Map<String, SerializedResult> = emptyMap()
+    ): String {
+        require(!project.isDisposed) { "Cannot create a pagination cursor for a disposed project" }
+        return createCursorInternal(
+            toolName = toolName,
+            results = results,
+            seenKeys = seenKeys,
+            searchExtender = searchExtender,
+            psiModCount = psiModCount,
+            projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+            project = project,
+            metadata = metadata,
+            serializedMetadata = serializedMetadata,
+            expectedGeneration = expectedGenerationForCurrentRequest()
+        )
+    }
+
+    private fun createCursorInternal(
+        toolName: String,
+        results: List<SerializedResult>,
+        seenKeys: Set<String>,
+        searchExtender: (suspend (Set<String>, Int) -> List<SerializedResult>)?,
+        psiModCount: Long,
+        projectBasePath: String,
+        project: Project?,
+        metadata: Map<String, String>,
+        serializedMetadata: Map<String, SerializedResult>,
+        expectedGeneration: Long
     ): String {
         val entryId = UUID.randomUUID().toString().replace("-", "")
         val now = Instant.now()
+        val boundedResults = ArrayList(results.take(MAX_CACHED_RESULTS_PER_CURSOR))
+        val boundedSeenKeys = HashSet(seenKeys).apply {
+            boundedResults.forEach { add(it.key) }
+        }
         val entry = CursorEntry(
             id = entryId,
             toolName = toolName,
-            results = ArrayList(results),
-            seenKeys = HashSet(seenKeys),
+            results = boundedResults,
+            seenKeys = boundedSeenKeys,
             searchExtender = searchExtender,
             psiModCount = psiModCount,
+            generation = expectedGeneration,
             projectBasePath = projectBasePath,
+            project = project?.let(::WeakReference),
             createdAt = now,
             lastAccessedAt = now,
-            metadata = metadata
+            metadata = metadata,
+            serializedMetadata = serializedMetadata,
+            resultLimitReached = results.size > boundedResults.size ||
+                (boundedResults.size == MAX_CACHED_RESULTS_PER_CURSOR && searchExtender != null)
         )
-        // ConcurrentHashMap.size is approximate under contention, so eviction count may be
-        // slightly off. Acceptable at MAX_CURSORS=20 with typical 1-3 concurrent agents.
-        if (cursors.size >= MAX_CURSORS) {
-            val oldest = cursors.entries.minByOrNull { it.value.lastAccessedAt }
-            if (oldest != null) {
-                cursors.remove(oldest.key)
+
+        return serverEpoch.ifCurrent(
+            expectedEpoch = expectedGeneration,
+            stale = { throw IllegalStateException(SESSION_CHANGED_MESSAGE) }
+        ) {
+            synchronized(this) {
+                evictExpiredLocked(now)
+                while (cursors.size >= MAX_CURSORS) {
+                    val oldest = cursors.entries.minWithOrNull(
+                        compareBy<Map.Entry<String, CursorEntry>>(
+                            { it.value.lastAccessedAt },
+                            { it.value.createdAt },
+                            { it.key }
+                        )
+                    ) ?: break
+                    cursors.remove(oldest.key, oldest.value)
+                    counters.removed(CacheEvictionReason.LRU)
+                }
+                cursors[entryId] = entry
+                counters.insertions++
+                encodeCursor(entryId, 0)
             }
         }
-        cursors[entryId] = entry
-        return encodeCursor(entryId, 0)
     }
 
-    suspend fun getPage(
+    /** Legacy path-only overload retained for headless unit tests and old in-process callers. */
+    @VisibleForTesting
+    internal suspend fun getPage(
         cursorToken: String,
         requestedPageSize: Int?,
         projectBasePath: String,
+        currentModCount: Long,
+        expectedToolName: String? = null,
+        currentModCountAfterSuspension: () -> Long = { currentModCount }
+    ): GetPageResult = getPageInternal(
+        cursorToken = cursorToken,
+        requestedPageSize = requestedPageSize,
+        projectBasePath = projectBasePath,
+        project = null,
+        currentModCount = currentModCount,
+        currentModCountAfterSuspension = currentModCountAfterSuspension,
+        expectedToolName = expectedToolName,
+        expectedGeneration = expectedGenerationForCurrentRequest()
+    )
+
+    /** Test-only compatibility overload. Production callers must provide their tool name. */
+    @VisibleForTesting
+    internal suspend fun getPage(
+        cursorToken: String,
+        requestedPageSize: Int?,
+        project: Project,
         currentModCount: Long
+    ): GetPageResult = getPageInternal(
+        cursorToken = cursorToken,
+        requestedPageSize = requestedPageSize,
+        projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+        project = project,
+        currentModCount = currentModCount,
+        currentModCountAfterSuspension = { currentModCount },
+        expectedToolName = null,
+        expectedGeneration = expectedGenerationForCurrentRequest()
+    )
+
+    /** Production overload: validates the exact live project and originating tool. */
+    suspend fun getPage(
+        cursorToken: String,
+        requestedPageSize: Int?,
+        project: Project,
+        currentModCount: Long,
+        expectedToolName: String
+    ): GetPageResult = getPageInternal(
+        cursorToken = cursorToken,
+        requestedPageSize = requestedPageSize,
+        projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+        project = project,
+        currentModCount = currentModCount,
+        currentModCountAfterSuspension = {
+            PsiModificationTracker.getInstance(project).modificationCount
+        },
+        expectedToolName = expectedToolName,
+        expectedGeneration = expectedGenerationForCurrentRequest()
+    )
+
+    private suspend fun getPageInternal(
+        cursorToken: String,
+        requestedPageSize: Int?,
+        projectBasePath: String,
+        project: Project?,
+        currentModCount: Long,
+        currentModCountAfterSuspension: () -> Long,
+        expectedToolName: String?,
+        expectedGeneration: Long
     ): GetPageResult {
         val decoded = decodeCursor(cursorToken)
             ?: return GetPageResult.Error(CursorError.MALFORMED, "Invalid cursor format. Please re-search.")
@@ -159,36 +352,113 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
         val pageSize = requestedPageSize
             ?: decoded.pageSize
             ?: return GetPageResult.Error(CursorError.MALFORMED, "No pageSize provided and cursor does not contain one. Please re-search.")
+        if (pageSize !in 1..MAX_PAGE_SIZE) {
+            return GetPageResult.Error(
+                CursorError.MALFORMED,
+                "pageSize must be between 1 and $MAX_PAGE_SIZE. Please re-search."
+            )
+        }
         val (entryId, offset) = decoded
 
-        val entry = cursors[entryId]
-            ?: return GetPageResult.Error(CursorError.NOT_FOUND, "Cursor not found. Please re-search.")
+        val entryAndError: Pair<CursorEntry?, GetPageResult.Error?> = serverEpoch.ifCurrent(
+            expectedEpoch = expectedGeneration,
+            stale = { null to searchInvalidated() }
+        ) {
+            synchronized(this) {
+                val candidate = cursors[entryId]
+                    ?: return@synchronized null to GetPageResult.Error(
+                        CursorError.NOT_FOUND, "Cursor not found. Please re-search."
+                    )
+                if (candidate.generation != expectedGeneration) {
+                    return@synchronized null to searchInvalidated()
+                }
 
-        if (Duration.between(entry.lastAccessedAt, Instant.now()).toMinutes() >= TTL_MINUTES) {
-            return GetPageResult.Error(CursorError.EXPIRED, "Cursor expired. Please re-search.")
+                val now = Instant.now()
+                if (Duration.between(candidate.lastAccessedAt, now).toMinutes() >= TTL_MINUTES) {
+                    cursors.remove(entryId, candidate)
+                    counters.removed(CacheEvictionReason.TTL)
+                    return@synchronized null to GetPageResult.Error(
+                        CursorError.EXPIRED, "Cursor expired. Please re-search."
+                    )
+                }
+
+                val owner = candidate.project?.get()
+                if (candidate.project != null && (owner == null || owner.isDisposed)) {
+                    cursors.remove(entryId, candidate)
+                    counters.removed(CacheEvictionReason.PROJECT_CLOSED)
+                    return@synchronized null to GetPageResult.Error(
+                        CursorError.NOT_FOUND, "Cursor project was closed. Please re-search."
+                    )
+                }
+                if (candidate.projectBasePath != projectBasePath ||
+                    (project == null && candidate.project != null) ||
+                    (project != null && owner !== project)
+                ) {
+                    return@synchronized null to GetPageResult.Error(
+                        CursorError.WRONG_PROJECT, "Cursor belongs to a different project."
+                    )
+                }
+                if (expectedToolName != null && candidate.toolName != expectedToolName) {
+                    return@synchronized null to GetPageResult.Error(
+                        CursorError.WRONG_TOOL,
+                        "Cursor belongs to tool '${candidate.toolName}', not '$expectedToolName'. Please re-search."
+                    )
+                }
+
+                candidate.lastAccessedAt = now
+                candidate to null
+            }
         }
-
-        if (entry.projectBasePath != projectBasePath) {
-            return GetPageResult.Error(CursorError.WRONG_PROJECT, "Cursor belongs to a different project.")
+        val (entry, lookupError) = entryAndError
+        if (lookupError != null) {
+            synchronized(this) { counters.misses++ }
+            return lookupError
         }
-
-        entry.lastAccessedAt = Instant.now()
+        entry ?: return searchInvalidated()
 
         return entry.mutex.withLock {
+            if (!isEntryCurrent(entry, expectedGeneration)) return@withLock searchInvalidated()
             val stale = entry.psiModCount != currentModCount
+            val requestedEnd = offset.toLong() + pageSize.toLong()
 
             // Extend cache if needed and possible.
             // Use >= so that when we're exactly at the boundary we still probe the extender,
             // allowing an accurate hasMore answer without an extra client round-trip.
-            if (offset + pageSize >= entry.results.size
+            val shouldExtend = requestedEnd >= entry.results.size.toLong()
                 && entry.searchExtender != null
+                && !entry.searchExhausted
                 && entry.results.size < MAX_CACHED_RESULTS_PER_CURSOR
-            ) {
+            if (shouldExtend) {
+                if (stale || !isEntryCurrent(entry, expectedGeneration)) {
+                    return@withLock searchInvalidated()
+                }
                 try {
-                    val newResults = entry.searchExtender!!(entry.seenKeys.toSet(), DEFAULT_OVERCOLLECT)
+                    val remainingCapacity = MAX_CACHED_RESULTS_PER_CURSOR - entry.results.size
+                    val extensionLimit = minOf(DEFAULT_OVERCOLLECT, remainingCapacity + 1)
+                    val newResults = entry.searchExtender!!(entry.seenKeys.toSet(), extensionLimit)
+
+                    val modCountAfterExtension = currentModCountAfterSuspension()
+                    if (modCountAfterExtension != entry.psiModCount ||
+                        !isEntryCurrent(entry, expectedGeneration)
+                    ) {
+                        return@withLock searchInvalidated()
+                    }
+
+                    var foundUnseenResult = false
                     for (result in newResults) {
-                        entry.results.add(result)
-                        entry.seenKeys.add(result.key)
+                        if (!entry.seenKeys.add(result.key)) continue
+                        foundUnseenResult = true
+                        if (entry.results.size < MAX_CACHED_RESULTS_PER_CURSOR) {
+                            entry.results.add(result)
+                            entry.cachedResultCount = entry.results.size
+                            if (result.symbolPointer != null) entry.cachedPointerCount++
+                        } else {
+                            entry.resultLimitReached = true
+                        }
+                    }
+                    if (!foundUnseenResult) entry.searchExhausted = true
+                    if (entry.results.size == MAX_CACHED_RESULTS_PER_CURSOR && !entry.searchExhausted) {
+                        entry.resultLimitReached = true
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -205,57 +475,175 @@ class PaginationService(private val coroutineScope: CoroutineScope) : Disposable
                 }
             }
 
-            val end = minOf(offset + pageSize, entry.results.size)
-            if (offset >= entry.results.size) {
-                return@withLock GetPageResult.Success(
-                    PaginationPage(
-                        items = emptyList(),
-                        nextCursor = null,
-                        offset = offset,
-                        pageSize = 0,
-                        totalCollected = entry.results.size,
-                        hasMore = false,
-                        stale = stale,
-                        metadata = entry.metadata
-                    )
-                )
-            }
-
-            val items = entry.results.subList(offset, end).map { it.data }
-            val actualPageSize = items.size
-            // After extension (if triggered), the cache reflects the true result set.
-            // hasMore is simply whether more items exist beyond this page.
-            val hasMore = end < entry.results.size
-            val nextCursor = if (hasMore && actualPageSize > 0) encodeCursor(entryId, offset + actualPageSize, pageSize) else null
-
-            GetPageResult.Success(
-                PaginationPage(
-                    items = items,
-                    nextCursor = nextCursor,
+            val end = minOf(requestedEnd, entry.results.size.toLong()).toInt()
+            if (offset.toLong() >= entry.results.size.toLong()) {
+                val hasMore = entry.resultLimitReached || !entry.searchExhausted
+                val page = PaginationPage(
+                    items = emptyList(),
+                    nextCursor = null,
                     offset = offset,
-                    pageSize = actualPageSize,
+                    pageSize = 0,
                     totalCollected = entry.results.size,
                     hasMore = hasMore,
                     stale = stale,
-                    metadata = entry.metadata
+                    metadata = entry.metadata,
+                    serializedMetadata = entry.serializedMetadata,
+                    entryId = entry.id,
+                    generation = entry.generation,
+                    psiModCount = entry.psiModCount
                 )
+                return@withLock returnPageIfCurrent(entry, expectedGeneration, page)
+            }
+
+            val serializedItems = entry.results.subList(offset, end).toList()
+            val items = serializedItems.map { it.data }
+            val actualPageSize = serializedItems.size
+            val hasCachedResults = end < entry.results.size
+            val canContinue = hasCachedResults ||
+                (!entry.searchExhausted && entry.results.size < MAX_CACHED_RESULTS_PER_CURSOR)
+            val hasMore = canContinue || entry.resultLimitReached
+            val nextCursor = if (canContinue && actualPageSize > 0) {
+                encodeCursor(entryId, offset + actualPageSize, pageSize)
+            } else {
+                null
+            }
+
+            val page = PaginationPage(
+                items = items,
+                nextCursor = nextCursor,
+                offset = offset,
+                pageSize = actualPageSize,
+                totalCollected = entry.results.size,
+                hasMore = hasMore,
+                stale = stale,
+                metadata = entry.metadata,
+                serializedItems = serializedItems,
+                serializedMetadata = entry.serializedMetadata,
+                entryId = entry.id,
+                generation = entry.generation,
+                psiModCount = entry.psiModCount
             )
+            returnPageIfCurrent(entry, expectedGeneration, page)
         }
     }
 
-    private fun sweepExpired() {
-        val now = Instant.now()
-        cursors.entries.removeIf { (_, entry) ->
-            Duration.between(entry.lastAccessedAt, now).toMinutes() >= TTL_MINUTES
+    /**
+     * Revalidates a page around lazy PSI-backed symbol materialization. A stale serialized page
+     * can still be returned, but creating fresh symbol handles from a mixed PSI snapshot cannot.
+     */
+    internal fun isPageSnapshotCurrent(
+        page: PaginationPage,
+        project: Project,
+        expectedToolName: String,
+        currentModCount: Long,
+        requireUnmodifiedPsi: Boolean
+    ): Boolean {
+        val expectedGeneration = serverEpoch.expectedForCurrentRequest()
+        return serverEpoch.ifCurrent(expectedGeneration, stale = { false }) {
+            synchronized(this) {
+                val pageEntryId = page.entryId ?: return@synchronized false
+                val pageGeneration = page.generation ?: return@synchronized false
+                val entry = cursors[pageEntryId] ?: return@synchronized false
+                pageGeneration == expectedGeneration &&
+                    entry.generation == expectedGeneration &&
+                    entry === cursors[pageEntryId] &&
+                    entry.project?.get() === project &&
+                    entry.toolName == expectedToolName &&
+                    entry.psiModCount == page.psiModCount &&
+                    (!requireUnmodifiedPsi || currentModCount == entry.psiModCount)
+            }
         }
+    }
+
+    private fun returnPageIfCurrent(
+        entry: CursorEntry,
+        expectedGeneration: Long,
+        page: PaginationPage
+    ): GetPageResult = serverEpoch.ifCurrent(expectedGeneration, stale = ::searchInvalidated) {
+        synchronized(this) {
+            if (isEntryCurrentLocked(entry, expectedGeneration)) {
+                counters.hits++
+                GetPageResult.Success(page)
+            } else {
+                searchInvalidated()
+            }
+        }
+    }
+
+    private fun isEntryCurrent(entry: CursorEntry, expectedGeneration: Long): Boolean =
+        serverEpoch.ifCurrent(expectedGeneration, stale = { false }) {
+            synchronized(this) { isEntryCurrentLocked(entry, expectedGeneration) }
+        }
+
+    private fun isEntryCurrentLocked(entry: CursorEntry, expectedGeneration: Long): Boolean {
+        return entry.generation == expectedGeneration && cursors[entry.id] === entry
+    }
+
+    private fun searchInvalidated(): GetPageResult.Error = GetPageResult.Error(
+        CursorError.SEARCH_INVALIDATED,
+        SESSION_CHANGED_MESSAGE
+    )
+
+    private fun sweepExpired() {
+        synchronized(this) {
+            counters.maintenanceScans++
+            evictExpiredLocked(Instant.now())
+        }
+    }
+
+    private fun evictExpiredLocked(now: Instant) {
+        cursors.entries.removeIf { (_, entry) ->
+            val closed =
+                entry.project?.get()?.isDisposed == true ||
+                (entry.project != null && entry.project.get() == null)
+            val expired = Duration.between(entry.lastAccessedAt, now).toMinutes() >= TTL_MINUTES
+            if (closed || expired) {
+                counters.removed(if (closed) CacheEvictionReason.PROJECT_CLOSED else CacheEvictionReason.TTL)
+                true
+            } else false
+        }
+    }
+
+    @Synchronized
+    internal fun removeProject(project: Project) {
+        cursors.entries.removeIf { (_, entry) ->
+            (entry.project?.get() === project).also {
+                if (it) counters.removed(CacheEvictionReason.PROJECT_CLOSED)
+            }
+        }
+    }
+
+    @Synchronized
+    internal fun stats(): CacheStats = counters.snapshot(
+        entries = cursors.size,
+        pointers = cursors.values.sumOf { it.cachedPointerCount.toLong() },
+        results = cursors.values.sumOf { it.cachedResultCount.toLong() }
+    )
+
+    /** Advances the shared MCP epoch and drops ordinary-search cursors from the old session. */
+    fun resetSession() {
+        serverEpoch.advanceAndReset(::clearForSessionReset)
+    }
+
+    @Synchronized
+    internal fun clearForSessionReset() {
+        counters.removed(CacheEvictionReason.SESSION_RESET, cursors.size)
+        cursors.clear()
     }
 
     @VisibleForTesting
+    @Synchronized
     internal fun expireEntryForTesting(entryId: String) {
         cursors[entryId]?.lastAccessedAt = Instant.MIN
     }
 
+    @VisibleForTesting
+    @Synchronized
+    internal fun sizeForTesting(): Int = cursors.size
+
     override fun dispose() {
-        cursors.clear()
+        maintenance.dispose()
+        resetSession()
     }
+
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/SymbolIdRegistry.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/SymbolIdRegistry.kt
@@ -1,0 +1,350 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import kotlinx.coroutines.ThreadContextElement
+import java.lang.ref.WeakReference
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.LinkedHashMap
+
+/**
+ * In-memory symbol handle storage owned by the running MCP server.
+ *
+ * A handle stores only an IntelliJ [SmartPsiElementPointer], never coordinates or a fallback
+ * query. That distinction is deliberate: if IntelliJ cannot restore the exact PSI declaration,
+ * resolving the handle fails with `SYMBOL_ID_EXPIRED` instead of selecting a nearby element.
+ *
+ * The cache is bounded by both an inactivity TTL and access-order LRU. The shared server epoch is
+ * advanced and this cache is cleared whenever the embedded MCP server starts or stops, so IDs
+ * never survive a restart. Each entry also keeps the identity (not merely the path) of its
+ * [Project], preventing an ID created for a closed project from resolving in a newly opened
+ * project at the same path.
+ */
+@Service(Service.Level.APP)
+class SymbolIdRegistry @JvmOverloads constructor(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val ttlMillis: Long = DEFAULT_TTL_MILLIS,
+    private val clock: () -> Long = { System.nanoTime() / 1_000_000L },
+    private val idGenerator: () -> String = Companion::newOpaqueId,
+    private val serverEpoch: McpServerEpoch = McpServerEpoch.shared
+) : Disposable {
+
+    private data class Entry(
+        val project: WeakReference<Project>,
+        var pointer: SmartPsiElementPointer<PsiElement>,
+        val generation: Long,
+        var lastAccessMillis: Long
+    )
+
+    // Insertion order plus explicit promotion gives O(1) non-promoting ownership lookup.
+    // It also keeps last-access times ordered for amortized prefix expiry.
+    private val entries = LinkedHashMap<String, Entry>()
+    private val counters = CacheCounters()
+
+    init {
+        require(maxEntries > 0) { "maxEntries must be positive" }
+        require(ttlMillis > 0) { "ttlMillis must be positive" }
+    }
+
+    private val maintenance = CacheMaintenance(this, ::sweepExpired, ::removeProject)
+
+    internal val responseHandleBudget: Int
+        get() = minOf(maxEntries, PaginationService.MAX_PAGE_SIZE)
+
+    /** Advances the shared MCP epoch and drops every symbol handle from the old session. */
+    fun resetSession() {
+        serverEpoch.advanceAndReset(::clearForSessionReset)
+    }
+
+    @Synchronized
+    internal fun clearForSessionReset() {
+        counters.removed(CacheEvictionReason.SESSION_RESET, entries.size)
+        entries.clear()
+    }
+
+    /**
+     * Registers [element] and returns an opaque handle.
+     *
+     * [preferredId] is used after a refactoring. If that handle is still owned by [project], its
+     * pointer is rebound and the same ID is returned; if it was concurrently evicted, a new ID is
+     * issued, which is the wire contract promised to callers.
+     */
+    @RequiresReadLock
+    fun bind(project: Project, element: PsiElement, preferredId: String? = null): String {
+        val pointer = SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)
+        return bind(
+            project,
+            serverEpoch.expectedForCurrentRequest(),
+            pointer,
+            preferredId
+        ).getOrThrow()
+    }
+
+    /**
+     * Registers a symbol only if the request still belongs to [expectedGeneration]. Long-running
+     * navigation work captures the generation before its read action; this prevents it from
+     * publishing a handle after a server stop/start reset.
+     */
+    @RequiresReadLock
+    internal fun bind(
+        project: Project,
+        expectedGeneration: Long,
+        element: PsiElement,
+        preferredId: String? = null
+    ): Result<String> {
+        val pointer = SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)
+        return bind(project, expectedGeneration, pointer, preferredId)
+    }
+
+    internal fun currentGeneration(): Long = serverEpoch.expectedForCurrentRequest()
+
+    /** Compatibility helper for focused registry tests; dispatchers use [McpServerEpoch] directly. */
+    internal fun generationContext(): ThreadContextElement<Long?> =
+        serverEpoch.requestContext(serverEpoch.capture())
+
+    internal fun isCurrentGeneration(expectedGeneration: Long): Boolean =
+        serverEpoch.isCurrent(expectedGeneration)
+
+    private fun bind(
+        project: Project,
+        expectedGeneration: Long,
+        pointer: SmartPsiElementPointer<PsiElement>,
+        preferredId: String?
+    ): Result<String> = serverEpoch.ifCurrent(
+        expectedEpoch = expectedGeneration,
+        stale = ::staleGeneration
+    ) {
+        synchronized(this) {
+            require(!project.isDisposed) { "Cannot bind a symbol from a disposed project" }
+            require(pointer.element?.isValid == true) { "Cannot bind an invalid PSI element" }
+
+            val now = clock()
+            evictExpiredPrefix(now)
+
+            if (preferredId != null) {
+                val existing = entries[preferredId]
+                if (existing?.project?.get() === project && existing.generation == expectedGeneration) {
+                    existing.pointer = pointer
+                    promote(preferredId, existing, now)
+                    return@synchronized Result.success(preferredId)
+                }
+            }
+
+            var symbolId: String
+            do {
+                symbolId = idGenerator()
+            } while (entries.containsKey(symbolId))
+
+            entries[symbolId] = Entry(WeakReference(project), pointer, expectedGeneration, now)
+            counters.insertions++
+            evictLruOverflow()
+            Result.success(symbolId)
+        }
+    }
+
+    /**
+     * Resolves [symbolId] to the exact stored PSI element.
+     *
+     * Must run under a read lock because dereferencing a smart pointer accesses PSI. No location,
+     * name, or nearest-element fallback is attempted when the pointer no longer resolves.
+     */
+    @RequiresReadLock
+    fun resolve(project: Project, symbolId: String): Result<PsiElement> {
+        val expectedGeneration = serverEpoch.expectedForCurrentRequest()
+        val resolved = serverEpoch.ifCurrent(expectedGeneration, stale = { null }) {
+            synchronized(this) {
+                val now = clock()
+                evictExpiredPrefix(now)
+                val candidate = entries[symbolId] ?: return@synchronized null
+                val owner = candidate.project.get()
+                if (owner == null || owner.isDisposed) {
+                    remove(symbolId, CacheEvictionReason.PROJECT_CLOSED)
+                    return@synchronized null
+                }
+                // A caller supplying the wrong project must not be able to destroy an otherwise
+                // valid handle owned by another open project instance.
+                if (owner !== project || project.isDisposed || candidate.generation != expectedGeneration) {
+                    return@synchronized null
+                }
+                promote(symbolId, candidate, now)
+                candidate to candidate.pointer
+            }
+        } ?: return expiredLookup(symbolId)
+        val (entry, pointer) = resolved
+
+        val element = runCatching { pointer.element }.getOrNull()
+        if (element == null || !element.isValid) {
+            synchronized(this) {
+                if (entries[symbolId] === entry && entry.pointer === pointer) {
+                    remove(symbolId, CacheEvictionReason.INVALIDATED)
+                }
+            }
+            return expiredLookup(symbolId)
+        }
+
+        // resetSession(), invalidate(), or a post-refactoring rebind may have raced with pointer
+        // dereferencing. Never let a handle from an older MCP generation resolve after reset.
+        val stillCurrent = serverEpoch.ifCurrent(expectedGeneration, stale = { false }) {
+            synchronized(this) {
+                entries[symbolId] === entry && entry.pointer === pointer && entry.project.get() === project &&
+                    entry.generation == expectedGeneration
+            }
+        }
+        if (!stillCurrent) return expiredLookup(symbolId)
+        synchronized(this) { counters.hits++ }
+        return Result.success(element)
+    }
+
+    /**
+     * Returns the exact live project instance owning [symbolId]. This lets the dispatcher route a
+     * symbol-ID-only call even when several projects are open, without exposing a project path in
+     * the opaque token.
+     */
+    fun projectFor(symbolId: String): Result<Project> {
+        val expectedGeneration = serverEpoch.expectedForCurrentRequest()
+        return serverEpoch.ifCurrent(expectedGeneration, stale = { expiredLookup(symbolId) }) {
+            synchronized(this) {
+                val now = clock()
+                evictExpiredPrefix(now)
+                val entry = entries[symbolId] ?: return@synchronized expiredLookup(symbolId)
+                val project = entry.project.get()
+                if (project == null || project.isDisposed) {
+                    remove(symbolId, CacheEvictionReason.PROJECT_CLOSED)
+                    return@synchronized expiredLookup(symbolId)
+                }
+                if (entry.generation != expectedGeneration) return@synchronized expiredLookup(symbolId)
+                promote(symbolId, entry, now)
+                counters.hits++
+                Result.success(project)
+            }
+        }
+    }
+
+    /** Explicitly invalidates a handle after deleting its declaration. */
+    fun invalidate(symbolId: String) {
+        val expectedGeneration = serverEpoch.expectedForCurrentRequest()
+        serverEpoch.ifCurrent(expectedGeneration, stale = {}) {
+            synchronized(this) {
+                if (entries[symbolId]?.generation == expectedGeneration) {
+                    remove(symbolId, CacheEvictionReason.INVALIDATED)
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    internal fun sizeForTest(): Int {
+        evictExpiredPrefix(clock())
+        return entries.size
+    }
+
+    override fun dispose() {
+        maintenance.dispose()
+        resetSession()
+    }
+
+    @Synchronized
+    internal fun stats(): CacheStats = counters.snapshot(entries.size, entries.size.toLong())
+
+    @Synchronized
+    internal fun removeProject(project: Project) {
+        val iterator = entries.entries.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().value.project.get() === project) {
+                iterator.remove()
+                counters.removed(CacheEvictionReason.PROJECT_CLOSED)
+            }
+        }
+    }
+
+    @Synchronized
+    internal fun sweepExpired() {
+        counters.maintenanceScans++
+        val now = clock()
+        val iterator = entries.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next().value
+            val reason = expiryReason(entry, now)
+            if (reason != null) {
+                iterator.remove()
+                counters.removed(reason)
+            }
+        }
+    }
+
+    private fun evictExpiredPrefix(now: Long) {
+        val iterator = entries.entries.iterator()
+        while (iterator.hasNext()) {
+            val reason = expiryReason(iterator.next().value, now) ?: break
+            iterator.remove()
+            counters.removed(reason)
+        }
+    }
+
+    private fun expiryReason(entry: Entry, now: Long): CacheEvictionReason? = when {
+        entry.project.get()?.isDisposed != false -> CacheEvictionReason.PROJECT_CLOSED
+        now - entry.lastAccessMillis >= ttlMillis -> CacheEvictionReason.TTL
+        else -> null
+    }
+
+    private fun promote(symbolId: String, entry: Entry, now: Long) {
+        entries.remove(symbolId)
+        entry.lastAccessMillis = now
+        entries[symbolId] = entry
+    }
+
+    private fun remove(symbolId: String, reason: CacheEvictionReason) {
+        if (entries.remove(symbolId) != null) counters.removed(reason)
+    }
+
+    private fun evictLruOverflow() {
+        while (entries.size > maxEntries) {
+            val iterator = entries.entries.iterator()
+            if (!iterator.hasNext()) return
+            iterator.next()
+            iterator.remove()
+            counters.removed(CacheEvictionReason.LRU)
+        }
+    }
+
+    private fun <T> expired(symbolId: String): Result<T> =
+        Result.failure(IllegalArgumentException(ErrorMessages.symbolIdExpired(symbolId)))
+
+    @Synchronized
+    private fun <T> expiredLookup(symbolId: String): Result<T> {
+        counters.misses++
+        return expired(symbolId)
+    }
+
+    private fun <T> staleGeneration(): Result<T> = Result.failure(
+        IllegalStateException(
+            "The MCP server session changed while the symbol handle was being resolved. " +
+                "Rediscover the symbol and retry the operation."
+        )
+    )
+
+    companion object {
+        const val DEFAULT_MAX_ENTRIES = 4_096
+        const val DEFAULT_TTL_MILLIS = 60 * 60 * 1_000L
+
+        private val secureRandom = SecureRandom()
+        private val base64Url = Base64.getUrlEncoder().withoutPadding()
+
+        fun getInstance(): SymbolIdRegistry =
+            ApplicationManager.getApplication().getService(SymbolIdRegistry::class.java)
+
+        private fun newOpaqueId(): String {
+            val bytes = ByteArray(18)
+            secureRandom.nextBytes(bytes)
+            return "sym_${base64Url.encodeToString(bytes)}"
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/mcp/McpToolDispatcher.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/mcp/McpToolDispatcher.kt
@@ -7,9 +7,12 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandEntry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandHistoryService
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.history.CommandStatus
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.EdtHeartbeatService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerEpoch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.UnifiedTargetArguments
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.asContextElement
@@ -54,7 +57,9 @@ class McpToolDispatcher @JvmOverloads constructor(
     },
     private val updateHistory: (Project, String, CommandStatus, String?, Long?) -> Unit = { project, id, status, result, duration ->
         CommandHistoryService.getInstance(project).updateCommandStatus(id, status, result, duration)
-    }
+    },
+    private val symbolIdRegistryProvider: () -> SymbolIdRegistry = SymbolIdRegistry::getInstance,
+    private val serverEpochProvider: () -> McpServerEpoch = { McpServerEpoch.shared }
 ) {
 
     private companion object {
@@ -65,6 +70,8 @@ class McpToolDispatcher @JvmOverloads constructor(
          * 100 KB+, and every entry would otherwise sit in the per-project deque.
          */
         const val HISTORY_RESULT_LIMIT = 4096
+        const val SESSION_CHANGED_MESSAGE =
+            "The MCP server session changed while the tool call was running. Rediscover the target and retry."
 
         private fun defaultEdtCheck(): Long? {
             val app = ApplicationManager.getApplication() ?: return null
@@ -82,6 +89,22 @@ class McpToolDispatcher @JvmOverloads constructor(
      * propagates.
      */
     suspend fun call(toolName: String, arguments: JsonObject): CallToolResult {
+        val serverEpoch = serverEpochProvider()
+        val requestEpoch = serverEpoch.capture()
+        return withContext(serverEpoch.requestContext(requestEpoch)) {
+            callInEpoch(toolName, arguments, serverEpoch, requestEpoch)
+        }
+    }
+
+    /** Executes every request phase against the one epoch captured by [call]. */
+    private suspend fun callInEpoch(
+        toolName: String,
+        arguments: JsonObject,
+        serverEpoch: McpServerEpoch,
+        requestEpoch: Long
+    ): CallToolResult {
+        val symbolIdRegistry = symbolIdRegistryProvider()
+
         val tool = toolRegistry.getTool(toolName)
             ?: return CallToolResult.error(ErrorMessages.toolNotFound(toolName))
 
@@ -108,16 +131,45 @@ class McpToolDispatcher @JvmOverloads constructor(
         }
         val projectPath = (projectPathElement as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull
 
-        val projectResult = ProjectResolver.resolveOrOpen(projectPath)
-        if (projectResult.isError) return projectResult.errorResult!!
-        val project = projectResult.project!!
+        // Continuation cursors already identify their cached operation. Target selectors are
+        // search inputs, so they must not influence project routing for the next page.
+        val hasPaginationCursor = hasValidPaginationCursor(arguments)
+        val executionArguments = if (hasPaginationCursor) {
+            UnifiedTargetArguments.withoutTargetSelectors(arguments)
+        } else {
+            arguments
+        }
+        val symbolId = if (hasPaginationCursor) {
+            null
+        } else {
+            UnifiedTargetArguments.symbolIdForRouting(arguments).getOrElse {
+                return CallToolResult.error(it.message ?: "Invalid symbolId target")
+            }
+        }
 
-        val commandEntry = CommandEntry(toolName = toolName, parameters = arguments)
+        val project = if (projectPath == null && symbolId != null) {
+            symbolIdRegistry.projectFor(symbolId).getOrElse {
+                return CallToolResult.error(it.message ?: ErrorMessages.symbolIdExpired(symbolId))
+            }
+        } else {
+            val projectResult = ProjectResolver.resolveOrOpen(projectPath)
+            if (projectResult.isError) return projectResult.errorResult!!
+            projectResult.project!!
+        }
+
+        val commandEntry = CommandEntry(toolName = toolName, parameters = executionArguments)
         recordHistorySafely(project, commandEntry)
 
         val startTime = System.currentTimeMillis()
         return try {
-            val result = withIdeModality { tool.execute(project, arguments) }
+            val result = withIdeModality {
+                tool.execute(project, executionArguments)
+            }
+            // A registry operation completed just before the boundary may have produced a valid
+            // old-epoch handle. Never publish that now-invalid result after restart.
+            if (!serverEpoch.isCurrent(requestEpoch)) {
+                return failed(project, commandEntry, startTime, SESSION_CHANGED_MESSAGE)
+            }
             updateHistorySafely(
                 project = project,
                 commandEntry = commandEntry,
@@ -165,6 +217,12 @@ class McpToolDispatcher @JvmOverloads constructor(
             null -> null
             else -> "[${block::class.simpleName}]"
         }
+
+    private fun hasValidPaginationCursor(arguments: JsonObject): Boolean =
+        (arguments[ParamNames.CURSOR] as? JsonPrimitive)
+            ?.takeIf { it.isString }
+            ?.contentOrNull
+            ?.isNotBlank() == true
 
     private suspend fun <T> withIdeModality(block: suspend () -> T): T {
         // Null in plain unit tests that never boot the platform.

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/LocalOriginGuard.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/LocalOriginGuard.kt
@@ -3,7 +3,6 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.server.transport
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
@@ -40,8 +39,9 @@ internal val LOOPBACK_HOSTS = setOf("127.0.0.1", "localhost", "::1")
 
 private val PORT_SUFFIX = Regex(":\\d{1,5}")
 
-private val PREFLIGHT_METHODS = listOf(HttpMethod.Get, HttpMethod.Post, HttpMethod.Delete, HttpMethod.Options)
-    .joinToString(", ") { it.value }
+private const val GET_METHOD = "GET"
+private const val OPTIONS_METHOD = "OPTIONS"
+private const val PREFLIGHT_METHODS = "GET, POST, DELETE, OPTIONS"
 
 private val PREFLIGHT_HEADERS = listOf(
     HttpHeaders.ContentType,
@@ -115,7 +115,7 @@ internal fun Application.installMcpOriginGuard(
 
         val origin = context.request.headers[HttpHeaders.Origin]
 
-        if (context.request.httpMethod == HttpMethod.Options) {
+        if (context.request.httpMethod.value == OPTIONS_METHOD) {
             if (origin == null || !isLoopbackOrigin(origin)) {
                 context.respondText("Origin not allowed", status = HttpStatusCode.Forbidden)
             } else {
@@ -151,7 +151,7 @@ private fun ApplicationCall.reflectOrigin(origin: String) {
 }
 
 private suspend fun ApplicationCall.rejectForbidden(message: String) {
-    if (request.httpMethod == HttpMethod.Get) {
+    if (request.httpMethod.value == GET_METHOD) {
         respondText(message, status = HttpStatusCode.Forbidden)
     } else {
         respondText(

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/settings/McpSettingsConfigurable.kt
@@ -31,7 +31,9 @@ import org.jetbrains.annotations.VisibleForTesting
 import java.awt.FlowLayout
 import java.awt.event.FocusAdapter
 import java.awt.event.FocusEvent
+import java.net.IDN
 import java.net.InetAddress
+import java.net.Inet6Address
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.util.function.Supplier
@@ -606,6 +608,7 @@ class McpSettingsConfigurable : Configurable {
 
     companion object {
         private val IPV4_PATTERN = Regex("^[0-9.]+\$")
+        private val HOSTNAME_LABEL_PATTERN = Regex("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\$")
 
         @VisibleForTesting
         fun isValidIpv4(host: String): Boolean {
@@ -627,7 +630,23 @@ class McpSettingsConfigurable : Configurable {
                 return isValidIpv4(trimmedHost)
             }
 
-            // Fallback for hostnames
+            // InetAddress delegates to the system resolver, which may be configured with a
+            // wildcard DNS suffix and report even syntactically invalid input as resolvable.
+            // Validate IPv6/hostname syntax first so resolution cannot turn values containing
+            // underscores or URI punctuation into accepted bind addresses.
+            if (trimmedHost.contains(':')) {
+                return runCatching { InetAddress.getByName(trimmedHost) is Inet6Address }
+                    .getOrDefault(false)
+            }
+            val asciiHost = runCatching { IDN.toASCII(trimmedHost.removeSuffix(".")) }
+                .getOrNull()
+                ?: return false
+            if (asciiHost.isEmpty() || asciiHost.length > 253 ||
+                asciiHost.split('.').any { !HOSTNAME_LABEL_PATTERN.matches(it) }
+            ) {
+                return false
+            }
+
             return runCatching { InetAddress.getByName(trimmedHost) }.isSuccess
         }
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/AbstractMcpTool.kt
@@ -6,9 +6,10 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.toArgumentFailur
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.exceptions.IndexNotReadyException
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.OptimizedSymbolSearch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.PathGlobMatcher
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
@@ -17,7 +18,9 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ClassResolver
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiSourcePosition
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ResponseFormatter
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ResolvedSymbolInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.ModalityState
@@ -26,6 +29,7 @@ import com.intellij.openapi.application.asContextElement
 import com.intellij.openapi.application.readAction as platformReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
@@ -38,7 +42,9 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.usageView.UsageViewUtil
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -90,12 +96,12 @@ import kotlinx.serialization.json.put
  *
  * ## PSI Synchronization
  *
- * By default, all tools automatically synchronize PSI with document changes before
- * execution. This ensures that recently created or modified files (e.g., by external
- * tools like Claude Code's write tool) are visible to PSI-based searches.
+ * Tools whose [requiresPsiSync] flag is enabled can synchronize PSI with document changes before
+ * execution. When the user opts in, this ensures that recently created or modified files (e.g.,
+ * by external tools like Claude Code's write tool) are visible to PSI-based searches.
  *
  * This behavior is controlled by:
- * - **User setting**: "Sync external file changes" in Settings (enabled by default)
+ * - **User setting**: "Sync external file changes" in Settings (disabled by default)
  * - **Per-tool opt-out**: Override [requiresPsiSync] to `false` for tools that don't use PSI
  *
  * ```kotlin
@@ -144,6 +150,9 @@ abstract class AbstractMcpTool : McpTool {
      * triggering enrollment as a side effect of being called.
      */
     protected open val participatesInLifecycle: Boolean = true
+
+    /** Whether this tool accepts the additive nested `target` selector contract. */
+    protected open val supportsUnifiedTarget: Boolean = false
 
     /**
      * Human-readable list of languages that currently support language+symbol lookup.
@@ -244,12 +253,20 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
             }
         }
 
+        val normalizedArguments = if (supportsUnifiedTarget) {
+            UnifiedTargetArguments.normalize(arguments).getOrElse {
+                return createErrorResult(it.message ?: "Invalid target")
+            }
+        } else {
+            arguments
+        }
+
         val settings = McpSettings.getInstance()
-        if (needsPsiSync(arguments) && settings.syncExternalChanges) {
+        if (needsPsiSync(normalizedArguments) && settings.syncExternalChanges) {
             ensurePsiUpToDate(project)
         }
         return try {
-            doExecute(project, arguments)
+            doExecute(project, normalizedArguments)
         } catch (e: com.intellij.openapi.project.IndexNotReadyException) {
             // The IDE entered dumb mode (reindexing) during this call.
             createErrorResult(
@@ -525,6 +542,7 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
         MISSING,
         POSITION,
         SYMBOL,
+        SYMBOL_ID,
         CONFLICT
     }
 
@@ -556,6 +574,7 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
      * client/schema placeholder and must not conflict with a complete position lookup.
      */
     protected fun resolveLookupMode(arguments: JsonObject): LookupModeState {
+        val hasSymbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID) != null
         val hasLanguage = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
         val hasSymbol = optionalStringArg(arguments, ParamNames.SYMBOL) != null
         val hasAnySymbol = hasLanguage || hasSymbol
@@ -567,6 +586,8 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
         val hasCompletePosition = hasFile && hasLine && hasColumn
 
         return when {
+            hasSymbolId && (hasAnySymbol || hasAnyPosition) -> LookupModeState.CONFLICT
+            hasSymbolId -> LookupModeState.SYMBOL_ID
             hasCompleteSymbol && hasAnyPosition -> LookupModeState.CONFLICT
             hasCompletePosition -> LookupModeState.POSITION
             hasAnySymbol -> LookupModeState.SYMBOL
@@ -685,6 +706,7 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
         arguments: JsonObject,
         allowLibraryFilesForPosition: Boolean = false
     ): Result<PsiElement> {
+        val symbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
         val language = optionalStringArg(arguments, ParamNames.LANGUAGE)
         val symbol = optionalStringArg(arguments, ParamNames.SYMBOL)
         val file = optionalStringArg(arguments, ParamNames.FILE)
@@ -692,7 +714,13 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
         val column = arguments[ParamNames.COLUMN]?.jsonPrimitive?.int
 
         return when (resolveLookupMode(arguments)) {
-            LookupModeState.CONFLICT -> ErrorMessages.SYMBOL_AND_POSITION_EXCLUSIVE.toArgumentFailure()
+            LookupModeState.CONFLICT -> {
+                if (symbolId != null) ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE.toArgumentFailure()
+                else ErrorMessages.SYMBOL_AND_POSITION_EXCLUSIVE.toArgumentFailure()
+            }
+
+            LookupModeState.SYMBOL_ID ->
+                SymbolIdRegistry.getInstance().resolve(project, symbolId!!)
 
             LookupModeState.SYMBOL -> {
                 if (language == null) return ErrorMessages.missingParamForSymbol(ParamNames.LANGUAGE).toArgumentFailure()
@@ -723,6 +751,48 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
 
             LookupModeState.MISSING -> ErrorMessages.SYMBOL_OR_POSITION_REQUIRED.toArgumentFailure()
         }
+    }
+
+    /** True when this call identifies its target exclusively through an opaque symbol handle. */
+    protected fun isSymbolIdLookup(arguments: JsonObject): Boolean =
+        resolveLookupMode(arguments) == LookupModeState.SYMBOL_ID
+
+    /**
+     * Binds the declaration's source/navigation PSI to an opaque server-side handle.
+     * Passing [preferredId] after a refactoring preserves the caller's ID whenever its cache
+     * entry is still live; otherwise the registry issues a replacement.
+     */
+    @RequiresReadLock
+    protected fun bindSymbolId(
+        project: Project,
+        element: PsiElement,
+        preferredId: String? = null
+    ): String {
+        val navigationTarget = PsiUtils.resolveNavigationTarget(element)
+        return SymbolIdRegistry.getInstance().bind(project, navigationTarget, preferredId)
+    }
+
+    /** Builds the common post-resolution/refactoring metadata returned to MCP clients. */
+    @RequiresReadLock
+    protected fun resolvedSymbolInfo(
+        project: Project,
+        element: PsiElement,
+        preferredId: String? = null
+    ): ResolvedSymbolInfo {
+        val target = PsiUtils.resolveNavigationTarget(element)
+        val position = PsiSourcePosition.position(project, target)
+        val qualifiedName = PsiUtils.qualifiedName(target)
+        return ResolvedSymbolInfo(
+            symbolId = bindSymbolId(project, target, preferredId),
+            name = (target as? PsiNamedElement)?.name,
+            kind = UsageViewUtil.getType(target).takeIf { it.isNotBlank() },
+            container = qualifiedName ?: PsiUtils.getAstPath(target).joinToString(".").ifEmpty { null },
+            file = target.containingFile?.virtualFile?.let { getRelativePath(project, it) },
+            line = position?.line,
+            column = position?.column,
+            qualifiedName = qualifiedName,
+            language = OptimizedSymbolSearch.getLanguageName(target)
+        )
     }
 
     /**
@@ -790,16 +860,128 @@ withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) { act
 
     /**
      * Gets a page from the pagination cache.
-     * Extracts project basePath and PSI mod count, delegates to PaginationService.
+     * Delegates to PaginationService with exact project identity and materializes cached symbol
+     * handles only for the items in the page that is about to be returned.
      * Returns GetPageResult — caller maps Success/Error into tool-specific CallToolResult.
      *
      * @param pageSize Explicit pageSize from request, or null to use the cursor-embedded value.
      */
     protected suspend fun getPageFromCache(cursorToken: String, pageSize: Int?, project: Project): PaginationService.GetPageResult {
         val service = ApplicationManager.getApplication().getService(PaginationService::class.java)
-        val basePath = ProjectResolver.normalizePath(project.basePath ?: "")
-        val modCount = PsiModificationTracker.getInstance(project).modificationCount
-        return service.getPage(cursorToken, pageSize, basePath, modCount)
+        val modificationTracker = PsiModificationTracker.getInstance(project)
+        val modCount = modificationTracker.modificationCount
+        val pageResult = service.getPage(cursorToken, pageSize, project, modCount, expectedToolName = name)
+        if (pageResult !is PaginationService.GetPageResult.Success) return pageResult
+
+        val page = pageResult.page
+        val hasSerializedPayload = page.serializedItems.isNotEmpty() || page.serializedMetadata.isNotEmpty()
+        val requiresUnmodifiedPsi = page.serializedItems.any { it.symbolPointer != null } ||
+            page.serializedMetadata.values.any { it.symbolPointer != null }
+        if (!service.isPageSnapshotCurrent(
+                page = page,
+                project = project,
+                expectedToolName = name,
+                currentModCount = modificationTracker.modificationCount,
+                requireUnmodifiedPsi = requiresUnmodifiedPsi
+            )
+        ) {
+            return invalidatedCachedPage()
+        }
+
+        if (!hasSerializedPayload) return pageResult
+
+        val materialized = suspendingReadAction {
+            val beforeModCount = modificationTracker.modificationCount
+            if (!service.isPageSnapshotCurrent(
+                    page = page,
+                    project = project,
+                    expectedToolName = name,
+                    currentModCount = beforeModCount,
+                    requireUnmodifiedPsi = requiresUnmodifiedPsi
+                )
+            ) {
+                return@suspendingReadAction invalidatedCachedPage()
+            }
+
+            val result = materializeCachedSymbolHandles(project, pageResult)
+            val afterModCount = modificationTracker.modificationCount
+            if (beforeModCount != afterModCount ||
+                !service.isPageSnapshotCurrent(
+                    page = page,
+                    project = project,
+                    expectedToolName = name,
+                    currentModCount = afterModCount,
+                    requireUnmodifiedPsi = requiresUnmodifiedPsi
+                )
+            ) {
+                invalidatedCachedPage()
+            } else {
+                result
+            }
+        }
+
+        if (materialized !is PaginationService.GetPageResult.Success) return materialized
+        return if (service.isPageSnapshotCurrent(
+                page = page,
+                project = project,
+                expectedToolName = name,
+                currentModCount = modificationTracker.modificationCount,
+                requireUnmodifiedPsi = requiresUnmodifiedPsi
+            )
+        ) {
+            materialized
+        } else {
+            invalidatedCachedPage()
+        }
+    }
+
+    private fun invalidatedCachedPage(): PaginationService.GetPageResult.Error =
+        PaginationService.GetPageResult.Error(
+            PaginationService.CursorError.SEARCH_INVALIDATED,
+            "Cached symbol context expired or changed. Please re-search."
+        )
+
+    /**
+     * A cached smart pointer outlives the short-lived symbol handle that was last returned for it.
+     * Rebind the exact pointer on demand, preferring the previous handle while it is still valid.
+     */
+    private fun materializeCachedSymbolHandles(
+        project: Project,
+        result: PaginationService.GetPageResult.Success
+    ): PaginationService.GetPageResult {
+        return try {
+            fun materialize(serialized: PaginationService.SerializedResult): JsonElement {
+                val pointer = serialized.symbolPointer ?: return serialized.data
+                val symbolId = synchronized(serialized) {
+                    val element = pointer.element
+                        ?: throw IllegalStateException("A cached symbol no longer resolves")
+                    bindSymbolId(project, element, serialized.materializedSymbolId).also {
+                        serialized.materializedSymbolId = it
+                    }
+                }
+                val objectData = serialized.data as? JsonObject
+                    ?: throw IllegalStateException("Cached symbol data is not a JSON object")
+                return JsonObject(objectData + (ParamNames.SYMBOL_ID to JsonPrimitive(symbolId)))
+            }
+
+            val page = result.page
+            val materializedMetadata = page.metadata + page.serializedMetadata.mapValues { (_, value) ->
+                materialize(value).toString()
+            }
+            PaginationService.GetPageResult.Success(
+                page.copy(
+                    items = page.serializedItems.map(::materialize),
+                    metadata = materializedMetadata
+                )
+            )
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (_: Exception) {
+            PaginationService.GetPageResult.Error(
+                PaginationService.CursorError.SEARCH_INVALIDATED,
+                "Cached symbol context expired or changed. Please re-search."
+            )
+        }
     }
 
     /**

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/UnifiedTargetArguments.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/UnifiedTargetArguments.kt
@@ -1,0 +1,201 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+
+/**
+ * Parses the additive nested `target` contract and translates it to the legacy flat arguments
+ * consumed by existing tools. Keeping normalization in one place makes the runtime validation
+ * identical for navigation and refactoring tools while preserving every old request shape.
+ */
+internal object UnifiedTargetArguments {
+    const val TARGET = "target"
+    const val POSITION = "position"
+    const val QUALIFIED_NAME = "qualifiedName"
+    const val NORMALIZED_VARIANT = "__unifiedTargetVariant"
+
+    private val legacySelectorNames = listOf(
+        ParamNames.SYMBOL_ID,
+        ParamNames.FILE,
+        ParamNames.LINE,
+        ParamNames.COLUMN,
+        ParamNames.LANGUAGE,
+        ParamNames.SYMBOL,
+        ParamNames.CLASS_NAME,
+        // These are legacy selectors specific to member-editing tools. They are still fully
+        // supported when `target` is omitted, but cannot identify a second target alongside it.
+        ParamNames.CLASS,
+        ParamNames.MEMBER,
+        ParamNames.PARAMETER_COUNT
+    )
+
+    fun normalize(arguments: JsonObject): Result<JsonObject> {
+        val rawTarget = arguments[TARGET] ?: return Result.success(arguments)
+        if (rawTarget == JsonNull) {
+            // Optional JSON-RPC arguments are commonly serialized explicitly as null. Treat that
+            // exactly like an omitted target so legacy selectors remain compatible with clients
+            // that do not strip null optionals.
+            return Result.success(arguments)
+        }
+        val target = rawTarget as? JsonObject
+            ?: return Result.failure(IllegalArgumentException("target must be an object when present"))
+
+        val mixedLegacy = legacySelectorNames.filter { isPresent(arguments[it]) }
+        if (mixedLegacy.isNotEmpty()) {
+            return Result.failure(
+                IllegalArgumentException(
+                    "Nested 'target' requires exactly one selector and is mutually exclusive with legacy top-level selector parameter(s): " +
+                        mixedLegacy.joinToString(", ")
+                )
+            )
+        }
+
+        val hasSymbolId = target.containsKey(ParamNames.SYMBOL_ID) && target[ParamNames.SYMBOL_ID] != JsonNull
+        val hasPosition = target.containsKey(POSITION) && target[POSITION] != JsonNull
+        val hasQualifiedName = target.containsKey(QUALIFIED_NAME) && target[QUALIFIED_NAME] != JsonNull
+        val variants = listOf(hasSymbolId, hasPosition, hasQualifiedName).count { it }
+        if (variants != 1) {
+            return Result.failure(
+                IllegalArgumentException(
+                    "target must select exactly one variant: symbolId, position, or qualifiedName + language"
+                )
+            )
+        }
+
+        val normalized = arguments.toMutableMap()
+        normalized.remove(TARGET)
+
+        when {
+            hasSymbolId -> {
+                val unexpected = target.keys - setOf(ParamNames.SYMBOL_ID)
+                if (unexpected.isNotEmpty()) return unexpectedFields("symbolId", unexpected)
+                val symbolId = requiredNonBlankString(target[ParamNames.SYMBOL_ID], "target.symbolId")
+                    .getOrElse { return Result.failure(it) }
+                normalized[ParamNames.SYMBOL_ID] = JsonPrimitive(symbolId)
+                normalized[NORMALIZED_VARIANT] = JsonPrimitive(ParamNames.SYMBOL_ID)
+            }
+
+            hasPosition -> {
+                val unexpected = target.keys - setOf(POSITION)
+                if (unexpected.isNotEmpty()) return unexpectedFields("position", unexpected)
+                val position = target[POSITION] as? JsonObject
+                    ?: return Result.failure(IllegalArgumentException("target.position must be an object"))
+                val unexpectedPosition = position.keys - setOf(ParamNames.FILE, ParamNames.LINE, ParamNames.COLUMN)
+                if (unexpectedPosition.isNotEmpty()) {
+                    return Result.failure(
+                        IllegalArgumentException(
+                            "target.position contains unsupported field(s): ${unexpectedPosition.sorted().joinToString(", ")}"
+                        )
+                    )
+                }
+                val file = requiredNonBlankString(position[ParamNames.FILE], "target.position.file")
+                    .getOrElse { return Result.failure(it) }
+                val line = requiredPositiveInt(position[ParamNames.LINE], "target.position.line")
+                    .getOrElse { return Result.failure(it) }
+                val column = requiredPositiveInt(position[ParamNames.COLUMN], "target.position.column")
+                    .getOrElse { return Result.failure(it) }
+                normalized[ParamNames.FILE] = JsonPrimitive(file)
+                normalized[ParamNames.LINE] = JsonPrimitive(line)
+                normalized[ParamNames.COLUMN] = JsonPrimitive(column)
+                normalized[NORMALIZED_VARIANT] = JsonPrimitive(POSITION)
+            }
+
+            else -> {
+                val unexpected = target.keys - setOf(QUALIFIED_NAME, ParamNames.LANGUAGE)
+                if (unexpected.isNotEmpty()) return unexpectedFields("qualifiedName", unexpected)
+                val qualifiedName = requiredNonBlankString(target[QUALIFIED_NAME], "target.qualifiedName")
+                    .getOrElse { return Result.failure(it) }
+                val language = requiredNonBlankString(target[ParamNames.LANGUAGE], "target.language")
+                    .getOrElse { return Result.failure(it) }
+                normalized[ParamNames.SYMBOL] = JsonPrimitive(qualifiedName)
+                normalized[ParamNames.LANGUAGE] = JsonPrimitive(language)
+                normalized[NORMALIZED_VARIANT] = JsonPrimitive(QUALIFIED_NAME)
+            }
+        }
+
+        return Result.success(JsonObject(normalized))
+    }
+
+    /**
+     * A pagination cursor continues an already resolved query, so selector inputs from that
+     * request must not leak into the next-page execution path.
+     */
+    fun withoutTargetSelectors(arguments: JsonObject): JsonObject = JsonObject(
+        arguments.filterKeys { it != TARGET && it !in legacySelectorNames }
+    )
+
+    /**
+     * Extracts only the opaque handle needed for dispatcher project routing. A string `target`
+     * belongs to tools such as ide_run_tests and is deliberately ignored here; target-aware tools
+     * perform the complete validation in [normalize].
+     */
+    fun symbolIdForRouting(arguments: JsonObject): Result<String?> {
+        // A few legacy clients serialize optional fields as empty strings. Treat a blank legacy
+        // handle as absent for routing; target-aware tools still validate a nested handle strictly.
+        val legacy = optionalTrimmedString(arguments[ParamNames.SYMBOL_ID])
+        val target = arguments[TARGET] as? JsonObject ?: return Result.success(legacy)
+        val nestedElement = target[ParamNames.SYMBOL_ID]
+        val nested = if (nestedElement == null || nestedElement == JsonNull) {
+            null
+        } else {
+            requiredNonBlankString(nestedElement, "target.symbolId").getOrElse { return Result.failure(it) }
+        }
+        if (legacy != null && nested != null) {
+            return Result.failure(
+                IllegalArgumentException("Nested 'target' is mutually exclusive with legacy top-level symbolId")
+            )
+        }
+        return Result.success(nested ?: legacy)
+    }
+
+    private fun isPresent(element: JsonElement?): Boolean = when (element) {
+        null, JsonNull -> false
+        is JsonPrimitive -> if (element.isString) !element.contentOrNull.isNullOrBlank() else true
+        else -> true
+    }
+
+    private fun requiredNonBlankString(element: JsonElement?, path: String): Result<String> {
+        val primitive = element as? JsonPrimitive
+        if (primitive?.isString != true) {
+            return Result.failure(IllegalArgumentException("$path must be a string"))
+        }
+        val value = primitive.contentOrNull?.trim().orEmpty()
+        if (value.isEmpty()) {
+            return Result.failure(IllegalArgumentException("$path must not be blank"))
+        }
+        return Result.success(value)
+    }
+
+    private fun optionalNonBlankString(element: JsonElement?, path: String): Result<String?> {
+        if (element == null || element == JsonNull) return Result.success(null)
+        return requiredNonBlankString(element, path).map { it }
+    }
+
+    private fun optionalTrimmedString(element: JsonElement?): String? =
+        (element as? JsonPrimitive)
+            ?.takeIf { it.isString }
+            ?.contentOrNull
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+
+    private fun requiredPositiveInt(element: JsonElement?, path: String): Result<Int> {
+        val value = (element as? JsonPrimitive)?.intOrNull
+            ?: return Result.failure(IllegalArgumentException("$path must be an integer"))
+        if (value <= 0) {
+            return Result.failure(IllegalArgumentException("$path must be positive and 1-based"))
+        }
+        return Result.success(value)
+    }
+
+    private fun unexpectedFields(variant: String, fields: Set<String>): Result<JsonObject> =
+        Result.failure(
+            IllegalArgumentException(
+                "target variant '$variant' contains incompatible field(s): ${fields.sorted().joinToString(", ")}"
+            )
+        )
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/DiagnosticsAnalysisService.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/DiagnosticsAnalysisService.kt
@@ -108,7 +108,39 @@ class DiagnosticsAnalysisService(private val project: Project) {
         severity: String,
         startLine: Int?,
         endLine: Int?,
-        maxProblems: Int
+        maxProblems: Int,
+        timeoutMs: Long? = null
+    ): FileAnalysisResult {
+        val effectiveTimeoutMs = (timeoutMs ?: configuredAnalysisTimeoutMs()).coerceAtLeast(1L)
+        return withTimeoutOrNull(effectiveTimeoutMs) {
+            analyzeFileWithinBudget(
+                virtualFile = virtualFile,
+                filePath = filePath,
+                severity = severity,
+                startLine = startLine,
+                endLine = endLine,
+                maxProblems = maxProblems,
+                timeoutMs = effectiveTimeoutMs
+            )
+        } ?: timeoutResult(effectiveTimeoutMs)
+    }
+
+    /**
+     * The complete analysis budget, including disk refresh, PSI setup, and waiting for the
+     * application-wide main-pass lock. Callers analyzing several files can pass the remaining
+     * part of one shared budget through [analyzeFile]'s `timeoutMs` parameter.
+     */
+    internal fun configuredAnalysisTimeoutMs(): Long =
+        (analysisTimeoutMsOverride ?: DEFAULT_ANALYSIS_TIMEOUT_MS).coerceAtLeast(1L)
+
+    private suspend fun analyzeFileWithinBudget(
+        virtualFile: VirtualFile,
+        filePath: String,
+        severity: String,
+        startLine: Int?,
+        endLine: Int?,
+        maxProblems: Int,
+        timeoutMs: Long
     ): FileAnalysisResult {
         refreshFromDisk(virtualFile)
 
@@ -154,7 +186,6 @@ class DiagnosticsAnalysisService(private val project: Project) {
             )
         }
 
-        val timeoutMs = analysisTimeoutMsOverride ?: DEFAULT_ANALYSIS_TIMEOUT_MS
         val minSeverity = minimumSeverityFor(severity)
 
         return DiagnosticsAnalysisCoordinator.getInstance().withMainPassLock {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsTool.kt
@@ -6,7 +6,9 @@ import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.BuildMessage
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DiagnosticsResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileDiagnosticsAnalysis
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.IntentionInfo
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ProblemInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TestResultInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TestSummary
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
@@ -24,11 +26,19 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.int
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
 
 /**
  * MCP tool that analyzes files for code problems and available intentions.
@@ -51,6 +61,8 @@ class GetDiagnosticsTool : AbstractMcpTool() {
     companion object {
         private const val MAX_PROBLEMS = 100
         private const val MAX_INTENTIONS = 50
+        private const val MAX_FILES = 100
+        private val WINDOWS_DRIVE_PATH = Regex("^[A-Za-z]:.*")
     }
 
     override val name = "ide_diagnostics"
@@ -58,20 +70,30 @@ class GetDiagnosticsTool : AbstractMcpTool() {
     override val description = """
         Get code diagnostics from multiple sources: file analysis (errors, warnings, intentions), build output (compiler errors/warnings from last build), and test results (from open test run tabs).
 
-        Returns: problems with severity and location, available intentions/quick fixes, build errors, and test results with error messages and stack traces. The analysisMode field reports which provider produced the file problems: "open_daemon" (file open in an editor) or "closed_batch" (public batch analysis); null when no analysis ran.
+        Returns: problems with severity and location, available intentions/quick fixes, build errors, and test results with error messages and stack traces. Single-file calls report legacy top-level analysis metadata. Multi-file calls return one aggregate problems list plus fileAnalyses entries with mode, freshness, timeout, message, returned problemCount, and problemsTruncated metadata for each file. Code problems share a 100-item response cap; top-level problemsTruncated reports omitted problems. Fresh analysis does not imply complete output: re-query truncated files individually, narrowing startLine/endLine if needed.
 
-        At least one source must be active: provide 'file' for code analysis, 'includeBuildErrors' for build output, or 'includeTestResults' for test results. Can combine all three.
+        At least one source must be active: provide exactly one of 'file' or 'files' for code analysis, 'includeBuildErrors' for build output, or 'includeTestResults' for test results. Can combine file analysis with build and test results. A multi-file call accepts at most 100 supplied paths, all sharing one analysis timeout budget; lexical aliases are analyzed only once.
 
         File analysis uses fresh daemon highlights for files that are already open in an editor. Closed files use public batch analysis, so weak warnings and quick-fix intentions may be less complete unless the file is open. The analyzed file is re-read from disk first, so results reflect edits made outside the IDE without calling ide_sync_files. For diagnostics across many files or the whole project with per-file coverage metadata, use ide_project_diagnostics.
 
-        Parameters: file (optional, enables code analysis), line + column (optional, for intentions, requires file), startLine/endLine (optional, requires file), includeBuildErrors (optional), includeTestResults (optional), severity (optional, default 'all'), testResultFilter (optional, default 'failed'), maxBuildErrors (optional, default 100), maxTestResults (optional, default 100).
+        Parameters: file or files (mutually exclusive, enable code analysis), line + column (optional, for intentions, single file only), startLine/endLine (optional, single file only), includeBuildErrors (optional), includeTestResults (optional), severity (optional, default 'all'), testResultFilter (optional, default 'failed'), maxBuildErrors (optional, default 100), maxTestResults (optional, default 100).
 
-        Example: {"file": "src/MyClass.java"} or {"includeBuildErrors": true, "severity": "errors"} or {"file": "src/MyClass.java", "includeBuildErrors": true, "includeTestResults": true}
+        Example: {"file": "src/MyClass.java"} or {"files": ["src/A.java", "src/B.java"]} or {"includeBuildErrors": true, "severity": "errors"}
     """.trimIndent()
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
         .file(required = false, description = "Path to file relative to project root (e.g., 'src/main/java/com/example/MyClass.java'). Optional — enables per-file code analysis.")
+        .property("files", buildJsonObject {
+            put("type", "array")
+            putJsonObject("items") {
+                put("type", "string")
+            }
+            put("minItems", 1)
+            put("maxItems", MAX_FILES)
+            put("uniqueItems", true)
+            put("description", "Project-relative file paths to analyze under one shared timeout budget (max $MAX_FILES). Mutually exclusive with 'file'.")
+        })
         .intProperty("line", "1-based line number for intention lookup. Optional, defaults to 1. Requires file.")
         .intProperty("column", "1-based column number for intention lookup. Optional, defaults to 1. Requires file.")
         .intProperty("startLine", "Filter problems to start from this line. Optional. Requires file.")
@@ -86,7 +108,49 @@ class GetDiagnosticsTool : AbstractMcpTool() {
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
         // Parse arguments
-        val filePath = arguments["file"]?.jsonPrimitive?.content
+        val rawFile = arguments["file"]
+        val rawFiles = arguments["files"]
+        val hasFileArgument = rawFile != null && rawFile != JsonNull
+        val hasFilesArgument = rawFiles != null && rawFiles != JsonNull
+        val filePath = if (hasFileArgument) {
+            (rawFile as? JsonPrimitive)
+                ?.takeIf { it.isString }
+                ?.contentOrNull
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?: return createErrorResult("Parameter 'file' must be a non-blank project-relative path.")
+        } else {
+            null
+        }
+        val filePaths = if (hasFilesArgument) {
+            val paths = (rawFiles as? JsonArray)
+                ?: return createErrorResult("Parameter 'files' must be an array of project-relative paths.")
+            if (paths.size > MAX_FILES) {
+                return createErrorResult("Parameter 'files' supports at most $MAX_FILES paths per request.")
+            }
+            // Use the normalized path only as the deduplication key. Keeping the first supplied
+            // representation makes fileAnalyses and problem locations echo a caller's request,
+            // while preventing aliases such as src/A.java and src/./A.java from consuming the
+            // shared analysis budget twice.
+            val firstPathByNormalizedPath = linkedMapOf<String, String>()
+            paths.forEachIndexed { index, element ->
+                val requestedPath = (element as? JsonPrimitive)
+                    ?.takeIf { it.isString }
+                    ?.contentOrNull
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: return createErrorResult("Parameter 'files[$index]' must be a non-blank project-relative path.")
+                val normalizedPath = try {
+                    normalizeProjectRelativePath(requestedPath)
+                } catch (e: IllegalArgumentException) {
+                    return createErrorResult("Parameter 'files[$index]' ${e.message}")
+                }
+                firstPathByNormalizedPath.putIfAbsent(normalizedPath, requestedPath)
+            }
+            firstPathByNormalizedPath.values.toList()
+        } else {
+            null
+        }
         val line = arguments["line"]?.jsonPrimitive?.intOrNull ?: 1
         val column = arguments["column"]?.jsonPrimitive?.intOrNull ?: 1
         val startLine = arguments["startLine"]?.jsonPrimitive?.intOrNull
@@ -98,23 +162,35 @@ class GetDiagnosticsTool : AbstractMcpTool() {
         val maxBuildErrors = (arguments[ParamNames.MAX_BUILD_ERRORS]?.jsonPrimitive?.intOrNull ?: 100).coerceIn(1, 500)
         val maxTestResults = (arguments[ParamNames.MAX_TEST_RESULTS]?.jsonPrimitive?.intOrNull ?: 100).coerceIn(1, 500)
 
-        // Validate: at least one source must be active
-        if (filePath == null && !includeBuildErrors && !includeTestResults) {
-            return createErrorResult("At least one source must be active: provide 'file' for code analysis, 'includeBuildErrors' for build output, or 'includeTestResults' for test results.")
+        if (hasFileArgument && hasFilesArgument) {
+            return createErrorResult("Parameters 'file' and 'files' are mutually exclusive; provide exactly one of them for code analysis.")
         }
 
-        // Validate: startLine/endLine require file
-        if (filePath == null && (startLine != null || endLine != null)) {
-            return createErrorResult("Parameters 'startLine' and 'endLine' require 'file' to be specified.")
+        if (hasFilesArgument && filePaths.isNullOrEmpty()) {
+            return createErrorResult("Parameter 'files' must contain at least one project-relative file path.")
+        }
+
+        // Location filters and intention lookup only have unambiguous semantics for one file.
+        val hasLocationArguments = listOf("line", "column", "startLine", "endLine")
+            .any { name -> arguments[name]?.let { it != JsonNull } == true }
+        if (filePath == null && hasLocationArguments) {
+            return createErrorResult("Parameters 'line', 'column', 'startLine', and 'endLine' are only supported with the single 'file' parameter.")
+        }
+
+        // Validate: at least one source must be active
+        if (filePath == null && filePaths.isNullOrEmpty() && !includeBuildErrors && !includeTestResults) {
+            return createErrorResult("At least one source must be active: provide 'file' or 'files' for code analysis, 'includeBuildErrors' for build output, or 'includeTestResults' for test results.")
         }
 
         // File diagnostics
-        var problems: List<com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ProblemInfo>? = null
+        var problems: List<ProblemInfo>? = null
+        var problemsTruncated: Boolean? = null
         var intentions: List<IntentionInfo>? = null
         var analysisFresh: Boolean? = null
         var analysisTimedOut: Boolean? = null
         var analysisMessage: String? = null
         var analysisMode: String? = null
+        var fileAnalyses: List<FileDiagnosticsAnalysis>? = null
 
         if (filePath != null) {
             requireSmartMode(project)
@@ -129,7 +205,8 @@ class GetDiagnosticsTool : AbstractMcpTool() {
                 severity = severity,
                 startLine = startLine,
                 endLine = endLine,
-                maxProblems = MAX_PROBLEMS
+                // One-item lookahead distinguishes exactly-at-limit output from truncation.
+                maxProblems = MAX_PROBLEMS + 1
             )
             // analyzeFile refreshes the file from disk, so it can discover the file is gone; the
             // VirtualFile is then invalid and every PSI lookup below it throws.
@@ -137,10 +214,17 @@ class GetDiagnosticsTool : AbstractMcpTool() {
                 return createErrorResult("File no longer exists on disk: $filePath")
             }
 
-            problems = analysisResult.problems
+            problems = analysisResult.problems.take(MAX_PROBLEMS)
+            problemsTruncated = analysisResult.problems.size > MAX_PROBLEMS
             analysisFresh = analysisResult.analysisFresh
             analysisTimedOut = analysisResult.analysisTimedOut
             analysisMessage = analysisResult.analysisMessage
+            if (problemsTruncated) {
+                analysisMessage = appendAnalysisMessage(
+                    analysisMessage,
+                    "Problem output was truncated at $MAX_PROBLEMS items. Re-query with narrower startLine/endLine filters."
+                )
+            }
             analysisMode = analysisResult.analysisMode
             intentions = analyzeIntentions(
                 project = project,
@@ -157,6 +241,81 @@ class GetDiagnosticsTool : AbstractMcpTool() {
                     "Intentions are unavailable because the file is not open in an editor."
                 )
             }
+        } else if (filePaths != null) {
+            requireSmartMode(project)
+
+            val analysisService = DiagnosticsAnalysisService.getInstance(project)
+            val deadlineNanos = System.nanoTime() + analysisService.configuredAnalysisTimeoutMs() * 1_000_000L
+            val aggregateProblems = mutableListOf<ProblemInfo>()
+            val perFileAnalyses = mutableListOf<FileDiagnosticsAnalysis>()
+            problemsTruncated = false
+
+            for (path in filePaths) {
+                val remainingMs = remainingBudgetMs(deadlineNanos)
+                if (remainingMs == null) {
+                    perFileAnalyses += sharedBudgetExhausted(path)
+                    continue
+                }
+
+                val virtualFile = resolveFile(project, path)
+                if (virtualFile == null) {
+                    perFileAnalyses += FileDiagnosticsAnalysis(
+                        file = path,
+                        mode = null,
+                        fresh = false,
+                        timedOut = false,
+                        message = "File not found: $path"
+                    )
+                    continue
+                }
+
+                val analysisRemainingMs = remainingBudgetMs(deadlineNanos)
+                if (analysisRemainingMs == null) {
+                    perFileAnalyses += sharedBudgetExhausted(path)
+                    continue
+                }
+
+                val remainingProblemSlots = MAX_PROBLEMS - aggregateProblems.size
+                val analysisResult = analysisService.analyzeFile(
+                    virtualFile = virtualFile,
+                    filePath = path,
+                    severity = severity,
+                    startLine = null,
+                    endLine = null,
+                    // Still probe a file when no slots remain, so hidden errors are never
+                    // presented as an empty, complete result for that file.
+                    maxProblems = remainingProblemSlots + 1,
+                    timeoutMs = analysisRemainingMs
+                )
+
+                val returnedProblems = analysisResult.problems.take(remainingProblemSlots)
+                val fileProblemsTruncated = analysisResult.problems.size > remainingProblemSlots
+                aggregateProblems += returnedProblems
+                if (fileProblemsTruncated) problemsTruncated = true
+                var message = when {
+                    !virtualFile.isValid -> "File no longer exists on disk: $path"
+                    else -> analysisResult.analysisMessage
+                }
+                if (fileProblemsTruncated) {
+                    message = appendAnalysisMessage(
+                        message,
+                        "Problems from this file were omitted by the shared $MAX_PROBLEMS-item response cap. " +
+                            "Re-query this path using 'file', narrowing startLine/endLine if needed."
+                    )
+                }
+                perFileAnalyses += FileDiagnosticsAnalysis(
+                    file = path,
+                    mode = analysisResult.analysisMode,
+                    fresh = analysisResult.analysisFresh,
+                    timedOut = analysisResult.analysisTimedOut,
+                    message = message,
+                    problemCount = returnedProblems.size,
+                    problemsTruncated = fileProblemsTruncated
+                )
+            }
+
+            problems = aggregateProblems
+            fileAnalyses = perFileAnalyses
         }
 
         // Build errors
@@ -199,11 +358,13 @@ class GetDiagnosticsTool : AbstractMcpTool() {
             problems = problems,
             intentions = intentions,
             problemCount = problems?.size,
+            problemsTruncated = problemsTruncated,
             intentionCount = intentions?.size,
             analysisFresh = analysisFresh,
             analysisTimedOut = analysisTimedOut,
             analysisMessage = analysisMessage,
             analysisMode = analysisMode,
+            fileAnalyses = fileAnalyses,
             buildErrors = buildErrors,
             buildErrorCount = buildErrorCount,
             buildWarningCount = buildWarningCount,
@@ -214,6 +375,50 @@ class GetDiagnosticsTool : AbstractMcpTool() {
             testResultsTruncated = testResultsTruncated
         ))
     }
+
+    private fun remainingBudgetMs(deadlineNanos: Long): Long? {
+        val remainingNanos = deadlineNanos - System.nanoTime()
+        if (remainingNanos <= 0L) return null
+        return ((remainingNanos + 999_999L) / 1_000_000L).coerceAtLeast(1L)
+    }
+
+    /**
+     * Returns a lexical, project-relative key without consulting the filesystem. This is used
+     * before analysis so aliases cannot repeat work, and it deliberately permits an internal
+     * `dir/../File.java` segment while rejecting a path that still escapes after normalization.
+     */
+    private fun normalizeProjectRelativePath(requestedPath: String): String {
+        if (
+            requestedPath.startsWith('/') ||
+            requestedPath.startsWith('\\') ||
+            WINDOWS_DRIVE_PATH.matches(requestedPath)
+        ) {
+            throw IllegalArgumentException("must be a project-relative path.")
+        }
+
+        val path = try {
+            Path.of(requestedPath)
+        } catch (_: InvalidPathException) {
+            throw IllegalArgumentException("is not a valid project-relative path.")
+        }
+        if (path.isAbsolute) {
+            throw IllegalArgumentException("must be a project-relative path.")
+        }
+
+        val normalized = path.normalize()
+        if (normalized.nameCount > 0 && normalized.getName(0).toString() == "..") {
+            throw IllegalArgumentException("must not escape the project root through path traversal.")
+        }
+        return normalized.toString()
+    }
+
+    private fun sharedBudgetExhausted(file: String) = FileDiagnosticsAnalysis(
+        file = file,
+        mode = null,
+        fresh = false,
+        timedOut = true,
+        message = "Shared diagnostics analysis timeout budget was exhausted before this file could be analyzed."
+    )
 
     private suspend fun analyzeIntentions(
         project: Project,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/StructureModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/StructureModels.kt
@@ -1,6 +1,8 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models
 
+import com.intellij.psi.PsiElement
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Represents a single node in the file structure tree.
@@ -10,7 +12,9 @@ import kotlinx.serialization.Serializable
  * @property modifiers List of modifiers (public, private, static, etc.)
  * @property signature Optional signature information (method parameters, return type, etc.)
  * @property line The line number where this element is defined
+ * @property endLine The final source line covered by this element, when known
  * @property children Child elements (e.g., methods within a class)
+ * @property symbolId Opaque session handle for the exact PSI declaration, when one exists
  */
 @Serializable
 data class StructureNode(
@@ -20,7 +24,9 @@ data class StructureNode(
     val signature: String?,
     val line: Int,
     val endLine: Int? = null,
-    val children: List<StructureNode> = emptyList()
+    val children: List<StructureNode> = emptyList(),
+    val symbolId: String? = null,
+    @Transient internal val pointerTarget: PsiElement? = null
 )
 
 /**
@@ -50,10 +56,14 @@ enum class StructureKind {
  * @property file The file path relative to project root
  * @property language The language ID (e.g., "JAVA", "Python", "kotlin")
  * @property structure The formatted tree string
+ * @property nodes The same hierarchy as structured data, including optional symbol handles
  */
 @Serializable
 data class FileStructureResult(
     val file: String,
     val language: String,
-    val structure: String
+    val structure: String,
+    val nodes: List<StructureNode> = emptyList(),
+    val symbolIdsTruncated: Boolean = false,
+    val symbolIdsOmitted: Int = 0
 )

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/models/ToolModels.kt
@@ -1,7 +1,9 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models
 
+import com.intellij.psi.PsiElement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class PositionInput(
@@ -29,11 +31,15 @@ data class UsageLocation(
  */
 @Serializable
 data class ResolvedSymbolInfo(
+    val symbolId: String,
     val name: String?,
     val kind: String?,
     val container: String?,
     val file: String?,
-    val line: Int?
+    val line: Int?,
+    val column: Int? = null,
+    val qualifiedName: String? = null,
+    val language: String? = null
 )
 
 @Serializable
@@ -56,6 +62,7 @@ data class FindUsagesResult(
 // find_definition output
 @Serializable
 data class DefinitionResult(
+    val symbolId: String,
     val file: String,
     val line: Int,
     val column: Int,
@@ -94,6 +101,7 @@ data class SymbolParameterInfo(
  */
 @Serializable
 data class SymbolInfoResult(
+    val symbolId: String,
     val name: String,
     val kind: String?,
     val qualifiedName: String?,
@@ -132,7 +140,20 @@ data class ReadFileResult(
 data class TypeHierarchyResult(
     val element: TypeElement,
     val supertypes: List<TypeElement>,
-    val subtypes: List<TypeElement>
+    val subtypes: List<TypeElement>,
+    /** Exact breadth-first wire order; legacy direction-specific arrays remain for compatibility. */
+    val traversal: List<TypeHierarchyTraversalNode> = emptyList(),
+    val returnedNodes: Int = 0,
+    val truncated: Boolean = false,
+    val elapsedMs: Long = 0,
+    val hasMore: Boolean = false,
+    val cursor: String? = null
+)
+
+@Serializable
+data class TypeHierarchyTraversalNode(
+    val direction: String,
+    val element: TypeElement
 )
 
 @Serializable
@@ -141,6 +162,7 @@ data class TypeElement(
     val file: String?,
     val kind: String,
     val language: String? = null,
+    val symbolId: String? = null,
     val supertypes: List<TypeElement>? = null
 )
 
@@ -148,7 +170,12 @@ data class TypeElement(
 @Serializable
 data class CallHierarchyResult(
     val element: CallElement,
-    val calls: List<CallElement>
+    val calls: List<CallElement>,
+    val returnedNodes: Int = 0,
+    val truncated: Boolean = false,
+    val elapsedMs: Long = 0,
+    val hasMore: Boolean = false,
+    val cursor: String? = null
 )
 
 @Serializable
@@ -158,6 +185,7 @@ data class CallElement(
     val line: Int,
     val column: Int,
     val language: String? = null,
+    val symbolId: String? = null,
     val children: List<CallElement>? = null
 )
 
@@ -181,21 +209,39 @@ data class ImplementationLocation(
     val line: Int,
     val column: Int,
     val kind: String,
-    val language: String? = null
+    val language: String? = null,
+    val qualifiedName: String? = null,
+    val symbolId: String? = null,
+    @Transient internal val pointerTarget: PsiElement? = null
 )
 
 
 // ide_diagnostics output
 @Serializable
+data class FileDiagnosticsAnalysis(
+    val file: String,
+    val mode: String? = null,
+    val fresh: Boolean,
+    val timedOut: Boolean,
+    val message: String? = null,
+    /** Problems from this file included in the aggregate response, not its total problem count. */
+    val problemCount: Int = 0,
+    /** Collected problems omitted by the response cap; independent of freshness and timeouts. */
+    val problemsTruncated: Boolean = false
+)
+
+@Serializable
 data class DiagnosticsResult(
     val problems: List<ProblemInfo>? = null,
     val intentions: List<IntentionInfo>? = null,
     val problemCount: Int? = null,
+    val problemsTruncated: Boolean? = null,
     val intentionCount: Int? = null,
     val analysisFresh: Boolean? = null,
     val analysisTimedOut: Boolean? = null,
     val analysisMessage: String? = null,
     val analysisMode: String? = null,
+    val fileAnalyses: List<FileDiagnosticsAnalysis>? = null,
     val buildErrors: List<BuildMessage>? = null,
     val buildErrorCount: Int? = null,
     val buildWarningCount: Int? = null,
@@ -295,7 +341,9 @@ data class RefactoringResult(
     val changesCount: Int,
     val message: String,
     val warnings: List<String>? = null,
-    val unretargetedImporters: List<String>? = null
+    val unretargetedImporters: List<String>? = null,
+    val updatedSymbol: ResolvedSymbolInfo? = null,
+    val invalidatedSymbolId: String? = null
 )
 
 
@@ -312,7 +360,10 @@ data class IndexStatusResult(
 data class SyncFilesResult(
     val syncedPaths: List<String>,
     val syncedAll: Boolean,
-    val message: String
+    val message: String,
+    val requestedPaths: List<String> = emptyList(),
+    val refreshedRoots: List<String> = emptyList(),
+    val deletedPaths: List<String> = emptyList()
 )
 
 // ide_build_project output
@@ -353,6 +404,7 @@ data class FindSymbolResult(
 
 @Serializable
 data class SymbolMatch(
+    val symbolId: String,
     val name: String,
     val qualifiedName: String?,
     val kind: String,
@@ -360,7 +412,8 @@ data class SymbolMatch(
     val line: Int,
     val column: Int,
     val containerName: String?,
-    val language: String? = null
+    val language: String? = null,
+    @Transient internal val pointerTarget: PsiElement? = null
 )
 
 // ide_find_super_methods output
@@ -379,7 +432,8 @@ data class MethodInfo(
     val file: String,
     val line: Int,
     val column: Int,
-    val language: String? = null
+    val language: String? = null,
+    val symbolId: String? = null
 )
 
 @Serializable
@@ -393,7 +447,8 @@ data class SuperMethodInfo(
     val column: Int?,
     val isInterface: Boolean,
     val depth: Int,
-    val language: String? = null
+    val language: String? = null,
+    val symbolId: String? = null
 )
 
 // ide_find_class output (reuses SymbolMatch)

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/CallHierarchyTool.kt
@@ -5,25 +5,35 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScopeResolver
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.CallElementData
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.HierarchyPageRequest
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.javascript.isJsTsElementOrFile
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.javascript.resolveJsTsCallHierarchySeed
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.CallWork
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.CallContinuation
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.PendingCallExpansion
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.PendingCallNode
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallElement
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallHierarchyResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.PsiModificationTracker
+import java.util.ArrayDeque
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 
 /**
  * Tool for analyzing method call relationships across multiple languages.
@@ -34,6 +44,8 @@ import kotlinx.serialization.json.put
  */
 class CallHierarchyTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     override val name = "ide_call_hierarchy"
 
     override val description = """
@@ -43,13 +55,14 @@ class CallHierarchyTool : AbstractMcpTool() {
 
         Rust note: "callers" direction works well; "callees" direction may have limited results due to Rust plugin PSI resolution constraints.
 
-        Returns: recursive tree with method signatures, file locations (line/column), and nested call relationships.
+        Returns deterministic breadth-first pages with method signatures, file locations, symbolId handles, and pagination metadata. Live progress is not available on stateless HTTP; continue with cursor.
 
         Target (mutually exclusive):
+        - symbolId: opaque handle returned by a previous semantic call
         - file + line + column: position-based lookup
         - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
-        Parameters: direction (required): "callers" or "callees". depth (optional, default: 3, max: 5). scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files).
+        Parameters: direction (required for a fresh query): "callers" or "callees". depth (optional, default: 3, max: 5), maxNodes (optional, default: 20 on a fresh query and 100 with cursor, max: 500), cursor (continuation page), scope (optional).
 
         Example: {"file": "src/Service.java", "line": 42, "column": 10, "direction": "callers"}
         Example: {"language": "Java", "symbol": "com.example.Service#processRequest(String)", "direction": "callers", "scope": "project_and_libraries"}
@@ -59,11 +72,15 @@ class CallHierarchyTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
         .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
-        .enumProperty("direction", "Direction: 'callers' (methods that call this method) or 'callees' (methods this method calls)", listOf("callers", "callees"), required = true)
+        .enumProperty("direction", "Direction for a fresh query: 'callers' or 'callees'. Omit when cursor is provided.", listOf("callers", "callees"))
         .intProperty("depth", "How many levels deep to traverse the call hierarchy (default: 3, max: 5)")
+        .intProperty("maxNodes", "Maximum hierarchy nodes returned and expanded in this page. Default: 20 on a fresh query and 100 with cursor; max: 500.")
+        .stringProperty("cursor", "Opaque session/project-bound continuation from the previous hierarchy page. Other search parameters are ignored.")
         .scopeProperty("Search scope. Default: project_files.")
         .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include callers/callees in generated sources (KSP/Dagger/annotation-processor output). Default: true.")
         .build()
@@ -71,11 +88,45 @@ class CallHierarchyTool : AbstractMcpTool() {
     companion object {
         private const val DEFAULT_DEPTH = 3
         private const val MAX_DEPTH = 5
+        private const val LEGACY_FIRST_PAGE_MAX_NODES = 20
+        private const val DEFAULT_MAX_NODES = 100
+        private const val MAX_NODES = 500
+        private const val TERMINAL_LOOKAHEAD_PROBES = 1
     }
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
+        val startedAt = System.currentTimeMillis()
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
+        val explicitMaxNodes = arguments["maxNodes"]?.jsonPrimitive?.intOrNull
+        // Before hierarchy pagination, language handlers exposed at most 20 direct calls on the
+        // initial request. Keep that wire-compatible default while allowing explicit maxNodes to
+        // opt into a larger first page; continuation pages retain the new 100-node default.
+        val maxNodes = explicitMaxNodes ?: if (cursor == null) {
+            LEGACY_FIRST_PAGE_MAX_NODES
+        } else {
+            DEFAULT_MAX_NODES
+        }
+        if (maxNodes !in 1..MAX_NODES) {
+            return createErrorResult("maxNodes must be between 1 and $MAX_NODES")
+        }
+
+        val continuationRegistry = HierarchyContinuationRegistry.getInstance()
+        if (cursor != null) {
+            requireSmartMode(project)
+            val lease = continuationRegistry.resolveLease(project, cursor).getOrElse {
+                return createErrorResult(it.message ?: "Hierarchy cursor expired")
+            }
+            val continuation = lease.continuation as? CallContinuation
+                ?: return createErrorResult("Cursor belongs to a different hierarchy tool. Start ide_call_hierarchy again without cursor.")
+            return suspendingReadAction {
+                buildCallPage(project, continuation, maxNodes, startedAt, lease.generation, cursor)
+            }
+        }
+
+        val generation = continuationRegistry.currentGeneration()
+
         val direction = arguments["direction"]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: direction")
+            ?: return createErrorResult("Missing required parameter: direction for a fresh hierarchy query")
         val depth = (arguments["depth"]?.jsonPrimitive?.int ?: DEFAULT_DEPTH).coerceIn(1, MAX_DEPTH)
         val rawScope = rawScopeValue(arguments[ParamNames.SCOPE])
         val scope = try {
@@ -110,7 +161,17 @@ class CallHierarchyTool : AbstractMcpTool() {
 
             ProgressManager.checkCanceled() // Allow cancellation before heavy operation
 
-            val hierarchyData = handler.getCallHierarchy(element, project, direction, depth, scope, excludeGenerated)
+            // Ask the language adapter for exactly one edge. The tool owns the bounded BFS and
+            // never lets a handler recursively materialize the complete graph.
+            val hierarchyData = handler.getCallHierarchy(
+                element,
+                project,
+                direction,
+                1,
+                scope,
+                excludeGenerated,
+                page = HierarchyPageRequest(offset = 0, limit = maxNodes + 1)
+            )
             if (hierarchyData == null) {
                 val isSymbolMode = optionalStringArg(arguments, ParamNames.LANGUAGE) != null
                 return@suspendingReadAction createErrorResult(
@@ -119,13 +180,283 @@ class CallHierarchyTool : AbstractMcpTool() {
                 )
             }
 
-            // Convert handler result to tool result
-            createJsonResult(CallHierarchyResult(
-                element = convertToCallElement(hierarchyData.element),
-                calls = hierarchyData.calls.map { convertToCallElement(it) }
-            ))
+            val pointerManager = SmartPointerManager.getInstance(project)
+            val modificationCount = PsiModificationTracker.getInstance(project).modificationCount
+            val root = convertToCallElement(
+                project,
+                hierarchyData.element,
+                element,
+                optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+            ).copy(children = null)
+            // Position lookup may start on a call-site reference. The handler has already
+            // resolved it to the callable declaration; continuation identity must follow that
+            // declaration rather than the disposable caller leaf.
+            val rootTarget = PsiUtils.resolveNavigationTarget(
+                hierarchyData.element.pointerTarget ?: element
+            )
+            val visited = linkedSetOf<String>()
+            val rootPointer = pointerManager.createSmartPsiElementPointer(rootTarget)
+            val visitedPointers = mutableListOf<SmartPsiElementPointer<PsiElement>>(rootPointer)
+            val frontier = buildList<CallWork> {
+                hierarchyData.calls
+                    .sortedWith(callDataComparator)
+                    .mapNotNullTo(this) { data ->
+                        pendingCallNode(
+                            project, pointerManager, data, depth = 1, visited = visited,
+                            visitedPointers = visitedPointers
+                        )
+                    }
+                hierarchyData.nextOffset?.let { offset ->
+                    add(PendingCallExpansion(rootPointer, depth = 0, offset = offset))
+                }
+            }
+            val continuation = CallContinuation(
+                rootPointer = rootPointer,
+                root = root,
+                frontier = frontier,
+                visited = visited,
+                visitedPointers = visitedPointers,
+                direction = direction,
+                maxDepth = depth,
+                scope = scope,
+                excludeGenerated = excludeGenerated,
+                rootModificationCount = modificationCount
+            )
+            buildCallPage(project, continuation, maxNodes, startedAt, generation)
         }
     }
+
+    private fun buildCallPage(
+        project: Project,
+        continuation: CallContinuation,
+        maxNodes: Int,
+        startedAt: Long,
+        generation: Long,
+        parentCursor: String? = null
+    ): CallToolResult {
+        val registry = HierarchyContinuationRegistry.getInstance()
+        if (!registry.isCurrentGeneration(generation)) {
+            return createErrorResult("The MCP server session changed. Start the hierarchy query again without cursor.")
+        }
+        val rootElement = continuation.rootPointer.element
+            ?: return createErrorResult("Hierarchy target was deleted or became invalid. Start the query again without cursor.")
+        val pointerManager = SmartPointerManager.getInstance(project)
+        val queue = ArrayDeque(continuation.frontier)
+        val visited = continuation.visited.toPersistentSet().builder()
+        val visitedPointers = continuation.visitedPointers.toPersistentList().builder()
+        val returned = mutableListOf<CallElement>()
+        var discoveredThisPage = 0
+        var expandedThisPage = 0
+        var terminalLookaheadProbes = 0
+        val modificationCount = PsiModificationTracker.getInstance(project).modificationCount
+
+        val rootSnapshot = if (continuation.rootModificationCount == modificationCount) continuation.root else {
+            refreshCallSnapshot(
+                project,
+                rootElement,
+                continuation.root,
+                continuation.direction,
+                continuation.scope,
+                continuation.excludeGenerated
+            )
+        }
+        // A cursor outlives individual symbol-cache entries. Rebind every disclosed handle even
+        // without a PSI edit: unrelated requests may have evicted it, or its idle TTL may be over.
+        val root = rootSnapshot.copy(symbolId = synchronized(continuation.rootHandle) {
+            bindSymbolId(project, rootElement, continuation.rootHandle.symbolId).also {
+                continuation.rootHandle.symbolId = it
+            }
+        })
+
+        fun hasKnownPendingNode(): Boolean = queue.any { work ->
+            work is PendingCallNode && (work.pointer == null || work.pointer.element != null)
+        }
+
+        // Resolve terminal edge probes eagerly when the page budget permits, but never let a wide
+        // or stale expansion-only frontier turn one MCP call into unbounded work. If the hard cap
+        // is reached, the remaining probes stay in the cursor; a continuation page may therefore
+        // return zero nodes while it retires terminal branches, without changing BFS order.
+        while (queue.isNotEmpty() && (returned.size < maxNodes || !hasKnownPendingNode())) {
+            ProgressManager.checkCanceled()
+            when (val work = queue.removeFirst()) {
+                is PendingCallNode -> {
+                    val target = work.pointer?.element
+                    if (work.pointer != null && target == null) continue
+                    val metadata = if (target == null || work.modificationCount == modificationCount) {
+                        work.snapshot.copy(children = null)
+                    } else {
+                        refreshCallSnapshot(
+                            project,
+                            target,
+                            work.snapshot,
+                            continuation.direction,
+                            continuation.scope,
+                            continuation.excludeGenerated
+                        )
+                    }
+                    val snapshot = metadata.copy(
+                        symbolId = target?.let {
+                            synchronized(work.handle) {
+                                bindSymbolId(project, it, work.handle.symbolId).also { symbolId ->
+                                    work.handle.symbolId = symbolId
+                                }
+                            }
+                        }
+                    )
+                    returned += snapshot
+                    if (target != null && work.depth < continuation.maxDepth) {
+                        queue.addLast(
+                            PendingCallExpansion(
+                                pointerManager.createSmartPsiElementPointer(PsiUtils.resolveNavigationTarget(target)),
+                                depth = work.depth,
+                                offset = 0
+                            )
+                        )
+                    }
+                }
+
+                is PendingCallExpansion -> {
+                    val lookingAhead = !hasKnownPendingNode()
+                    val pageWorkLimitReached =
+                        discoveredThisPage >= maxNodes || expandedThisPage >= maxNodes
+                    if (pageWorkLimitReached) {
+                        if (!lookingAhead || terminalLookaheadProbes >= TERMINAL_LOOKAHEAD_PROBES) {
+                            queue.addFirst(work)
+                            break
+                        }
+                        terminalLookaheadProbes++
+                    }
+                    expandedThisPage++
+                    val target = work.pointer.element ?: continue
+                    val handler = LanguageHandlerRegistry.getCallHierarchyHandler(target) ?: continue
+                    val scanLimit = (
+                        work.offset.toLong() + (maxNodes - discoveredThisPage).coerceAtLeast(0).toLong() + 1L
+                    ).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+                    val direct = handler.getCallHierarchy(
+                        target,
+                        project,
+                        continuation.direction,
+                        1,
+                        continuation.scope,
+                        continuation.excludeGenerated,
+                        page = HierarchyPageRequest(offset = 0, limit = scanLimit)
+                    ) ?: continue
+                    val pendingChildren = direct.calls.sortedWith(callDataComparator).mapNotNull { child ->
+                        pendingCallNode(
+                            project, pointerManager, child, work.depth + 1, visited, visitedPointers
+                        )
+                    }
+                    discoveredThisPage += maxOf(
+                        (direct.calls.size - work.offset).coerceAtLeast(0),
+                        pendingChildren.size
+                    )
+                    val additions = buildList<CallWork> {
+                        addAll(pendingChildren)
+                        direct.nextOffset?.let { nextOffset ->
+                            if (nextOffset > work.offset) add(work.copy(offset = nextOffset))
+                        }
+                    }
+                    for (addition in additions.asReversed()) queue.addFirst(addition)
+                }
+            }
+        }
+
+        val nextState = continuation.copy(
+            rootPointer = pointerManager.createSmartPsiElementPointer(PsiUtils.resolveNavigationTarget(rootElement)),
+            root = root,
+            frontier = queue.toList(),
+            visited = visited.build(),
+            visitedPointers = visitedPointers.build(),
+            rootModificationCount = modificationCount
+        )
+        val hasMore = nextState.frontier.any { work ->
+            when (work) {
+                is PendingCallNode -> work.pointer == null || work.pointer.element != null
+                is PendingCallExpansion -> work.pointer.element != null
+            }
+        }
+        val nextCursor = if (hasMore) {
+            registry.register(project, generation, nextState, parentCursor, "$maxNodes:$modificationCount").getOrElse {
+                return createErrorResult(it.message ?: "The MCP server session changed")
+            }
+        } else null
+
+        return createJsonResult(
+            CallHierarchyResult(
+                element = root,
+                calls = returned,
+                returnedNodes = returned.size,
+                truncated = hasMore,
+                elapsedMs = System.currentTimeMillis() - startedAt,
+                hasMore = hasMore,
+                cursor = nextCursor
+            )
+        )
+    }
+
+    private fun refreshCallSnapshot(
+        project: Project,
+        target: PsiElement,
+        previous: CallElement,
+        direction: String,
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
+    ): CallElement {
+        val handler = LanguageHandlerRegistry.getCallHierarchyHandler(target) ?: return previous
+        val fresh = handler.getCallHierarchy(
+            target,
+            project,
+            direction,
+            1,
+            scope,
+            excludeGenerated,
+            page = HierarchyPageRequest(offset = 0, limit = 0)
+        )?.element ?: return previous
+        return convertToCallElement(project, fresh, bindHandle = false).copy(symbolId = previous.symbolId)
+    }
+
+    private fun pendingCallNode(
+        project: Project,
+        pointerManager: SmartPointerManager,
+        data: CallElementData,
+        depth: Int,
+        visited: MutableSet<String>,
+        visitedPointers: MutableList<SmartPsiElementPointer<PsiElement>>
+    ): PendingCallNode? {
+        // Growing-prefix pagination re-reads earlier siblings. Undisclosed frontier nodes keep
+        // metadata and exact pointers, and consume a symbol handle only when a page returns them.
+        val unboundSnapshot = convertToCallElement(project, data, bindHandle = false)
+        val target = data.pointerTarget?.let(PsiUtils::resolveNavigationTarget)
+        val pointer = if (target == null) {
+            val key = "${data.language}|${data.file}|${data.line}|${data.column}|${data.name}"
+            if (!visited.add(key)) return null
+            null
+        } else {
+            if (visitedPointers.any { existing ->
+                    existing.element?.let { sameHierarchyDeclaration(it, target) } == true
+                }
+            ) return null
+            // Only a live pointer proves identity for a physical declaration. Signature/name
+            // keys can collide for local/anonymous declarations, and offsets can move on edits.
+            pointerManager.createSmartPsiElementPointer(target).also { pointer ->
+                visitedPointers += pointer
+            }
+        }
+        return PendingCallNode(
+            pointer = pointer,
+            snapshot = unboundSnapshot,
+            depth = depth,
+            modificationCount = PsiModificationTracker.getInstance(project).modificationCount
+        )
+    }
+
+    private val callDataComparator = compareBy<CallElementData>(
+        { it.language },
+        { it.file },
+        { it.line },
+        { it.column },
+        { it.name }
+    )
 
     private fun resolveCallHierarchySeed(project: Project, arguments: JsonObject): Result<com.intellij.psi.PsiElement> {
         val element = resolveElementFromArguments(project, arguments, allowLibraryFilesForPosition = true).getOrElse {
@@ -145,14 +476,27 @@ class CallHierarchyTool : AbstractMcpTool() {
     /**
      * Converts handler CallElementData to tool CallElement.
      */
-    private fun convertToCallElement(data: CallElementData): CallElement {
+    private fun convertToCallElement(
+        project: Project,
+        data: CallElementData,
+        fallbackTarget: com.intellij.psi.PsiElement? = null,
+        preferredSymbolId: String? = null,
+        bindHandle: Boolean = true
+    ): CallElement {
         return CallElement(
             name = data.name,
             file = data.file,
             line = data.line,
             column = data.column,
             language = data.language,
-            children = data.children?.map { convertToCallElement(it) }
+            symbolId = if (bindHandle) {
+                (data.pointerTarget ?: fallbackTarget)?.let {
+                    bindSymbolId(project, it, preferredSymbolId)
+                }
+            } else null,
+            // Hierarchy traversal is flat. Avoid binding handles for nested handler metadata that
+            // is deliberately discarded by the wire model on every call site.
+            children = null
         )
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureTool.kt
@@ -1,9 +1,11 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileStructureResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.StructureNode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.TreeFormatter
@@ -30,7 +32,10 @@ class FileStructureTool : AbstractMcpTool() {
 
         Supports: Java, Kotlin, Python, JavaScript, TypeScript, PHP, Markdown
 
-        Returns: Formatted tree string with element types, modifiers, signatures, and line numbers.
+        Returns: The legacy formatted tree string plus structured nodes with element types,
+        modifiers, signatures, source ranges, children, and optional symbolId handles. All nodes
+        are returned; at most 500 handles are allocated per response. symbolIdsTruncated and
+        symbolIdsOmitted report nodes whose optional handle was omitted by this budget.
 
         Parameters: file (required) - Path relative to project root
 
@@ -61,22 +66,54 @@ class FileStructureTool : AbstractMcpTool() {
             // Extract structure
             val nodes = handler.getFileStructure(psiFile, project)
 
-            if (nodes.isEmpty()) {
-                return@suspendingReadAction createSuccessResult(
-                    "File is empty or has no parseable structure.\n\n" +
+            // Preserve the previous human-readable payload even when no nodes were found.
+            val treeString = if (nodes.isEmpty()) {
+                "File is empty or has no parseable structure.\n\n" +
                     "File: ${psiFile.name}\n" +
                     "Language: ${psiFile.language.id}"
-                )
+            } else {
+                TreeFormatter.format(nodes, psiFile.name, psiFile.language.id)
             }
-
-            // Format as tree
-            val treeString = TreeFormatter.format(nodes, psiFile.name, psiFile.language.id)
+            val bindingBudget = StructureBindingBudget(SymbolIdRegistry.getInstance().responseHandleBudget)
+            val structuredNodes = bindStructureNodes(project, nodes, bindingBudget)
 
             createJsonResult(FileStructureResult(
                 file = file,
                 language = psiFile.language.id,
-                structure = treeString
+                structure = treeString,
+                nodes = structuredNodes,
+                symbolIdsTruncated = bindingBudget.omitted > 0,
+                symbolIdsOmitted = bindingBudget.omitted
             ))
         }
     }
+
+    /**
+     * Attaches handles while the exact PSI elements produced by the language handler are still
+     * available. Re-resolving a node later by line would be ambiguous for overloads and nested
+     * declarations that share a line.
+     */
+    private class StructureBindingBudget(var remaining: Int, var omitted: Int = 0)
+
+    private fun bindStructureNodes(
+        project: Project,
+        nodes: List<StructureNode>,
+        budget: StructureBindingBudget
+    ): List<StructureNode> =
+        nodes.map { node ->
+            // Preorder gives containers a handle before their descendants. Keep the complete
+            // outline, but never evict IDs from this same response by overfilling the registry.
+            val target = node.pointerTarget?.takeIf { it.isValid }
+            val symbolId = if (target == null) null else if (budget.remaining > 0) {
+                budget.remaining--
+                bindSymbolId(project, target)
+            } else {
+                budget.omitted++
+                null
+            }
+            node.copy(
+                children = bindStructureNodes(project, node.children, budget),
+                symbolId = symbolId
+            )
+        }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindClassTool.kt
@@ -7,7 +7,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScop
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindClassResult
@@ -15,6 +14,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SymbolMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.ChooseByNameContributorEx
 import com.intellij.navigation.NavigationItem
@@ -24,7 +24,7 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.SmartPointerManager
 import com.intellij.psi.codeStyle.MinusculeMatcher
 import com.intellij.psi.codeStyle.NameUtil
 import com.intellij.psi.search.GlobalSearchScope
@@ -149,7 +149,10 @@ class FindClassTool : AbstractMcpTool() {
             val serializedResults = sortedClasses.map { cls ->
                 PaginationService.SerializedResult(
                     key = "${cls.file}:${cls.line}:${cls.column}:${cls.name}",
-                    data = json.encodeToJsonElement(cls)
+                    data = json.encodeToJsonElement(cls),
+                    symbolPointer = cls.pointerTarget?.let {
+                        SmartPointerManager.getInstance(project).createSmartPsiElementPointer(it)
+                    }
                 )
             }
 
@@ -160,7 +163,7 @@ class FindClassTool : AbstractMcpTool() {
                 seenKeys = serializedResults.map { it.key }.toSet(),
                 searchExtender = searchExtender,
                 psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-                projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+                project = project,
                 metadata = mapOf("query" to query)
             )
         }
@@ -209,7 +212,10 @@ class FindClassTool : AbstractMcpTool() {
             .map { cls ->
                 PaginationService.SerializedResult(
                     key = "${cls.file}:${cls.line}:${cls.column}:${cls.name}",
-                    data = json.encodeToJsonElement(cls)
+                    data = json.encodeToJsonElement(cls),
+                    symbolPointer = cls.pointerTarget?.let {
+                        SmartPointerManager.getInstance(project).createSmartPsiElementPointer(it)
+                    }
                 )
             }
     }
@@ -346,30 +352,16 @@ class FindClassTool : AbstractMcpTool() {
         if (!scope.contains(file)) return null
         val relativePath = ProjectUtils.getToolFilePath(project, file)
 
-        val name = when (targetElement) {
-            is PsiNamedElement -> targetElement.name
-            else -> {
-                try {
-                    val method = targetElement.javaClass.getMethod("getName")
-                    method.invoke(targetElement) as? String
-                } catch (_: Exception) {
-                    null
-                }
-            }
-        } ?: return null
+        val name = PsiUtils.classDisplayName(project, targetElement) ?: return null
 
-        val qualifiedName = try {
-            val method = targetElement.javaClass.getMethod("getQualifiedName")
-            method.invoke(targetElement) as? String
-        } catch (e: Exception) {
-            null
-        }
+        val qualifiedName = PsiUtils.qualifiedName(targetElement)
 
         val line = getLineNumber(project, targetElement) ?: 1
         val kind = determineKind(targetElement)
         val language = getLanguageName(targetElement)
 
         return SymbolMatch(
+            symbolId = PaginationService.UNMATERIALIZED_SYMBOL_ID,
             name = name,
             qualifiedName = qualifiedName,
             kind = kind,
@@ -377,7 +369,8 @@ class FindClassTool : AbstractMcpTool() {
             line = line,
             column = getColumnNumber(project, targetElement) ?: 1,
             containerName = null,
-            language = language
+            language = language,
+            pointerTarget = targetElement
         )
     }
 
@@ -410,6 +403,8 @@ class FindClassTool : AbstractMcpTool() {
     }
 
     private fun determineKind(element: PsiElement): String {
+        PsiUtils.kotlinClassKind(element)?.let { return it }
+
         fun probe(methodName: String): Boolean = try {
             element.javaClass.getMethod(methodName).invoke(element) == true
         } catch (_: Exception) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindDefinitionTool.kt
@@ -21,6 +21,8 @@ import kotlinx.serialization.json.jsonPrimitive
 
 class FindDefinitionTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     companion object {
         private const val DEFAULT_MAX_PREVIEW_LINES = 50
         private const val MAX_ALLOWED_PREVIEW_LINES = 500
@@ -34,6 +36,7 @@ class FindDefinitionTool : AbstractMcpTool() {
         Returns: file path, line/column of definition, code preview, and symbol name.
 
         Target (mutually exclusive):
+        - symbolId: opaque handle returned by a previous semantic call
         - file + line + column: position-based lookup
         - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
@@ -45,6 +48,8 @@ class FindDefinitionTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
         .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
@@ -78,6 +83,11 @@ class FindDefinitionTool : AbstractMcpTool() {
             if (effectiveTarget is PsiDirectory) {
                 val dirPath = getRelativePath(project, effectiveTarget.virtualFile)
                 return@suspendingReadAction createJsonResult(DefinitionResult(
+                    symbolId = bindSymbolId(
+                        project,
+                        effectiveTarget,
+                        optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+                    ),
                     file = dirPath,
                     line = 1,
                     column = 1,
@@ -99,6 +109,11 @@ class FindDefinitionTool : AbstractMcpTool() {
                     if (dir != null) {
                         val dirPath = getRelativePath(project, dir.virtualFile)
                         return@suspendingReadAction createJsonResult(DefinitionResult(
+                            symbolId = bindSymbolId(
+                                project,
+                                effectiveTarget,
+                                optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+                            ),
                             file = dirPath,
                             line = 1,
                             column = 1,
@@ -156,6 +171,11 @@ class FindDefinitionTool : AbstractMcpTool() {
             }
 
             createJsonResult(DefinitionResult(
+                symbolId = bindSymbolId(
+                    project,
+                    effectiveTarget,
+                    optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+                ),
                 file = getRelativePath(project, targetFile),
                 line = targetLine,
                 column = targetColumn,

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindFileTool.kt
@@ -5,7 +5,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScopeResolver
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileMatch
@@ -146,7 +145,7 @@ class FindFileTool : AbstractMcpTool() {
                 seenKeys = serializedResults.map { it.key }.toSet(),
                 searchExtender = searchExtender,
                 psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-                projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+                project = project,
                 metadata = mapOf("query" to query)
             )
         }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindImplementationsTool.kt
@@ -6,7 +6,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScop
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScopeResolver
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ImplementationLocation
@@ -15,6 +14,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.SmartPointerManager
 import com.intellij.psi.util.PsiModificationTracker
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonElement
@@ -34,6 +34,8 @@ import kotlinx.serialization.json.put
  */
 class FindImplementationsTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     companion object {
         private const val DEFAULT_PAGE_SIZE = 100
         private const val MAX_PAGE_SIZE = PaginationService.MAX_PAGE_SIZE
@@ -51,6 +53,7 @@ class FindImplementationsTool : AbstractMcpTool() {
         Supports pagination: first call returns results + nextCursor. Pass cursor to get the next page.
 
         Target (mutually exclusive):
+        - symbolId: opaque handle returned by a previous semantic call (necessary for fresh search, ignored when cursor is provided)
         - file + line + column: position-based lookup (necessary for fresh search, ignored when cursor is provided)
         - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()}; necessary for fresh search, ignored when cursor is provided)
         - cursor: pagination cursor from a previous response
@@ -65,6 +68,8 @@ class FindImplementationsTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
         .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
@@ -133,14 +138,20 @@ class FindImplementationsTool : AbstractMcpTool() {
                     line = impl.line,
                     column = impl.column,
                     kind = impl.kind,
-                    language = impl.language
+                    language = impl.language,
+                    qualifiedName = impl.qualifiedName,
+                    symbolId = null,
+                    pointerTarget = impl.pointerTarget
                 )
             }
 
             val serializedResults = implementationLocations.map { impl ->
                 PaginationService.SerializedResult(
                     key = "${impl.file}:${impl.line}:${impl.column}:${impl.name}",
-                    data = json.encodeToJsonElement(impl)
+                    data = json.encodeToJsonElement(impl),
+                    symbolPointer = impl.pointerTarget?.let {
+                        SmartPointerManager.getInstance(project).createSmartPsiElementPointer(it)
+                    }
                 )
             }
 
@@ -151,7 +162,7 @@ class FindImplementationsTool : AbstractMcpTool() {
                 seenKeys = serializedResults.map { it.key }.toSet(),
                 searchExtender = null,
                 psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-                projectBasePath = ProjectResolver.normalizePath(project.basePath ?: "")
+                project = project
             )
 
             token to null

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSuperMethodsTool.kt
@@ -23,6 +23,8 @@ import kotlinx.serialization.json.JsonObject
  */
 class FindSuperMethodsTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     override val name = ToolNames.FIND_SUPER_METHODS
 
     override val description = """
@@ -35,6 +37,7 @@ class FindSuperMethodsTool : AbstractMcpTool() {
         Returns: full hierarchy chain from immediate parent (depth=1) to root, with file locations (line/column) and containing class info.
 
         Target (mutually exclusive):
+        - symbolId: opaque handle returned by a previous semantic call
         - file + line + column: position-based lookup (position can be anywhere within the method body)
         - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
@@ -46,6 +49,8 @@ class FindSuperMethodsTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
         .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
@@ -86,7 +91,12 @@ class FindSuperMethodsTool : AbstractMcpTool() {
                     file = superMethodsData.method.file,
                     line = superMethodsData.method.line,
                     column = superMethodsData.method.column,
-                    language = superMethodsData.method.language
+                    language = superMethodsData.method.language,
+                    symbolId = bindSymbolId(
+                        project,
+                        superMethodsData.method.pointerTarget ?: element,
+                        optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+                    )
                 ),
                 hierarchy = superMethodsData.hierarchy.map { superMethod ->
                     SuperMethodInfo(
@@ -99,7 +109,8 @@ class FindSuperMethodsTool : AbstractMcpTool() {
                         column = superMethod.column,
                         isInterface = superMethod.isInterface,
                         depth = superMethod.depth,
-                        language = superMethod.language
+                        language = superMethod.language,
+                        symbolId = superMethod.pointerTarget?.let { bindSymbolId(project, it) }
                     )
                 },
                 totalCount = superMethodsData.hierarchy.size

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindSymbolTool.kt
@@ -7,7 +7,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScop
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.OptimizedSymbolSearch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.SymbolData
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindSymbolResult
@@ -16,6 +15,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.SmartPointerManager
 import com.intellij.psi.util.PsiModificationTracker
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonElement
@@ -117,7 +117,6 @@ class FindSymbolTool : AbstractMcpTool() {
                 limit = collectLimit,
                 languageFilter = nativeLanguageFilter
             )
-
             val matches = symbols.map { it.toSymbolMatch() }
 
             val searchExtender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = { seenKeys, limit ->
@@ -129,7 +128,10 @@ class FindSymbolTool : AbstractMcpTool() {
             val serializedResults = matches.map { sym ->
                 PaginationService.SerializedResult(
                     key = sym.paginationKey(),
-                    data = json.encodeToJsonElement(sym)
+                    data = json.encodeToJsonElement(sym),
+                    symbolPointer = sym.pointerTarget?.let {
+                        SmartPointerManager.getInstance(project).createSmartPsiElementPointer(it)
+                    }
                 )
             }
 
@@ -140,7 +142,7 @@ class FindSymbolTool : AbstractMcpTool() {
                 seenKeys = serializedResults.map { it.key }.toSet(),
                 searchExtender = searchExtender,
                 psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-                projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+                project = project,
                 metadata = mapOf("query" to query)
             )
         }
@@ -191,7 +193,10 @@ class FindSymbolTool : AbstractMcpTool() {
             .map { sym ->
                 PaginationService.SerializedResult(
                     key = sym.paginationKey(),
-                    data = json.encodeToJsonElement(sym)
+                    data = json.encodeToJsonElement(sym),
+                    symbolPointer = sym.pointerTarget?.let {
+                        SmartPointerManager.getInstance(project).createSmartPsiElementPointer(it)
+                    }
                 )
             }
             .toList()
@@ -205,7 +210,9 @@ class FindSymbolTool : AbstractMcpTool() {
         line = line,
         column = column,
         containerName = containerName,
-        language = language
+        language = language,
+        symbolId = PaginationService.UNMATERIALIZED_SYMBOL_ID,
+        pointerTarget = pointerTarget
     )
 
     private fun SymbolMatch.paginationKey(): String = "$file:$line:$column:$name"

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FindUsagesTool.kt
@@ -10,7 +10,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScop
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.PathGlobMatcher
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.PathGlobScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindUsagesResult
@@ -45,6 +44,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 class FindUsagesTool : AbstractMcpTool() {
+
+    override val supportsUnifiedTarget: Boolean = true
 
     companion object {
         private val LOG = logger<FindUsagesTool>()
@@ -81,6 +82,7 @@ class FindUsagesTool : AbstractMcpTool() {
         Supports pagination: first call returns results + nextCursor. Pass cursor to get the next page.
 
         Target (mutually exclusive):
+        - symbolId: opaque handle returned by a previous semantic call (necessary for fresh search, ignored when cursor is provided)
         - file + line + column: position-based lookup (necessary for fresh search, ignored when cursor is provided)
         - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()}; necessary for fresh search, ignored when cursor is provided)
         - cursor: pagination cursor from a previous response
@@ -96,6 +98,8 @@ class FindUsagesTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
         .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
@@ -161,16 +165,10 @@ class FindUsagesTool : AbstractMcpTool() {
             // Echo the declaration actually searched: position-based lookup snaps comments and
             // whitespace to the nearest enclosing named element, and without this echo that
             // snap is invisible to the caller.
-            val nav = targetElement.navigationElement ?: targetElement
-            val declFile = nav.containingFile?.virtualFile
-            val declDoc = nav.containingFile?.let { PsiDocumentManager.getInstance(project).getDocument(it) }
-            val resolvedInfo = ResolvedSymbolInfo(
-                name = (targetElement as? PsiNamedElement)?.name,
-                kind = UsageViewUtil.getType(targetElement).takeIf { it.isNotBlank() },
-                container = PsiUtils.qualifiedName(targetElement)
-                    ?: PsiUtils.getAstPath(nav).joinToString(".").ifEmpty { null },
-                file = declFile?.let { getRelativePath(project, it) },
-                line = declDoc?.getLineNumber(nav.textOffset)?.plus(1)
+            val resolvedInfo = resolvedSymbolInfo(
+                project,
+                targetElement,
+                optionalStringArg(arguments, ParamNames.SYMBOL_ID)
             )
 
             val usages = ConcurrentLinkedQueue<UsageLocation>()
@@ -256,10 +254,15 @@ class FindUsagesTool : AbstractMcpTool() {
                 seenKeys = serializedResults.map { it.key }.toSet(),
                 searchExtender = searchExtender,
                 psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-                projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
-                metadata = mapOf(
-                    METADATA_RESOLVED_SYMBOL to json.encodeToString(resolvedInfo),
-                    METADATA_SEARCH_EXHAUSTED to searchExhausted.toString()
+                project = project,
+                metadata = mapOf(METADATA_SEARCH_EXHAUSTED to searchExhausted.toString()),
+                serializedMetadata = mapOf(
+                    METADATA_RESOLVED_SYMBOL to PaginationService.SerializedResult(
+                        key = METADATA_RESOLVED_SYMBOL,
+                        data = json.encodeToJsonElement(resolvedInfo),
+                        symbolPointer = smartPointer,
+                        materializedSymbolId = resolvedInfo.symbolId
+                    )
                 )
             )
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/HierarchyNodeIdentity.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/HierarchyNodeIdentity.kt
@@ -1,0 +1,20 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
+import com.intellij.psi.PsiElement
+
+/** Compares restored declarations, not public handles or non-unique display signatures. */
+internal fun sameHierarchyDeclaration(first: PsiElement, second: PsiElement): Boolean {
+    val left = PsiUtils.resolveNavigationTarget(first)
+    val right = PsiUtils.resolveNavigationTarget(second)
+    if (left === right) return true
+
+    val leftFile = left.containingFile?.virtualFile
+    val rightFile = right.containingFile?.virtualFile
+    if (leftFile != null && rightFile != null && left.isPhysical && right.isPhysical) {
+        // Both offsets are read from current PSI restored through smart pointers. A line shift
+        // updates both sides, while equally named local/anonymous declarations remain distinct.
+        return leftFile == rightFile && left.textOffset == right.textOffset && left.javaClass == right.javaClass
+    }
+    return left.manager.areElementsEquivalent(left, right)
+}

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SearchTextTool.kt
@@ -7,7 +7,6 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.PathGlobMatcher
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.PathGlobScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.createFilteredScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
-import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.ProjectResolver
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SearchTextResult
@@ -177,7 +176,7 @@ class SearchTextTool : AbstractMcpTool() {
             seenKeys = serializedResults.map { it.key }.toSet(),
             searchExtender = searchExtender,
             psiModCount = PsiModificationTracker.getInstance(project).modificationCount,
-            projectBasePath = ProjectResolver.normalizePath(project.basePath ?: ""),
+            project = project,
             metadata = buildMap {
                 put("query", query)
                 put("regex", regex.toString())

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SymbolInfoTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SymbolInfoTool.kt
@@ -33,6 +33,8 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 class SymbolInfoTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     companion object {
         private const val DEFAULT_MAX_DOC_LENGTH = 4000
         private const val MAX_ALLOWED_DOC_LENGTH = 20000
@@ -51,6 +53,7 @@ class SymbolInfoTool : AbstractMcpTool() {
         Prefer this over ide_find_definition + reading the file when you only need the signature or the docs.
 
         Target (mutually exclusive):
+        - symbolId: opaque handle returned by a previous semantic call
         - file + line + column: position-based lookup, so overloads are addressable
         - language + symbol: fully qualified symbol reference (supported languages: ${supportedSymbolReferenceLanguagesDescription()})
 
@@ -61,6 +64,8 @@ class SymbolInfoTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
         .file(required = false, description = "Project-relative file path, or a dependency/library absolute path or jar:// URL previously returned by the plugin. Required for position-based lookup.")
         .lineAndColumn(required = false)
         .languageAndSymbol(required = false)
@@ -95,7 +100,16 @@ class SymbolInfoTool : AbstractMcpTool() {
             // List<Request> reports Request rather than the type variable E.
             val originalElement = element.takeIf { it !== target }
 
-            createJsonResult(buildResult(project, target, originalElement, includeDoc, maxDocLength))
+            createJsonResult(
+                buildResult(
+                    project,
+                    target,
+                    originalElement,
+                    includeDoc,
+                    maxDocLength,
+                    optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+                )
+            )
         }
     }
 
@@ -104,7 +118,8 @@ class SymbolInfoTool : AbstractMcpTool() {
         target: PsiElement,
         originalElement: PsiElement?,
         includeDoc: Boolean,
-        maxDocLength: Int
+        maxDocLength: Int,
+        preferredSymbolId: String?
     ): SymbolInfoResult {
         val name = (target as? PsiNamedElement)?.name ?: target.text.orEmpty().take(80)
         val resolved = SymbolSignatureResolver.resolve(target, originalElement)
@@ -119,6 +134,7 @@ class SymbolInfoTool : AbstractMcpTool() {
         val position = PsiSourcePosition.position(project, target)
 
         return SymbolInfoResult(
+            symbolId = bindSymbolId(project, target, preferredSymbolId),
             name = name,
             kind = UsageViewUtil.getType(target).takeIf { it.isNotBlank() },
             qualifiedName = qualifiedName(target, name, resolved),

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyTool.kt
@@ -1,28 +1,40 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScopeResolver
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.HierarchyPageRequest
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.OptimizedSymbolSearch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeElementData
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyDirection
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.PendingTypeExpansion
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.PendingTypeNode
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.TypeContinuation
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.TypeWork
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeElement
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyTraversalNode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.PsiModificationTracker
+import java.util.ArrayDeque
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 
 /**
  * Tool for retrieving type hierarchies across multiple languages.
@@ -33,9 +45,14 @@ import kotlinx.serialization.json.put
  */
 class TypeHierarchyTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     companion object {
         private val JS_TS_LANGUAGE_FILTER = setOf("JavaScript", "TypeScript")
         private val TYPE_SYMBOL_KINDS = setOf("CLASS", "INTERFACE")
+        private const val DEFAULT_MAX_NODES = 100
+        private const val MAX_NODES = 500
+        private const val TERMINAL_LOOKAHEAD_PROBES = 1
     }
 
     override val name = "ide_type_hierarchy"
@@ -47,24 +64,51 @@ class TypeHierarchyTool : AbstractMcpTool() {
 
         Rust note: className parameter not supported for Rust; use file + line + column instead.
 
-        Returns: target class info, full supertype chain (recursive), and all subtypes in the project.
+        Returns deterministic breadth-first pages containing target class info, supertypes, subtypes, symbolId handles, and pagination metadata. Live progress is not available on stateless HTTP; continue with cursor.
 
-        Parameters: Either className (e.g., "com.example.MyClass" for Java/PHP-style FQNs or "MyComponent" for JavaScript/TypeScript symbols) OR file + line + column. scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files).
+        Parameters for a fresh query: either symbolId, className (e.g., "com.example.MyClass" for Java/PHP-style FQNs or "MyComponent" for JavaScript/TypeScript symbols), OR file + line + column. maxNodes (optional, default: 100, max: 500), scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files). For the next page, pass cursor; other search parameters are ignored.
 
         Example: {"className": "com.example.UserService", "scope": "project_and_libraries"} or {"file": "src/MyClass.java", "line": 10, "column": 14}
     """.trimIndent()
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
+        .target()
+        .symbolId()
+        .languageAndSymbol(required = false)
         .stringProperty("className", "Fully qualified class name for JVM/PHP-style languages or simple class/interface name for JavaScript/TypeScript (e.g., 'com.example.MyClass', 'App\\\\Models\\\\User', or 'MyComponent').")
         .file(required = false, description = "Path to file relative to project root (e.g., 'src/main/java/com/example/MyClass.java'). Use with line and column.")
         .intProperty("line", "1-based line number where the class is defined. Required if using file parameter.")
         .intProperty("column", "1-based column number. Required if using file parameter.")
+        .intProperty("maxNodes", "Maximum hierarchy nodes returned and expanded in this page. Default: 100, max: 500.")
+        .stringProperty("cursor", "Opaque session/project-bound continuation from the previous hierarchy page. Other search parameters are ignored.")
         .scopeProperty("Search scope. Default: project_files.")
         .booleanProperty(ParamNames.INCLUDE_GENERATED, "Include supertypes/subtypes defined in generated sources (KSP/Dagger/annotation-processor output). Default: true — keep generated types in the hierarchy.")
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
+        val startedAt = System.currentTimeMillis()
+        val maxNodes = arguments["maxNodes"]?.jsonPrimitive?.intOrNull ?: DEFAULT_MAX_NODES
+        if (maxNodes !in 1..MAX_NODES) {
+            return createErrorResult("maxNodes must be between 1 and $MAX_NODES")
+        }
+
+        val cursor = optionalStringArg(arguments, ParamNames.CURSOR)
+        val continuationRegistry = HierarchyContinuationRegistry.getInstance()
+        if (cursor != null) {
+            requireSmartMode(project)
+            val lease = continuationRegistry.resolveLease(project, cursor).getOrElse {
+                return createErrorResult(it.message ?: "Hierarchy cursor expired")
+            }
+            val continuation = lease.continuation as? TypeContinuation
+                ?: return createErrorResult("Cursor belongs to a different hierarchy tool. Start ide_type_hierarchy again without cursor.")
+            return suspendingReadAction {
+                buildTypePage(project, continuation, maxNodes, startedAt, lease.generation, cursor)
+            }
+        }
+
+        val generation = continuationRegistry.currentGeneration()
+
         requireSmartMode(project)
 
         val className = arguments["className"]?.jsonPrimitive?.content
@@ -81,12 +125,15 @@ class TypeHierarchyTool : AbstractMcpTool() {
         return suspendingReadAction {
             ProgressManager.checkCanceled() // Allow cancellation
 
-            val element = resolveTargetElement(project, arguments, scope)
-            if (element == null) {
+            val elementResult = resolveTargetElement(project, arguments, scope)
+            val element = elementResult.getOrElse { error ->
+                if (optionalStringArg(arguments, ParamNames.SYMBOL_ID) != null) {
+                    return@suspendingReadAction createErrorResult(error.message ?: "SYMBOL_ID_EXPIRED")
+                }
                 val errorMsg = when {
                     className != null -> "Class '$className' not found in project '${project.name}'. Verify the fully qualified name is correct and the class is part of this project."
                     file != null -> "No class found at the specified file/line/column position."
-                    else -> "Provide either 'className' (e.g., 'com.example.MyClass') or 'file' + 'line' + 'column'."
+                    else -> "Provide 'symbolId', 'className' (e.g., 'com.example.MyClass'), or 'file' + 'line' + 'column'."
                 }
                 return@suspendingReadAction createErrorResult(errorMsg)
             }
@@ -102,37 +149,356 @@ class TypeHierarchyTool : AbstractMcpTool() {
 
             ProgressManager.checkCanceled() // Allow cancellation before heavy operation
 
-            val hierarchyData = handler.getTypeHierarchy(element, project, scope, excludeGenerated)
+            // Ask the language adapter for exactly one edge. The tool owns the bounded BFS and
+            // never lets a handler recursively materialize the complete graph.
+            val hierarchyData = handler.getTypeHierarchy(
+                element,
+                project,
+                scope,
+                excludeGenerated,
+                directOnly = true,
+                direction = TypeHierarchyDirection.SUPERTYPE,
+                page = HierarchyPageRequest(offset = 0, limit = maxNodes + 1)
+            )
             if (hierarchyData == null) {
                 return@suspendingReadAction createErrorResult("No class/type found at the specified position.")
             }
 
-            // Convert handler result to tool result
-            createJsonResult(TypeHierarchyResult(
-                element = convertToTypeElement(hierarchyData.element),
-                supertypes = hierarchyData.supertypes.map { convertToTypeElement(it) },
-                subtypes = hierarchyData.subtypes.map { convertToTypeElement(it) }
-            ))
+            val pointerManager = SmartPointerManager.getInstance(project)
+            val modificationCount = PsiModificationTracker.getInstance(project).modificationCount
+            val root = convertToTypeElement(
+                project,
+                hierarchyData.element,
+                element,
+                optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+            ).copy(supertypes = null)
+            // Position lookup may start on a reference leaf. The handler has already resolved
+            // that leaf to the semantic class declaration; bind the continuation to that exact
+            // declaration so deleting/moving the referencing file does not invalidate the root.
+            val rootTarget = PsiUtils.resolveNavigationTarget(
+                hierarchyData.element.pointerTarget ?: element
+            )
+            val visited = linkedSetOf<String>()
+            val rootPointer = pointerManager.createSmartPsiElementPointer(rootTarget)
+            val visitedPointers = mutableListOf<SmartPsiElementPointer<PsiElement>>(rootPointer)
+            val frontier = buildList<TypeWork> {
+                hierarchyData.supertypes
+                    .sortedWith(typeDataComparator)
+                    .mapNotNullTo(this) { data ->
+                        pendingTypeNode(
+                            project, pointerManager, data, TypeHierarchyDirection.SUPERTYPE, visited, visitedPointers
+                        )
+                    }
+                hierarchyData.nextOffset?.let { offset ->
+                    add(PendingTypeExpansion(rootPointer, TypeHierarchyDirection.SUPERTYPE, offset))
+                }
+                // Subtypes are loaded lazily. This keeps initial work bounded even when both
+                // sides of the hierarchy are very wide.
+                add(PendingTypeExpansion(rootPointer, TypeHierarchyDirection.SUBTYPE, 0))
+            }
+            val continuation = TypeContinuation(
+                rootPointer = rootPointer,
+                root = root,
+                frontier = frontier,
+                visited = visited,
+                visitedPointers = visitedPointers,
+                scope = scope,
+                excludeGenerated = excludeGenerated,
+                rootModificationCount = modificationCount
+            )
+            buildTypePage(project, continuation, maxNodes, startedAt, generation)
         }
     }
 
+    private fun buildTypePage(
+        project: Project,
+        continuation: TypeContinuation,
+        maxNodes: Int,
+        startedAt: Long,
+        generation: Long,
+        parentCursor: String? = null
+    ): CallToolResult {
+        val registry = HierarchyContinuationRegistry.getInstance()
+        if (!registry.isCurrentGeneration(generation)) {
+            return createErrorResult("The MCP server session changed. Start the hierarchy query again without cursor.")
+        }
+        val rootElement = continuation.rootPointer.element
+            ?: return createErrorResult("Hierarchy target was deleted or became invalid. Start the query again without cursor.")
+        val pointerManager = SmartPointerManager.getInstance(project)
+        val queue = ArrayDeque(continuation.frontier)
+        val visited = continuation.visited.toPersistentSet().builder()
+        val visitedPointers = continuation.visitedPointers.toPersistentList().builder()
+        val returnedSupertypes = mutableListOf<TypeElement>()
+        val returnedSubtypes = mutableListOf<TypeElement>()
+        val traversal = mutableListOf<TypeHierarchyTraversalNode>()
+        var discoveredThisPage = 0
+        var expandedThisPage = 0
+        var terminalLookaheadProbes = 0
+        val modificationCount = PsiModificationTracker.getInstance(project).modificationCount
 
+        val rootSnapshot = if (continuation.rootModificationCount == modificationCount) continuation.root else {
+            refreshTypeSnapshot(
+                project,
+                rootElement,
+                continuation.root,
+                TypeHierarchyDirection.SUPERTYPE,
+                continuation.scope,
+                continuation.excludeGenerated
+            )
+        }
+        // Cursor retention is independent of symbol LRU/TTL. Materialize handles on every page,
+        // including retries and unchanged PSI, rather than returning a stale cached token.
+        val root = rootSnapshot.copy(symbolId = synchronized(continuation.rootHandle) {
+            bindSymbolId(project, rootElement, continuation.rootHandle.symbolId).also {
+                continuation.rootHandle.symbolId = it
+            }
+        })
 
-    private fun resolveTargetElement(project: Project, arguments: JsonObject, scope: BuiltInSearchScope): PsiElement? {
+        fun returnedCount(): Int = returnedSupertypes.size + returnedSubtypes.size
+
+        fun hasKnownPendingNode(): Boolean = queue.any { work ->
+            work is PendingTypeNode && (work.pointer == null || work.pointer.element != null)
+        }
+
+        // Resolve terminal edge probes eagerly when the page budget permits, but never let a wide
+        // or stale expansion-only frontier turn one MCP call into unbounded work. If the hard cap
+        // is reached, the remaining probes stay in the cursor; a continuation page may therefore
+        // return zero nodes while it retires terminal branches, without changing BFS order.
+        while (queue.isNotEmpty() && (returnedCount() < maxNodes || !hasKnownPendingNode())) {
+            ProgressManager.checkCanceled()
+            when (val work = queue.removeFirst()) {
+                is PendingTypeNode -> {
+                    val target = work.pointer?.element
+                    if (work.pointer != null && target == null) continue
+                    val metadata = if (target == null || work.modificationCount == modificationCount) {
+                        work.snapshot.copy(supertypes = null)
+                    } else {
+                        refreshTypeSnapshot(
+                            project,
+                            target,
+                            work.snapshot,
+                            work.direction,
+                            continuation.scope,
+                            continuation.excludeGenerated
+                        )
+                    }
+                    val snapshot = metadata.copy(
+                        symbolId = target?.let {
+                            synchronized(work.handle) {
+                                bindSymbolId(project, it, work.handle.symbolId).also { symbolId ->
+                                    work.handle.symbolId = symbolId
+                                }
+                            }
+                        }
+                    )
+                    when (work.direction) {
+                        TypeHierarchyDirection.SUPERTYPE -> returnedSupertypes.add(snapshot)
+                        TypeHierarchyDirection.SUBTYPE -> returnedSubtypes.add(snapshot)
+                    }
+                    traversal += TypeHierarchyTraversalNode(
+                        direction = work.direction.name.lowercase(),
+                        element = snapshot
+                    )
+                    if (target != null) {
+                        queue.addLast(
+                            PendingTypeExpansion(
+                                pointerManager.createSmartPsiElementPointer(PsiUtils.resolveNavigationTarget(target)),
+                                work.direction,
+                                0
+                            )
+                        )
+                    }
+                }
+
+                is PendingTypeExpansion -> {
+                    val lookingAhead = !hasKnownPendingNode()
+                    val pageWorkLimitReached =
+                        discoveredThisPage >= maxNodes || expandedThisPage >= maxNodes
+                    if (pageWorkLimitReached) {
+                        if (!lookingAhead || terminalLookaheadProbes >= TERMINAL_LOOKAHEAD_PROBES) {
+                            queue.addFirst(work)
+                            break
+                        }
+                        terminalLookaheadProbes++
+                    }
+                    expandedThisPage++
+                    val target = work.pointer.element ?: continue
+                    val handler = LanguageHandlerRegistry.getTypeHierarchyHandler(target) ?: continue
+                    val scanLimit = (
+                        work.offset.toLong() + (maxNodes - discoveredThisPage).coerceAtLeast(0).toLong() + 1L
+                    ).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+                    val direct = handler.getTypeHierarchy(
+                        target,
+                        project,
+                        continuation.scope,
+                        continuation.excludeGenerated,
+                        directOnly = true,
+                        direction = work.direction,
+                        // Re-read an ever larger prefix and filter it by smart-pointer identity.
+                        // A raw offset is not stable when a declaration is renamed or moved
+                        // between pages: an item can cross the offset and be lost forever.
+                        page = HierarchyPageRequest(offset = 0, limit = scanLimit)
+                    ) ?: continue
+                    val children = when (work.direction) {
+                        TypeHierarchyDirection.SUPERTYPE -> direct.supertypes
+                        TypeHierarchyDirection.SUBTYPE -> direct.subtypes
+                    }
+                    // Normalize only the bounded prefix returned by the handler. A global lexical
+                    // sibling sort would require exhausting a potentially unbounded index query;
+                    // cross-page order instead follows stable bounded discovery windows.
+                    val pendingChildren = children.sortedWith(typeDataComparator).mapNotNull { child ->
+                        pendingTypeNode(
+                            project, pointerManager, child, work.direction, visited, visitedPointers
+                        )
+                    }
+                    discoveredThisPage += maxOf(
+                        (children.size - work.offset).coerceAtLeast(0),
+                        pendingChildren.size
+                    )
+                    val additions = buildList<TypeWork> {
+                        addAll(pendingChildren)
+                        direct.nextOffset?.let { nextOffset ->
+                            // A non-advancing continuation would create an endless cursor chain.
+                            if (nextOffset > work.offset) add(work.copy(offset = nextOffset))
+                        }
+                    }
+                    for (addition in additions.asReversed()) queue.addFirst(addition)
+                }
+            }
+        }
+
+        val nextState = continuation.copy(
+            rootPointer = pointerManager.createSmartPsiElementPointer(PsiUtils.resolveNavigationTarget(rootElement)),
+            root = root,
+            frontier = queue.toList(),
+            visited = visited.build(),
+            visitedPointers = visitedPointers.build(),
+            rootModificationCount = modificationCount
+        )
+        val hasMore = nextState.frontier.any { work ->
+            when (work) {
+                is PendingTypeNode -> work.pointer == null || work.pointer.element != null
+                is PendingTypeExpansion -> work.pointer.element != null
+            }
+        }
+        val nextCursor = if (hasMore) {
+            registry.register(project, generation, nextState, parentCursor, "$maxNodes:$modificationCount").getOrElse {
+                return createErrorResult(it.message ?: "The MCP server session changed")
+            }
+        } else null
+        val returnedNodes = returnedCount()
+
+        return createJsonResult(
+            TypeHierarchyResult(
+                element = root,
+                supertypes = returnedSupertypes,
+                subtypes = returnedSubtypes,
+                traversal = traversal,
+                returnedNodes = returnedNodes,
+                truncated = hasMore,
+                elapsedMs = System.currentTimeMillis() - startedAt,
+                hasMore = hasMore,
+                cursor = nextCursor
+            )
+        )
+    }
+
+    private fun pendingTypeNode(
+        project: Project,
+        pointerManager: SmartPointerManager,
+        data: TypeElementData,
+        direction: TypeHierarchyDirection,
+        visited: MutableSet<String>,
+        visitedPointers: MutableList<SmartPsiElementPointer<PsiElement>>
+    ): PendingTypeNode? {
+        // Frontier snapshots stay unbound until disclosed. Re-reading a growing prefix must not
+        // allocate handles for prior siblings or for look-ahead nodes absent from this page.
+        val unboundSnapshot = convertToTypeElement(project, data, bindHandle = false)
+        val target = data.pointerTarget?.let(PsiUtils::resolveNavigationTarget)
+        val pointer = if (target == null) {
+            val key = "${data.language}|${data.file}|${data.line}|${data.qualifiedName}|${data.kind}|${data.name}"
+            if (!visited.add(key)) return null
+            null
+        } else {
+            if (visitedPointers.any { existing ->
+                    existing.element?.let { sameHierarchyDeclaration(it, target) } == true
+                }
+            ) return null
+            // Physical declaration identity comes from the live pointer, never a display key:
+            // different local classes can share every name/signature field in one source file.
+            pointerManager.createSmartPsiElementPointer(target).also { pointer ->
+                visitedPointers += pointer
+            }
+        }
+        return PendingTypeNode(
+            pointer = pointer,
+            snapshot = unboundSnapshot,
+            direction = direction,
+            modificationCount = PsiModificationTracker.getInstance(project).modificationCount
+        )
+    }
+
+    private fun refreshTypeSnapshot(
+        project: Project,
+        target: PsiElement,
+        previous: TypeElement,
+        direction: TypeHierarchyDirection,
+        scope: BuiltInSearchScope,
+        excludeGenerated: Boolean
+    ): TypeElement {
+        val handler = LanguageHandlerRegistry.getTypeHierarchyHandler(target) ?: return previous
+        val fresh = handler.getTypeHierarchy(
+            target,
+            project,
+            scope,
+            excludeGenerated,
+            directOnly = true,
+            direction = direction,
+            page = HierarchyPageRequest(offset = 0, limit = 0)
+        )?.element ?: return previous
+        return convertToTypeElement(project, fresh, bindHandle = false).copy(symbolId = previous.symbolId)
+    }
+
+    private val typeDataComparator = compareBy<TypeElementData>(
+        { it.language },
+        { it.file.orEmpty() },
+        { it.line ?: Int.MAX_VALUE },
+        { it.qualifiedName.orEmpty() },
+        { it.name }
+    )
+
+    private fun resolveTargetElement(project: Project, arguments: JsonObject, scope: BuiltInSearchScope): Result<PsiElement> {
+        val symbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+        val hasQualifiedTarget = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
+            optionalStringArg(arguments, ParamNames.SYMBOL) != null
+        if (symbolId != null || hasQualifiedTarget) {
+            if (optionalStringArg(arguments, ParamNames.CLASS_NAME) != null) {
+                return Result.failure(IllegalArgumentException(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE))
+            }
+            return resolveElementFromArguments(project, arguments, allowLibraryFilesForPosition = true)
+        }
+
         // Try className first. Direct class lookup covers JVM/PHP-style FQNs; symbol search
         // fills the same entry point for WebStorm JS/TS class and interface names.
         val className = arguments["className"]?.jsonPrimitive?.content
         if (className != null) {
-            return findClassByName(project, className)
+            val target = findClassByName(project, className)
                 ?: findJavaScriptOrTypeScriptClassByName(project, className, scope)
+                ?: return Result.failure(IllegalArgumentException("Class not found"))
+            return Result.success(target)
         }
 
         // Otherwise use file/line/column (works for all languages)
-        val file = arguments["file"]?.jsonPrimitive?.content ?: return null
-        val line = arguments["line"]?.jsonPrimitive?.int ?: return null
-        val column = arguments["column"]?.jsonPrimitive?.int ?: return null
+        val file = arguments["file"]?.jsonPrimitive?.content
+            ?: return Result.failure(IllegalArgumentException("Missing position"))
+        val line = arguments["line"]?.jsonPrimitive?.int
+            ?: return Result.failure(IllegalArgumentException("Missing position"))
+        val column = arguments["column"]?.jsonPrimitive?.int
+            ?: return Result.failure(IllegalArgumentException("Missing position"))
 
         return findPsiElement(project, file, line, column)
+            ?.let { Result.success(it) }
+            ?: Result.failure(IllegalArgumentException("No element at position"))
     }
 
     private fun findJavaScriptOrTypeScriptClassByName(
@@ -171,13 +537,26 @@ class TypeHierarchyTool : AbstractMcpTool() {
     /**
      * Converts handler TypeElementData to tool TypeElement.
      */
-    private fun convertToTypeElement(data: TypeElementData): TypeElement {
+    private fun convertToTypeElement(
+        project: Project,
+        data: TypeElementData,
+        fallbackTarget: PsiElement? = null,
+        preferredSymbolId: String? = null,
+        bindHandle: Boolean = true
+    ): TypeElement {
         return TypeElement(
             name = data.name,
             file = data.file,
             kind = data.kind,
             language = data.language,
-            supertypes = data.supertypes?.map { convertToTypeElement(it) }
+            symbolId = if (bindHandle) {
+                (data.pointerTarget ?: fallbackTarget)?.let {
+                    bindSymbolId(project, it, preferredSymbolId)
+                }
+            } else null,
+            // Hierarchy traversal is flat. Avoid binding handles for nested handler metadata that
+            // is deliberately discarded by the wire model on every call site.
+            supertypes = null
         )
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/SyncFilesTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/SyncFilesTool.kt
@@ -1,21 +1,26 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SyncFilesResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.LinkOption
+import java.nio.file.Path
 
 class SyncFilesTool : AbstractMcpTool() {
 
@@ -37,65 +42,221 @@ class SyncFilesTool : AbstractMcpTool() {
             putJsonObject("items") {
                 put("type", "string")
             }
-            put("description", "File or directory paths relative to project root to sync. If omitted, syncs the entire project.")
+            put(
+                "description",
+                "File or directory paths relative to the selected project/content root. Absolute paths, traversal, and symlink escapes are rejected. Deleted paths refresh their nearest existing parent. If omitted, syncs the entire selected root."
+            )
         })
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
-        val basePath = project.basePath
-            ?: return createErrorResult("Project base path is not available.")
+        if (project.basePath == null) {
+            return createErrorResult("Project base path is not available.")
+        }
 
         val requestedPaths = arguments["paths"]?.jsonArray?.map { it.jsonPrimitive.content }
-
-        // Determine the effective root: if project_path was a workspace sub-project,
-        // use that sub-project root instead of the workspace basePath
         val projectPathArg = arguments["project_path"]?.jsonPrimitive?.content
-        val effectiveRoot = resolveEffectiveRoot(project, projectPathArg) ?: basePath
+        val effectiveRoot = resolveEffectiveRoot(project, projectPathArg)
+            ?: return createErrorResult(
+                "The selected project_path is not inside the project base path or one of its content roots."
+            )
 
         val syncedPaths: List<String>
+        val refreshedRoots: List<String>
+        val deletedPaths: List<String>
         val syncedAll: Boolean
 
         if (requestedPaths != null && requestedPaths.isNotEmpty()) {
-            val resolvedFiles = requestedPaths.mapNotNull { relativePath ->
-                resolveFile(project, relativePath)?.let { relativePath to it }
+            // Validate and resolve the complete batch before touching the VFS. A bad path must not
+            // leave the call half-applied.
+            val targets = try {
+                requestedPaths.map { relativePath -> resolveTarget(effectiveRoot, relativePath) }
+            } catch (e: IllegalArgumentException) {
+                return createErrorResult(e.message ?: "Invalid sync path.")
             }
-            if (resolvedFiles.isNotEmpty()) {
-                VfsUtil.markDirtyAndRefresh(false, true, true, *resolvedFiles.map { it.second }.toTypedArray())
+
+            val refreshTargets = minimalRefreshRoots(targets.map { target ->
+                findVfsRefreshRoot(effectiveRoot, target.diskRefreshPath)
+                    ?: return createErrorResult(
+                        "Could not find an existing VFS parent for '${target.requestedPath}' inside the selected project root."
+                    )
+            })
+
+            if (refreshTargets.isNotEmpty()) {
+                VfsUtil.markDirtyAndRefresh(
+                    false,
+                    true,
+                    true,
+                    *refreshTargets.map { it.virtualFile }.toTypedArray()
+                )
             }
-            syncedPaths = resolvedFiles.map { it.first }
+
+            syncedPaths = requestedPaths
+            refreshedRoots = refreshTargets.map { displayPath(effectiveRoot, it.path) }
+            deletedPaths = targets.filterNot { it.existed }.map { it.requestedPath }
             syncedAll = false
         } else {
-            val projectDir = LocalFileSystem.getInstance().findFileByPath(effectiveRoot)
-            if (projectDir != null) {
-                VfsUtil.markDirtyAndRefresh(false, true, true, projectDir)
-            }
-            syncedPaths = listOf(effectiveRoot)
+            val projectDir = LocalFileSystem.getInstance().findFileByPath(effectiveRoot.toString())
+                ?: return createErrorResult("Selected project root is not available in the IDE VFS: $effectiveRoot")
+            VfsUtil.markDirtyAndRefresh(false, true, true, projectDir)
+            syncedPaths = listOf(effectiveRoot.toString())
+            refreshedRoots = listOf(effectiveRoot.toString())
+            deletedPaths = emptyList()
             syncedAll = true
         }
 
         commitDocuments(project)
 
-        val message = if (syncedAll) {
-            "Synchronized entire project."
-        } else if (requestedPaths != null && syncedPaths.size < requestedPaths.size) {
-            "Synchronized ${syncedPaths.size} of ${requestedPaths.size} requested path(s). Not found: ${(requestedPaths - syncedPaths.toSet()).joinToString(", ")}."
-        } else {
-            "Synchronized ${syncedPaths.size} path(s)."
+        val message = when {
+            syncedAll -> "Synchronized entire project."
+            deletedPaths.isNotEmpty() ->
+                "Synchronized ${syncedPaths.size} path(s), including ${deletedPaths.size} deleted path(s) via existing parent directories."
+            else -> "Synchronized ${syncedPaths.size} path(s)."
         }
 
         return createJsonResult(SyncFilesResult(
             syncedPaths = syncedPaths,
             syncedAll = syncedAll,
-            message = message
+            message = message,
+            requestedPaths = requestedPaths.orEmpty(),
+            refreshedRoots = refreshedRoots,
+            deletedPaths = deletedPaths
         ))
     }
 
-    private fun resolveEffectiveRoot(project: Project, projectPathArg: String?): String? {
-        if (projectPathArg == null) return project.basePath
-        val normalized = projectPathArg.trimEnd('/', '\\')
-        if (normalized == project.basePath) return project.basePath
-        return ProjectUtils.getModuleContentRoots(project)
-            .firstOrNull { it == normalized }
-            ?: project.basePath
+    /** Resolve the routing hint to the most specific project/content root that contains it. */
+    private fun resolveEffectiveRoot(project: Project, projectPathArg: String?): Path? {
+        val baseRoot = project.basePath?.let(::realPathOrNull) ?: return null
+        if (projectPathArg == null) return baseRoot
+
+        val requestedRoot = realPathOrNull(projectPathArg) ?: return null
+        val allowedRoots = (listOfNotNull(project.basePath) + ProjectUtils.getModuleContentRoots(project))
+            .mapNotNull(::realPathOrNull)
+            .distinct()
+
+        return allowedRoots
+            .filter { requestedRoot == it || requestedRoot.startsWith(it) }
+            .maxByOrNull { it.nameCount }
+    }
+
+    private fun resolveTarget(effectiveRoot: Path, requestedPath: String): SyncTarget {
+        val relativePath = parseSafeRelativePath(requestedPath)
+        val targetPath = effectiveRoot.resolve(relativePath).normalize()
+        if (targetPath != effectiveRoot && !targetPath.startsWith(effectiveRoot)) {
+            throw IllegalArgumentException("Path escapes the selected project root: $requestedPath")
+        }
+
+        val existed = Files.exists(targetPath)
+        val nearestExisting = nearestExistingPath(effectiveRoot, targetPath)
+            ?: throw IllegalArgumentException(
+                "No existing parent inside the selected project root for path: $requestedPath"
+            )
+        val realExisting = try {
+            nearestExisting.toRealPath()
+        } catch (_: Exception) {
+            throw IllegalArgumentException(
+                "Path cannot be resolved safely; it may contain a dangling symbolic link: $requestedPath"
+            )
+        }
+        if (realExisting != effectiveRoot && !realExisting.startsWith(effectiveRoot)) {
+            throw IllegalArgumentException("Path escapes the selected project root through a symbolic link: $requestedPath")
+        }
+
+        return SyncTarget(
+            requestedPath = requestedPath,
+            diskRefreshPath = if (existed) targetPath else nearestExisting,
+            existed = existed
+        )
+    }
+
+    private fun parseSafeRelativePath(requestedPath: String): Path {
+        if (requestedPath.isBlank()) {
+            throw IllegalArgumentException("Sync paths must not be blank.")
+        }
+        if (requestedPath.split('/', '\\').any { it == ".." }) {
+            throw IllegalArgumentException("Path traversal is not allowed in sync paths: $requestedPath")
+        }
+        if (
+            requestedPath.startsWith('/') ||
+            requestedPath.startsWith('\\') ||
+            WINDOWS_DRIVE_PATH.matches(requestedPath)
+        ) {
+            throw IllegalArgumentException("Sync paths must be relative to the selected project root: $requestedPath")
+        }
+
+        val path = try {
+            Path.of(requestedPath)
+        } catch (_: InvalidPathException) {
+            throw IllegalArgumentException("Invalid sync path: $requestedPath")
+        }
+        if (path.isAbsolute) {
+            throw IllegalArgumentException("Sync paths must be relative to the selected project root: $requestedPath")
+        }
+        return path
+    }
+
+    private fun nearestExistingPath(effectiveRoot: Path, targetPath: Path): Path? {
+        var candidate: Path? = targetPath
+        while (candidate != null && (candidate == effectiveRoot || candidate.startsWith(effectiveRoot))) {
+            if (Files.exists(candidate, LinkOption.NOFOLLOW_LINKS)) {
+                return candidate
+            }
+            if (candidate == effectiveRoot) break
+            candidate = candidate.parent
+        }
+        return null
+    }
+
+    private fun findVfsRefreshRoot(effectiveRoot: Path, diskRefreshPath: Path): RefreshRoot? {
+        val localFileSystem = LocalFileSystem.getInstance()
+        var candidate: Path? = diskRefreshPath
+        while (candidate != null && (candidate == effectiveRoot || candidate.startsWith(effectiveRoot))) {
+            val virtualFile = localFileSystem.findFileByPath(candidate.toString())
+            if (virtualFile != null) {
+                return RefreshRoot(candidate, virtualFile)
+            }
+            if (candidate == effectiveRoot) break
+            candidate = candidate.parent
+        }
+        return null
+    }
+
+    /** Recursive refresh of an ancestor already covers all requested descendants. */
+    private fun minimalRefreshRoots(roots: List<RefreshRoot>): List<RefreshRoot> {
+        val selected = mutableListOf<RefreshRoot>()
+        for (candidate in roots.distinctBy { it.path }.sortedBy { it.path.nameCount }) {
+            if (selected.none { candidate.path == it.path || candidate.path.startsWith(it.path) }) {
+                selected += candidate
+            }
+        }
+        return selected
+    }
+
+    private fun displayPath(effectiveRoot: Path, path: Path): String {
+        if (path == effectiveRoot) return effectiveRoot.toString()
+        return effectiveRoot.relativize(path).joinToString("/") { it.toString() }
+    }
+
+    private fun realPathOrNull(path: String): Path? {
+        return try {
+            Path.of(path).toRealPath()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private data class SyncTarget(
+        val requestedPath: String,
+        val diskRefreshPath: Path,
+        val existed: Boolean
+    )
+
+    private data class RefreshRoot(
+        val path: Path,
+        val virtualFile: VirtualFile
+    )
+
+    private companion object {
+        val WINDOWS_DRIVE_PATH = Regex("^[A-Za-z]:.*")
     }
 }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ChangeSignatureTool.kt
@@ -2,30 +2,37 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ResolvedSymbolInfo
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.refactoring.changeSignature.OverriderMethodUsageInfo
+import com.intellij.usageView.UsageInfo
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.jetbrains.annotations.TestOnly
 
 class ChangeSignatureTool : AbstractMcpTool() {
 
-    companion object {
-        private val LOG = logger<ChangeSignatureTool>()
-    }
+    override val supportsUnifiedTarget: Boolean = true
 
     /**
      * Test hook replacing the `processor.run()` call, so tests can reproduce the production
@@ -37,6 +44,10 @@ class ChangeSignatureTool : AbstractMcpTool() {
     @TestOnly
     internal var processorRunHook: (() -> Unit)? = null
 
+    /** Lets behavior tests prove that incomplete reflective discovery fails closed. */
+    @TestOnly
+    internal var previewUsageSearchHook: (() -> Unit)? = null
+
     override val name = ToolNames.CHANGE_SIGNATURE
 
     override val description = """
@@ -46,14 +57,18 @@ class ChangeSignatureTool : AbstractMcpTool() {
         New parameters get a default value inserted at all call sites.
 
         Examples:
+        - By handle: {"symbolId": "<opaque-id>", "newName": "renamed"}
         - Add parameter: {"file": "src/Service.java", "line": 15, "column": 10, "newParameters": [{"oldIndex": 0, "name": "id", "type": "String"}, {"oldIndex": -1, "name": "validate", "type": "boolean", "defaultValue": "true"}]}
         - Change return type: {"file": "src/Service.java", "line": 15, "column": 10, "newReturnType": "Optional<User>"}
     """.trimIndent()
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
-        .file(description = "Path to file containing the method. REQUIRED.")
-        .lineAndColumn(required = true)
+        .target()
+        .symbolId()
+        .languageAndSymbol(required = false)
+        .file(required = false, description = "Path to file containing the method. Required with line+column; omit when symbolId is used.")
+        .lineAndColumn(required = false)
         .stringProperty(ParamNames.NEW_NAME, "New method name. Omit to keep current name.")
         .stringProperty(ParamNames.NEW_RETURN_TYPE, "New return type as a string (e.g., 'void', 'Optional<User>'). Omit to keep current.")
         .stringProperty(ParamNames.NEW_VISIBILITY, "New visibility: 'public', 'protected', 'private', or 'package-private'. Omit to keep current.")
@@ -65,6 +80,10 @@ class ChangeSignatureTool : AbstractMcpTool() {
             })
         })
         .booleanProperty(ParamNames.GENERATE_DELEGATE, "Generate a delegation method with the old signature. Default: false.")
+        .booleanProperty(
+            ParamNames.DRY_RUN,
+            "Resolve and validate the method, then discover usages/conflicts without modifying files. Default: false."
+        )
         .build()
 
     @Serializable
@@ -73,12 +92,14 @@ class ChangeSignatureTool : AbstractMcpTool() {
         val file: String,
         val message: String,
         val affectedFiles: List<String> = emptyList(),
-        val changesCount: Int = 0
+        val changesCount: Int = 0,
+        val updatedSymbol: ResolvedSymbolInfo? = null
     )
 
     private data class SignaturePreparation(
         val method: PsiMethod,
-        val relativePath: String
+        val relativePath: String,
+        val writable: Boolean
     )
 
     private data class SignatureState(
@@ -104,12 +125,11 @@ class ChangeSignatureTool : AbstractMcpTool() {
     )
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
-        val filePath = arguments[ParamNames.FILE]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
-        val line = arguments[ParamNames.LINE]?.jsonPrimitive?.int
-            ?: return createErrorResult("Missing required parameter: line")
-        val column = arguments[ParamNames.COLUMN]?.jsonPrimitive?.int
-            ?: return createErrorResult("Missing required parameter: column")
+        val startedAtNanos = System.nanoTime()
+        val dryRun = arguments[ParamNames.DRY_RUN]?.jsonPrimitive?.booleanOrNull == true
+        val requestedSymbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+        val hasQualifiedTarget = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
+            optionalStringArg(arguments, ParamNames.SYMBOL) != null
 
         val newName = arguments[ParamNames.NEW_NAME]?.jsonPrimitive?.content
         val newReturnType = arguments[ParamNames.NEW_RETURN_TYPE]?.jsonPrimitive?.content
@@ -124,10 +144,6 @@ class ChangeSignatureTool : AbstractMcpTool() {
         if (newVisibility != null && newVisibility !in listOf("public", "protected", "private", "package-private", "package-local")) {
             return createErrorResult("Invalid visibility: '$newVisibility'. Must be: public, protected, private, or package-private.")
         }
-
-        val virtualFile = resolveFile(project, filePath)
-            ?: return createErrorResult("File not found: $filePath")
-        ensureWritable(virtualFile)?.let { return it }
 
         val changeSignatureProcessorClass = try {
             Class.forName("com.intellij.refactoring.changeSignature.ChangeSignatureProcessor")
@@ -148,19 +164,108 @@ class ChangeSignatureTool : AbstractMcpTool() {
         }
 
         val prep = suspendingReadAction {
-            prepareChange(project, virtualFile, filePath, line, column)
+            if (requestedSymbolId != null || hasQualifiedTarget) {
+                if (optionalStringArg(arguments, ParamNames.FILE) != null ||
+                    arguments[ParamNames.LINE]?.let { it != kotlinx.serialization.json.JsonNull } == true ||
+                    arguments[ParamNames.COLUMN]?.let { it != kotlinx.serialization.json.JsonNull } == true
+                ) {
+                    return@suspendingReadAction Result.failure<SignaturePreparation>(
+                        IllegalArgumentException(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE)
+                    )
+                }
+                prepareChangeBySemanticTarget(
+                    project,
+                    arguments,
+                    requestedSymbolId,
+                    requireWritable = !dryRun
+                )
+            } else {
+                val filePath = optionalStringArg(arguments, ParamNames.FILE)
+                    ?: return@suspendingReadAction Result.failure<SignaturePreparation>(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.FILE}")
+                    )
+                val line = arguments[ParamNames.LINE]?.jsonPrimitive?.int
+                    ?: return@suspendingReadAction Result.failure<SignaturePreparation>(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.LINE}")
+                    )
+                val column = arguments[ParamNames.COLUMN]?.jsonPrimitive?.int
+                    ?: return@suspendingReadAction Result.failure<SignaturePreparation>(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.COLUMN}")
+                    )
+                val virtualFile = resolveFile(project, filePath)
+                    ?: return@suspendingReadAction Result.failure<SignaturePreparation>(
+                        IllegalArgumentException("File not found: $filePath")
+                    )
+                if (!dryRun && !virtualFile.isWritable) {
+                    return@suspendingReadAction Result.failure<SignaturePreparation>(
+                        IllegalArgumentException("File is read-only and cannot be modified: ${virtualFile.path}")
+                    )
+                }
+                prepareChange(project, virtualFile, filePath, line, column)
+            }
         }
 
         return when {
             prep.isFailure -> createErrorResult(prep.exceptionOrNull()?.message ?: "Failed to prepare change")
             else -> {
                 val p = prep.getOrThrow()
-                applyChange(
-                    project, p, newName, newReturnType, newVisibility, newParametersJson,
-                    generateDelegate, changeSignatureProcessorClass, javaChangeInfoImplClass, parameterInfoImplClass
-                )
+                if (dryRun) {
+                    previewChange(
+                        project = project,
+                        prep = p,
+                        newName = newName,
+                        newReturnType = newReturnType,
+                        newVisibility = newVisibility,
+                        newParametersJson = newParametersJson,
+                        generateDelegate = generateDelegate,
+                        changeSignatureProcessorClass = changeSignatureProcessorClass,
+                        javaChangeInfoImplClass = javaChangeInfoImplClass,
+                        parameterInfoImplClass = parameterInfoImplClass,
+                        requestedSymbolId = requestedSymbolId,
+                        startedAtNanos = startedAtNanos
+                    )
+                } else {
+                    applyChange(
+                        project, p, newName, newReturnType, newVisibility, newParametersJson,
+                        generateDelegate, changeSignatureProcessorClass, javaChangeInfoImplClass,
+                        parameterInfoImplClass, requestedSymbolId
+                    )
+                }
             }
         }
+    }
+
+    private fun prepareChangeBySemanticTarget(
+        project: Project,
+        arguments: JsonObject,
+        symbolId: String?,
+        requireWritable: Boolean = true
+    ): Result<SignaturePreparation> {
+        val element = resolveElementFromArguments(project, arguments).getOrElse {
+            return Result.failure(it)
+        }
+        val method = element as? PsiMethod
+            ?: return Result.failure(
+                IllegalArgumentException(
+                    symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target does not identify a Java method"
+                )
+            )
+        val virtualFile = method.containingFile?.virtualFile
+            ?: return Result.failure(
+                IllegalArgumentException(
+                    symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no editable source file"
+                )
+            )
+        if (requireWritable && !virtualFile.isWritable) {
+            return Result.failure(IllegalArgumentException("File is read-only and cannot be modified: ${virtualFile.path}"))
+        }
+        return Result.success(
+            SignaturePreparation(
+                method,
+                ProjectUtils.getToolFilePath(project, virtualFile),
+                virtualFile.isWritable
+            )
+        )
     }
 
     private fun prepareChange(
@@ -188,7 +293,301 @@ class ChangeSignatureTool : AbstractMcpTool() {
             ?: return Result.failure(Exception("No method found at line $line, column $column. Position the cursor on a method name."))
 
         val relativePath = ProjectUtils.getToolFilePath(project, virtualFile)
-        return Result.success(SignaturePreparation(method, relativePath))
+        return Result.success(SignaturePreparation(method, relativePath, virtualFile.isWritable))
+    }
+
+    private suspend fun previewChange(
+        project: Project,
+        prep: SignaturePreparation,
+        newName: String?,
+        newReturnType: String?,
+        newVisibility: String?,
+        newParametersJson: kotlinx.serialization.json.JsonArray?,
+        generateDelegate: Boolean,
+        changeSignatureProcessorClass: Class<*>,
+        javaChangeInfoImplClass: Class<*>,
+        parameterInfoImplClass: Class<*>,
+        requestedSymbolId: String?,
+        startedAtNanos: Long
+    ): CallToolResult {
+        return try {
+            val (changeInfo, verification) = suspendingReadAction {
+                buildChangeInfo(
+                    project,
+                    prep.method,
+                    newName,
+                    newReturnType,
+                    newVisibility,
+                    newParametersJson,
+                    generateDelegate,
+                    javaChangeInfoImplClass,
+                    parameterInfoImplClass
+                )
+            }
+            val processor = edtAction {
+                instantiateProcessor(project, changeSignatureProcessorClass, changeInfo).also {
+                    it.setPreviewUsages(false)
+                }
+            }
+
+            val warnings = mutableListOf<String>()
+            val affectedFiles = linkedSetOf(prep.relativePath)
+            var usages = emptyArray<UsageInfo>()
+            var conflicts = emptyList<String>()
+            var discoveryComplete = true
+
+            try {
+                previewUsageSearchHook?.invoke()
+                usages = RefactoringScopeGuard.computeUsagesOffEdtStrict(project) {
+                    RefactoringScopeGuard.findUsagesReflectivelyOrThrow(processor)
+                }
+                // ChangeSignatureProcessorBase delegates extension conflicts through
+                // ActionUtil.underModalProgress. It must not be entered while this coroutine
+                // owns a read lock: the modal worker may itself need read/write access and the
+                // EDT then deadlocks waiting for that worker. Running it on EDT without an
+                // enclosing read action matches the platform processor's own call path.
+                val conflictResult = edtAction {
+                    RefactoringScopeGuard.collectChangeSignatureConflictsReflectively(
+                        changeInfo,
+                        usages
+                    )
+                }
+                // Conflict extensions receive a mutable Ref<Array<UsageInfo>> and are allowed
+                // to replace or filter it. All preview metadata must describe that effective
+                // array, just as the platform's subsequent conflict descriptions do.
+                usages = conflictResult.usages
+                val scopeMetadata = suspendingReadAction {
+                    val usageFiles = usages.mapNotNullTo(linkedSetOf()) { usage ->
+                        usage.virtualFile?.let { ProjectUtils.getToolFilePath(project, it) }
+                    }
+                    usageFiles to RefactoringScopeGuard.readOnlyFilesIn(project, usages)
+                }
+                conflicts = conflictResult.conflicts
+                affectedFiles.addAll(scopeMetadata.first)
+                warnings.addAll(conflicts)
+                if (scopeMetadata.second.isNotEmpty()) {
+                    warnings.add(RefactoringScopeGuard.blockedMessage(scopeMetadata.second))
+                }
+            } catch (e: ProcessCanceledException) {
+                throw e
+            } catch (e: Exception) {
+                discoveryComplete = false
+                val cause = (e as? java.lang.reflect.InvocationTargetException)?.cause ?: e
+                warnings.add(
+                    "Usage/conflict discovery failed: ${cause.message ?: cause.javaClass.simpleName}. " +
+                        "The preview is not safe to apply."
+                )
+            }
+
+            if (!prep.writable) {
+                warnings.add("Target file is read-only; the change signature operation cannot be applied.")
+            }
+            // Java exposes OverriderUsageInfo, but other language integrations can provide a
+            // different UsageInfo implementation of this shared interface. Either form can
+            // make Change Signature show an overrider/covariant-return chooser on apply.
+            val hasOverriderUsages = usages.any { it is OverriderMethodUsageInfo<*> }
+            val missingDefaultForNewParameter = usages.isNotEmpty() &&
+                hasNewParameterWithoutDefault(newParametersJson)
+            val narrowsVisibility = hasOverriderUsages &&
+                verification.targetVisibility?.let { requestedVisibility ->
+                    val requestedRank = visibilityRank(requestedVisibility)
+                    val currentRank = visibilityRank(verification.before.visibility)
+                    requestedRank >= 0 && currentRank >= 0 && requestedRank < currentRank
+                } == true
+            val changesReturnTypeWithOverriders = hasOverriderUsages && newReturnType != null
+
+            if (missingDefaultForNewParameter) {
+                warnings.add(
+                    "A new parameter has no explicit non-blank defaultValue while call sites exist; " +
+                        "the IDE may require an interactive default-value decision."
+                )
+            }
+            if (narrowsVisibility) {
+                warnings.add(
+                    "Narrowing visibility while overriding methods exist may require an interactive confirmation."
+                )
+            }
+            if (changesReturnTypeWithOverriders) {
+                warnings.add(
+                    "Changing the return type while overriding methods exist may require an interactive " +
+                        "covariant-overrider choice."
+                )
+            }
+            val requiresInteractiveDecision = missingDefaultForNewParameter || narrowsVisibility ||
+                changesReturnTypeWithOverriders
+            val target = suspendingReadAction {
+                resolvedSymbolInfo(project, prep.method, requestedSymbolId)
+            }
+            val hasReadOnlyScope = warnings.any { it.startsWith("Blocked by read-only files") }
+            createJsonResult(
+                RefactoringPreviewResult(
+                    canApply = discoveryComplete && prep.writable && !hasReadOnlyScope &&
+                        conflicts.isEmpty() && !requiresInteractiveDecision,
+                    target = target,
+                    plannedChange = buildJsonObject {
+                        put("operation", "changeSignature")
+                        put("before", signatureStateJson(verification.before))
+                        put("requested", buildJsonObject {
+                            newName?.let { put("newName", it) }
+                            newReturnType?.let { put("newReturnType", it) }
+                            newVisibility?.let { put("newVisibility", it) }
+                            newParametersJson?.let { put("newParameters", it) }
+                            put("generateDelegate", generateDelegate)
+                        })
+                    },
+                    affectedFiles = affectedFiles.sorted(),
+                    usageCount = usages.size,
+                    conflictCount = conflicts.size,
+                    warnings = warnings.distinct(),
+                    elapsedMs = elapsedMillisSince(startedAtNanos)
+                )
+            )
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: Exception) {
+            val cause = if (e is java.lang.reflect.InvocationTargetException) e.cause ?: e else e
+            createErrorResult(
+                "Change signature preview failed: ${cause.message}",
+                ToolNames.DIAGNOSTICS
+            )
+        }
+    }
+
+    private fun signatureStateJson(state: SignatureState): JsonObject = buildJsonObject {
+        put("name", state.name)
+        state.returnTypeText?.let { put("returnType", it) }
+        put("visibility", state.visibility)
+        put("parameters", buildJsonArray {
+            for ((name, type) in state.parameters) {
+                add(buildJsonObject {
+                    put("name", name)
+                    put("type", type)
+                })
+            }
+        })
+    }
+
+    private fun buildChangeInfo(
+        project: Project,
+        method: PsiMethod,
+        newName: String?,
+        newReturnType: String?,
+        newVisibility: String?,
+        newParametersJson: kotlinx.serialization.json.JsonArray?,
+        generateDelegate: Boolean,
+        javaChangeInfoImplClass: Class<*>,
+        parameterInfoImplClass: Class<*>
+    ): Pair<Any, SignatureVerification> {
+        val factory = JavaPsiFacade.getElementFactory(project)
+        val effectiveName = newName ?: method.name
+        val canonicalTypesClass = Class.forName("com.intellij.refactoring.util.CanonicalTypes")
+        val createMethod = canonicalTypesClass.getMethod("createTypeWrapper", PsiType::class.java)
+
+        val requestedReturnPsiType = newReturnType?.let { factory.createTypeFromText(it, method) }
+        val effectiveReturnType = if (requestedReturnPsiType != null) {
+            createMethod.invoke(null, requestedReturnPsiType)
+        } else {
+            method.returnType?.let { createMethod.invoke(null, it) }
+        }
+        val effectiveVisibility = when (newVisibility) {
+            "public" -> PsiModifier.PUBLIC
+            "protected" -> PsiModifier.PROTECTED
+            "private" -> PsiModifier.PRIVATE
+            "package-private", "package-local" -> PsiModifier.PACKAGE_LOCAL
+            else -> currentVisibility(method)
+        }
+        val paramInfos = if (newParametersJson != null) {
+            buildParameterInfos(method, newParametersJson, parameterInfoImplClass, factory).getOrThrow()
+        } else {
+            buildCurrentParameterInfos(method, parameterInfoImplClass)
+        }
+
+        val thrownExceptions = extractThrownExceptions(method)
+        val canonicalTypeClass = Class.forName("com.intellij.refactoring.util.CanonicalTypes\$Type")
+        val constructor = javaChangeInfoImplClass.getConstructor(
+            String::class.java,
+            PsiMethod::class.java,
+            String::class.java,
+            canonicalTypeClass,
+            paramInfos.javaClass,
+            thrownExceptions.javaClass,
+            Boolean::class.java,
+            Set::class.java,
+            Set::class.java
+        )
+        val changeInfo = constructor.newInstance(
+            effectiveVisibility,
+            method,
+            effectiveName,
+            effectiveReturnType,
+            paramInfos,
+            thrownExceptions,
+            generateDelegate,
+            emptySet<PsiMethod>(),
+            emptySet<PsiMethod>()
+        )
+        val verification = SignatureVerification(
+            pointer = SmartPointerManager.getInstance(project).createSmartPsiElementPointer(method),
+            before = captureSignatureState(method),
+            targetName = newName,
+            targetReturnTypeText = requestedReturnPsiType?.canonicalText,
+            targetVisibility = if (newVisibility != null) effectiveVisibility else null,
+            targetParameters = newParametersJson?.map { parameterJson ->
+                val parameter = parameterJson.jsonObject
+                val parameterName = parameter["name"]!!.jsonPrimitive.content
+                val parameterType = factory.createTypeFromText(
+                    parameter["type"]!!.jsonPrimitive.content,
+                    method
+                )
+                parameterName to parameterType.canonicalText
+            }
+        )
+        return changeInfo to verification
+    }
+
+    /**
+     * Keeps Java's existing throws contract when an unrelated part of a signature changes.
+     *
+     * The Java plugin owns the concrete exception-info representation. In particular, current
+     * platform versions use a `PsiClassType` constructor rather than the historical `PsiType`
+     * one, so synthesising these objects reflectively is version-fragile. Use its public helper
+     * instead while keeping the Java-plugin dependency optional at class-load time.
+     *
+     * Do not substitute an empty array when this fails: applying that fallback silently removes
+     * source-level throws declarations. Unwrap cancellation and errors so normal IDE control flow
+     * and fatal failures retain their usual semantics.
+     */
+    private fun extractThrownExceptions(method: PsiMethod): Any {
+        val javaThrownExceptionInfoClass = Class.forName(
+            "com.intellij.refactoring.changeSignature.JavaThrownExceptionInfo"
+        )
+        val extractMethod = javaThrownExceptionInfoClass.getMethod(
+            "extractExceptions",
+            PsiMethod::class.java
+        )
+        return try {
+            requireNotNull(extractMethod.invoke(null, method)) {
+                "JavaThrownExceptionInfo.extractExceptions returned null"
+            }
+        } catch (exception: java.lang.reflect.InvocationTargetException) {
+            val cause = exception.cause ?: throw exception
+            when (cause) {
+                is ProcessCanceledException -> throw cause
+                is Error -> throw cause
+                else -> throw cause
+            }
+        }
+    }
+
+    private fun instantiateProcessor(
+        project: Project,
+        changeSignatureProcessorClass: Class<*>,
+        changeInfo: Any
+    ): BaseRefactoringProcessor {
+        val changeInfoClass = Class.forName("com.intellij.refactoring.changeSignature.JavaChangeInfo")
+        return changeSignatureProcessorClass
+            .getConstructor(Project::class.java, changeInfoClass)
+            .newInstance(project, changeInfo) as BaseRefactoringProcessor
     }
 
     private suspend fun applyChange(
@@ -201,118 +600,33 @@ class ChangeSignatureTool : AbstractMcpTool() {
         generateDelegate: Boolean,
         changeSignatureProcessorClass: Class<*>,
         javaChangeInfoImplClass: Class<*>,
-        parameterInfoImplClass: Class<*>
+        parameterInfoImplClass: Class<*>,
+        requestedSymbolId: String?
     ): CallToolResult {
         return try {
             val method = prep.method
 
             val (changeInfo, verification) = suspendingReadAction {
-                val factory = JavaPsiFacade.getElementFactory(project)
-
-                val effectiveName = newName ?: method.name
-                val canonicalTypesClass = Class.forName("com.intellij.refactoring.util.CanonicalTypes")
-                val createMethod = canonicalTypesClass.getMethod("createTypeWrapper", PsiType::class.java)
-
-                val requestedReturnPsiType = newReturnType?.let { factory.createTypeFromText(it, method) }
-                val effectiveReturnType = if (requestedReturnPsiType != null) {
-                    createMethod.invoke(null, requestedReturnPsiType)
-                } else {
-                    if (method.returnType != null) createMethod.invoke(null, method.returnType) else null
-                }
-
-                val effectiveVisibility = when (newVisibility) {
-                    "public" -> PsiModifier.PUBLIC
-                    "protected" -> PsiModifier.PROTECTED
-                    "private" -> PsiModifier.PRIVATE
-                    "package-private", "package-local" -> PsiModifier.PACKAGE_LOCAL
-                    else -> currentVisibility(method)
-                }
-
-                val paramInfos = if (newParametersJson != null) {
-                    buildParameterInfos(method, newParametersJson, parameterInfoImplClass, factory)
-                        .getOrThrow()
-                } else {
-                    buildCurrentParameterInfos(method, parameterInfoImplClass)
-                }
-
-                val changeInfoClass = Class.forName("com.intellij.refactoring.changeSignature.JavaChangeInfo")
-                val thrownExceptionInfoClass = Class.forName("com.intellij.refactoring.changeSignature.ThrownExceptionInfo")
-                val thrownExceptions = try {
-                    val javaThrownExceptionInfoClass = Class.forName("com.intellij.refactoring.changeSignature.JavaThrownExceptionInfo")
-                    val existingThrows = method.throwsList.referenceElements
-                    if (existingThrows.isEmpty()) {
-                        java.lang.reflect.Array.newInstance(thrownExceptionInfoClass, 0)
-                    } else {
-                        val arr = java.lang.reflect.Array.newInstance(thrownExceptionInfoClass, existingThrows.size)
-                        for ((i, ref) in existingThrows.withIndex()) {
-                            val psiType = ref.resolve()?.let { resolved ->
-                                if (resolved is PsiClass) {
-                                    JavaPsiFacade.getElementFactory(project).createType(resolved)
-                                } else null
-                            } ?: PsiElementFactory.getInstance(project).createTypeFromText(ref.qualifiedName, method)
-                            val info = javaThrownExceptionInfoClass.getConstructor(Integer.TYPE, PsiType::class.java)
-                                .newInstance(i, psiType)
-                            java.lang.reflect.Array.set(arr, i, info)
-                        }
-                        arr
-                    }
-                } catch (e: Exception) {
-                    LOG.warn("Could not preserve throws declarations, falling back to empty: ${e.message}")
-                    java.lang.reflect.Array.newInstance(thrownExceptionInfoClass, 0)
-                }
-                val canonicalTypeClass = Class.forName("com.intellij.refactoring.util.CanonicalTypes\$Type")
-
-                val constructor = javaChangeInfoImplClass.getConstructor(
-                    String::class.java,
-                    PsiMethod::class.java,
-                    String::class.java,
-                    canonicalTypeClass,
-                    paramInfos.javaClass,
-                    thrownExceptions.javaClass,
-                    Boolean::class.java,
-                    Set::class.java,
-                    Set::class.java
-                )
-
-                val newChangeInfo = constructor.newInstance(
-                    effectiveVisibility,
+                buildChangeInfo(
+                    project,
                     method,
-                    effectiveName,
-                    effectiveReturnType,
-                    paramInfos,
-                    thrownExceptions,
+                    newName,
+                    newReturnType,
+                    newVisibility,
+                    newParametersJson,
                     generateDelegate,
-                    emptySet<PsiMethod>(),
-                    emptySet<PsiMethod>()
-                )
-
-                newChangeInfo to SignatureVerification(
-                    pointer = SmartPointerManager.getInstance(project).createSmartPsiElementPointer(method),
-                    before = captureSignatureState(method),
-                    targetName = newName,
-                    targetReturnTypeText = requestedReturnPsiType?.canonicalText,
-                    targetVisibility = if (newVisibility != null) effectiveVisibility else null,
-                    // Safe to re-read the JSON here: buildParameterInfos already validated every
-                    // entry (name, type present and parseable) earlier in this read action.
-                    targetParameters = newParametersJson?.map { paramJson ->
-                        val obj = paramJson.jsonObject
-                        val paramName = obj["name"]!!.jsonPrimitive.content
-                        val paramType = factory.createTypeFromText(obj["type"]!!.jsonPrimitive.content, method)
-                        paramName to paramType.canonicalText
-                    }
+                    javaChangeInfoImplClass,
+                    parameterInfoImplClass
                 )
             }
 
-            val changeInfoClass = Class.forName("com.intellij.refactoring.changeSignature.JavaChangeInfo")
             val affectedFiles = mutableSetOf<String>()
 
             edtAction {
                 val docManager = FileDocumentManager.getInstance()
                 val unsavedBefore = docManager.unsavedDocuments.toSet()
 
-                val processor = changeSignatureProcessorClass
-                    .getConstructor(Project::class.java, changeInfoClass)
-                    .newInstance(project, changeInfo) as com.intellij.refactoring.BaseRefactoringProcessor
+                val processor = instantiateProcessor(project, changeSignatureProcessorClass, changeInfo)
 
                 processor.setPreviewUsages(false)
 
@@ -361,12 +675,18 @@ class ChangeSignatureTool : AbstractMcpTool() {
                         "(read-only file, unwritable elements, or indexing in progress)."
                 )
             } else {
+                val updatedSymbol = suspendingReadAction {
+                    verification.pointer.element?.let { resolvedMethod ->
+                        resolvedSymbolInfo(project, resolvedMethod, requestedSymbolId)
+                    }
+                }
                 createJsonResult(ChangeSignatureResult(
                     success = true,
                     file = prep.relativePath,
                     message = "Changed signature of '${method.name}'",
                     affectedFiles = affectedFiles.toList(),
-                    changesCount = affectedFiles.size
+                    changesCount = affectedFiles.size,
+                    updatedSymbol = updatedSymbol
                 ))
             }
         } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
@@ -420,10 +740,28 @@ class ChangeSignatureTool : AbstractMcpTool() {
         else -> PsiModifier.PACKAGE_LOCAL
     }
 
+    private fun hasNewParameterWithoutDefault(
+        parametersJson: kotlinx.serialization.json.JsonArray?
+    ): Boolean = parametersJson?.any { parameterJson ->
+        val parameter = parameterJson.jsonObject
+        parameter["oldIndex"]?.jsonPrimitive?.int == -1 &&
+            parameter["defaultValue"]?.jsonPrimitive?.contentOrNull?.isNotBlank() != true
+    } == true
+
+    private fun visibilityRank(visibility: String): Int = when (visibility) {
+        PsiModifier.PRIVATE -> 0
+        PsiModifier.PACKAGE_LOCAL, "package-private", "package-local" -> 1
+        PsiModifier.PROTECTED -> 2
+        PsiModifier.PUBLIC -> 3
+        else -> -1
+    }
+
     private fun captureSignatureState(method: PsiMethod): SignatureState = SignatureState(
         name = method.name,
         returnTypeText = method.returnType?.canonicalText,
-        visibility = currentVisibility(method),
+        visibility = currentVisibility(method).let {
+            if (it == PsiModifier.PACKAGE_LOCAL) "package-private" else it
+        },
         parameters = method.parameterList.parameters.map { it.name to it.type.canonicalText }
     )
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/EditMemberTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/EditMemberTool.kt
@@ -2,15 +2,32 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.UnifiedTargetArguments
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ResolvedSymbolInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.*
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.PsiTreeUtil
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class EditMemberTool : AbstractMcpTool() {
+
+    override val supportsUnifiedTarget: Boolean = true
 
     override val name = ToolNames.EDIT_MEMBER
 
@@ -25,9 +42,13 @@ class EditMemberTool : AbstractMcpTool() {
         {"file": "src/Worker.java", "class": "Worker", "member": "Worker", "content": "public interface Worker<T> extends Runnable { ... }"}
 
         The content should be the complete replacement including modifiers, type, name, and body.
+        It must contain exactly one syntactically valid declaration of the original category,
+        optionally surrounded by comments. Nested declarations are allowed. Invalid or ambiguous
+        content is rejected before editing; use ide_refactor_safe_delete for deletion.
         Auto-reformats the changed range by default.
 
         Examples:
+        - {"symbolId": "<opaque-id>", "content": "public void renamed() {}"}
         - {"file": "src/Main.java", "class": "Main", "member": "process", "content": "public void process(String input, boolean validate) {\n    if (validate) check(input);\n}"}
         - {"file": "src/Config.kt", "class": "Config", "member": "timeout", "content": "val timeout: Duration = Duration.ofSeconds(30)"}
         - {"file": "src/Service.java", "member": "Service", "content": "public class Service<T> implements Serializable { ... }"}
@@ -35,20 +56,24 @@ class EditMemberTool : AbstractMcpTool() {
 
     override val inputSchema = SchemaBuilder.tool()
         .projectPath()
-        .file(description = "Path to file relative to project root. REQUIRED.")
+        .target()
+        .symbolId()
+        .languageAndSymbol(required = false)
+        .file(required = false, description = "Path to file relative to project root. Required with member selectors; omit when symbolId is used.")
         .stringProperty(ParamNames.CLASS, "Class/interface name containing the member. Optional for top-level members (Kotlin).")
-        .stringProperty(ParamNames.MEMBER, "Name of the method, function, field, or property to replace entirely.", required = true)
+        .stringProperty(ParamNames.MEMBER, "Name of the method, function, field, or property to replace entirely. Required unless symbolId is used.")
         .intProperty(ParamNames.PARAMETER_COUNT, "Number of parameters (for disambiguating overloaded methods).")
         .intProperty(ParamNames.LINE, "1-based line number of the member (for disambiguation when multiple members share the same name).")
-        .stringProperty(ParamNames.CONTENT, "The complete replacement member declaration including modifiers, type, name, and body.", required = true)
+        .stringProperty(ParamNames.CONTENT, "Exactly one complete, syntactically valid declaration of the original category, including modifiers, type, name, and body. Surrounding comments are allowed.", required = true)
         .booleanProperty(ParamNames.REFORMAT, "Auto-reformat the changed range and optimize imports. Default: true.")
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
-        val filePath = arguments[ParamNames.FILE]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
-        val memberName = arguments[ParamNames.MEMBER]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: member")
+        val requestedSymbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+        val hasQualifiedTarget = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
+            optionalStringArg(arguments, ParamNames.SYMBOL) != null
+        val hasStructuredTarget = optionalStringArg(arguments, UnifiedTargetArguments.NORMALIZED_VARIANT) != null
+        val memberName = optionalStringArg(arguments, ParamNames.MEMBER) ?: "<symbolId>"
         val content = arguments[ParamNames.CONTENT]?.jsonPrimitive?.content
             ?: return createErrorResult("Missing required parameter: content")
         if (content.isBlank()) {
@@ -58,22 +83,87 @@ class EditMemberTool : AbstractMcpTool() {
         val parameterCount = MemberEditingUtils.getOptionalInt(arguments, ParamNames.PARAMETER_COUNT)
         val line = MemberEditingUtils.getOptionalInt(arguments, ParamNames.LINE)
         val reformat = MemberEditingUtils.getOptionalBoolean(arguments, ParamNames.REFORMAT)
-
-        val virtualFile = resolveFile(project, filePath)
-            ?: return createErrorResult("File not found: $filePath")
-        ensureWritable(virtualFile)?.let { return it }
+        val hasLegacyMemberSelector = listOf(ParamNames.FILE, ParamNames.CLASS, ParamNames.MEMBER).any {
+            optionalStringArg(arguments, it) != null
+        } || parameterCount != null || line != null
 
         val prep = suspendingReadAction {
-            prepareMemberEdit(project, virtualFile, filePath, className, memberName, parameterCount, line)
+            if (requestedSymbolId != null || hasQualifiedTarget || hasStructuredTarget) {
+                if (!hasStructuredTarget && hasLegacyMemberSelector) {
+                    Result.failure(IllegalArgumentException(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE))
+                } else {
+                    prepareMemberEditBySemanticTarget(project, arguments, requestedSymbolId)
+                }
+            } else {
+                val filePath = optionalStringArg(arguments, ParamNames.FILE)
+                    ?: return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.FILE}")
+                    )
+                if (memberName == "<symbolId>") {
+                    return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.MEMBER}")
+                    )
+                }
+                val virtualFile = resolveFile(project, filePath)
+                    ?: return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("File not found: $filePath")
+                    )
+                if (!virtualFile.isWritable) {
+                    return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("File is read-only and cannot be modified: ${virtualFile.path}")
+                    )
+                }
+                prepareMemberEdit(project, virtualFile, filePath, className, memberName, parameterCount, line)
+            }
         }
 
         return when {
             prep.isFailure -> prep.exceptionOrNull()!!.let { handleError(it, memberName) }
             else -> {
                 val p = prep.getOrThrow()
-                applyFullReplacement(project, p, content, reformat)
+                applyFullReplacement(project, p, content, reformat, requestedSymbolId)
             }
         }
+    }
+
+    private fun prepareMemberEditBySemanticTarget(
+        project: Project,
+        arguments: JsonObject,
+        symbolId: String?
+    ): Result<MemberEditPreparation> {
+        val rawElement = resolveElementFromArguments(project, arguments).getOrElse { return Result.failure(it) }
+        // A position resolves initially to the leaf token under the cursor. Convert that token to
+        // its semantic declaration before asking the language-specific member resolver; symbolId
+        // and qualified-name selectors already resolve directly to their declaration.
+        val element = if (
+            optionalStringArg(arguments, UnifiedTargetArguments.NORMALIZED_VARIANT) == UnifiedTargetArguments.POSITION
+        ) {
+            PsiUtils.resolveTargetElement(rawElement) ?: rawElement
+        } else {
+            rawElement
+        }
+        val psiFile = element.containingFile
+            ?: return Result.failure(
+                IllegalArgumentException(symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no source file")
+            )
+        val virtualFile = psiFile.virtualFile
+            ?: return Result.failure(
+                IllegalArgumentException(symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no editable source file")
+            )
+        if (!virtualFile.isWritable) {
+            return Result.failure(IllegalArgumentException("File is read-only and cannot be modified: ${virtualFile.path}"))
+        }
+        val resolver = MemberEditingUtils.getResolver(psiFile, project)
+            ?: return Result.failure(
+                IllegalArgumentException("Member editing not supported for ${psiFile.language.displayName}. Supported: Java, Kotlin.")
+            )
+        val member = resolver.resolveMember(element)
+            ?: return Result.failure(IllegalArgumentException("Target does not identify an editable Java/Kotlin member"))
+        val document = MemberEditingUtils.getDocument(psiFile)
+            ?: return Result.failure(IllegalArgumentException("Cannot get document for file: ${virtualFile.path}"))
+        return Result.success(
+            MemberEditPreparation(psiFile, document, member, ProjectUtils.getToolFilePath(project, virtualFile))
+        )
     }
 
     private fun prepareMemberEdit(
@@ -115,13 +205,14 @@ class EditMemberTool : AbstractMcpTool() {
         project: Project,
         prep: MemberEditPreparation,
         content: String,
-        reformat: Boolean
+        reformat: Boolean,
+        requestedSymbolId: String?
     ): CallToolResult {
         val member = prep.member
-
         var startLine = 0
         var endLine = 0
         var error: String? = null
+        var updatedSymbol: ResolvedSymbolInfo? = null
 
         suspendingWriteAction(project, "Edit member: ${member.name}") {
             if (!member.element.isValid) {
@@ -132,15 +223,69 @@ class EditMemberTool : AbstractMcpTool() {
             val range = member.element.textRange
             val startOffset = range.startOffset
             val endOffset = range.endOffset
+            val replacementRange = TextRange(startOffset, startOffset + content.length)
+            val declarationType = member.element.node?.elementType
+            if (declarationType == null) {
+                error = "Cannot identify the declaration syntax for '${member.name}'. Rediscover the member and retry."
+                return@suspendingWriteAction
+            }
+            val isConstructor = (member.element as? PsiMethod)?.isConstructor
+
+            // Parse the replacement in its real syntactic context before changing the document.
+            // A comment, malformed declaration, or several sibling declarations cannot identify
+            // one replacement symbol. Nested declarations inside its body are still allowed.
+            val previewText = prep.document.text.replaceRange(startOffset, endOffset, content)
+            val previewFile = PsiFileFactory.getInstance(project)
+                .createFileFromText(prep.psiFile.name, prep.psiFile.fileType, previewText)
+            val preview = findReplacementDeclaration(previewFile, replacementRange, declarationType, isConstructor)
+            if (preview == null) {
+                error = "content must contain exactly one complete ${member.kind} declaration, optionally " +
+                    "surrounded by comments. To delete a member, use ide_refactor_safe_delete."
+                return@suspendingWriteAction
+            }
 
             prep.document.replaceString(startOffset, endOffset, content)
-            MemberEditingUtils.commitDocuments(project)
-            if (reformat) {
-                MemberEditingUtils.reformatRange(project, prep.psiFile, startOffset, startOffset + content.length)
+            try {
                 MemberEditingUtils.commitDocuments(project)
+                // Only the exact newly committed declaration is eligible for rebinding. Never
+                // reuse the old pointer or walk from its former offset to a named parent.
+                val replacement = findReplacementDeclaration(
+                    prep.psiFile, replacementRange, declarationType, isConstructor
+                )?.takeIf { it.textRange == preview.textRange && it.text == preview.text }
+                val replacementPointer = replacement?.let {
+                    SmartPointerManager.getInstance(project).createSmartPsiElementPointer(it)
+                }
+                val editedRange = prep.document.createRangeMarker(replacementRange.startOffset, replacementRange.endOffset)
+                try {
+                    if (reformat) {
+                        MemberEditingUtils.reformatRange(
+                            project, prep.psiFile, replacementRange.startOffset, replacementRange.endOffset
+                        )
+                        MemberEditingUtils.commitDocuments(project)
+                    }
+                    val updated = replacementPointer?.element?.takeIf {
+                        it.isValid && matchesDeclarationType(it, declarationType, isConstructor)
+                    }
+                    if (updated != null) {
+                        updatedSymbol = resolvedSymbolInfo(project, updated, requestedSymbolId)
+                    }
+                    val finalRange = if (editedRange.isValid) {
+                        TextRange(editedRange.startOffset, editedRange.endOffset)
+                    } else {
+                        updated?.textRange ?: replacementRange
+                    }
+                    startLine = MemberEditingUtils.safeLineNumber(prep.document, finalRange.startOffset)
+                    endLine = MemberEditingUtils.safeLineNumber(prep.document, finalRange.endOffset)
+                } finally {
+                    editedRange.dispose()
+                }
+            } finally {
+                // An applied edit can outlive pointer restoration (or formatting can fail).
+                // Never leave the requested ID available to a different declaration afterward.
+                if (updatedSymbol == null && requestedSymbolId != null) {
+                    SymbolIdRegistry.getInstance().invalidate(requestedSymbolId)
+                }
             }
-            startLine = MemberEditingUtils.safeLineNumber(prep.document, startOffset)
-            endLine = MemberEditingUtils.safeLineNumber(prep.document, startOffset + content.length)
         }
 
         if (error != null) {
@@ -153,11 +298,58 @@ class EditMemberTool : AbstractMcpTool() {
             MemberEditResult(
                 success = true,
                 file = prep.relativePath,
-                message = "Replaced ${member.kind} '${member.name}' entirely",
+                message = "Replaced ${member.kind} '${member.name}' entirely" + if (updatedSymbol == null) {
+                    ". The symbol handle could not be restored; rediscover the edited declaration before another refactoring."
+                } else "",
                 startLine = startLine,
-                endLine = endLine
+                endLine = endLine,
+                updatedSymbol = updatedSymbol
             )
         )
+    }
+
+    private fun findReplacementDeclaration(
+        file: PsiFile,
+        range: TextRange,
+        declarationType: IElementType,
+        isConstructor: Boolean?
+    ): PsiElement? {
+        val firstTokenOffset = skipTrivia(file, range.startOffset, range.endOffset)
+        if (firstTokenOffset >= range.endOffset) return null
+        val leaf = file.findElementAt(firstTokenOffset) ?: return null
+        val declaration = generateSequence(leaf) { it.parent }
+            .takeWhile { it !is PsiFile && range.contains(it.textRange) }
+            .lastOrNull { matchesDeclarationType(it, declarationType, isConstructor) }
+            ?: return null
+        if (skipTrivia(file, range.startOffset, declaration.textRange.startOffset) != declaration.textRange.startOffset ||
+            skipTrivia(file, declaration.textRange.endOffset, range.endOffset) != range.endOffset ||
+            PsiTreeUtil.findChildOfType(declaration, PsiErrorElement::class.java) != null
+        ) {
+            return null
+        }
+        return declaration
+    }
+
+    private fun matchesDeclarationType(
+        element: PsiElement,
+        declarationType: IElementType,
+        isConstructor: Boolean?
+    ): Boolean = element.node?.elementType == declarationType &&
+        (isConstructor == null || (element as? PsiMethod)?.isConstructor == isConstructor)
+
+    private fun skipTrivia(file: PsiFile, startOffset: Int, endOffset: Int): Int {
+        var offset = startOffset
+        while (offset < endOffset) {
+            val element = file.findElementAt(offset) ?: break
+            val comment = PsiTreeUtil.getParentOfType(element, PsiComment::class.java, false)
+            offset = when {
+                element is PsiWhiteSpace -> minOf(element.textRange.endOffset, endOffset)
+                comment != null && comment.textRange.startOffset >= startOffset &&
+                    comment.textRange.endOffset <= endOffset -> comment.textRange.endOffset
+                else -> break
+            }
+        }
+        return offset
     }
 
     private fun handleError(error: Throwable, memberName: String): CallToolResult {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/HeadlessRenameProcessor.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/HeadlessRenameProcessor.kt
@@ -3,10 +3,14 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ConflictMessages
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
 import com.intellij.refactoring.ConflictsDialogBase
 import com.intellij.refactoring.rename.RenameProcessor
+import com.intellij.refactoring.rename.RenamePsiElementProcessor
+import com.intellij.refactoring.rename.RenameUtil
 import com.intellij.refactoring.rename.naming.AutomaticRenamer
+import com.intellij.refactoring.rename.naming.AutomaticRenamerFactory
 import com.intellij.usageView.UsageInfo
 import com.intellij.util.containers.MultiMap
 
@@ -15,17 +19,133 @@ import com.intellij.util.containers.MultiMap
  */
 internal class HeadlessRenameProcessor(
     project: Project,
-    element: PsiElement,
-    newName: String,
+    private val previewElement: PsiElement,
+    private val previewNewName: String,
     searchInComments: Boolean,
-    searchTextOccurrences: Boolean
-) : RenameProcessor(project, element, newName, searchInComments, searchTextOccurrences) {
+    searchTextOccurrences: Boolean,
+    private val trackAutomaticRenameCandidates: Boolean = false
+) : RenameProcessor(project, previewElement, previewNewName, searchInComments, searchTextOccurrences) {
+
+    /**
+     * Recorded while the platform creates renamers in [findUsages].  Candidate generation can
+     * be thread-affine for a language plugin, so it must happen only in that normal platform
+     * flow, never in a second best-effort pass after the usage search.
+     */
+    @Volatile
+    private var hasRecordedAutomaticRenameCandidates = false
+
+    private var implicitFactoriesTrackedForPreview = false
 
     /**
      * Sanitized conflict messages collected instead of showing the conflicts dialog.
      * Surfaced by [RenameSymbolTool] as result warnings.
      */
     val capturedConflicts = mutableListOf<String>()
+
+    override fun addRenamerFactory(factory: AutomaticRenamerFactory) {
+        super.addRenamerFactory(
+            if (trackAutomaticRenameCandidates) TrackingAutomaticRenamerFactory(factory) else factory
+        )
+    }
+
+    /**
+     * Mirrors the non-mutating first step of [RenameProcessor.doRun].  It is intentionally
+     * separate from [findUsages], because the platform's public findUsages method does not call
+     * prepareRenaming itself.
+     *
+     * Call this from the EDT without an enclosing read action, matching [RenameProcessor.doRun]:
+     * language processors may run synchronous progress that temporarily yields the EDT, which is
+     * forbidden while a caller-held read lock is active. A processor that cannot prepare its
+     * complete rename map must make the caller fail the preview closed rather than report a
+     * partial plan.
+     */
+    fun preparePreviewRenaming() {
+        prepareRenaming(previewElement, previewNewName, myAllRenames)
+        if (trackAutomaticRenameCandidates && !implicitFactoriesTrackedForPreview) {
+            // RenameProcessor evaluates null-option extension factories implicitly. Add tracking
+            // delegates before findUsages so the preview observes the same call and usage list.
+            // The platform will also invoke the original implicit factory; this is read-only and
+            // avoids relying on its private renamer list.
+            AutomaticRenamerFactory.EP_NAME.extensionList
+                .filter { it.optionName == null }
+                .forEach { super.addRenamerFactory(TrackingAutomaticRenamerFactory(it)) }
+            implicitFactoriesTrackedForPreview = true
+        }
+    }
+
+    /**
+     * Automatic renamers are finalized in preprocessUsages(), which may display a chooser.
+     * The dry-run does not call that method, so a renamer that actually found related elements
+     * makes its complete affected set impossible to promise. Merely applicable factories are not
+     * enough: several platform factories apply broadly but produce an empty renamer for ordinary
+     * declarations.
+     *
+     * This deliberately uses only public APIs. [TrackingAutomaticRenamerFactory] records the
+     * result while [RenameProcessor.findUsages] invokes its normal configured factories with
+     * the platform-selected element and per-element usages. No factory code is run here.
+     */
+    fun hasPotentialAutomaticRenames(): Boolean = hasRecordedAutomaticRenameCandidates
+
+    private inner class TrackingAutomaticRenamerFactory(
+        private val delegate: AutomaticRenamerFactory
+    ) : AutomaticRenamerFactory {
+        override fun isApplicable(element: PsiElement): Boolean = delegate.isApplicable(element)
+
+        override fun getOptionName(): String? = delegate.optionName
+
+        override fun isEnabled(): Boolean = delegate.isEnabled
+
+        override fun setEnabled(enabled: Boolean) {
+            delegate.isEnabled = enabled
+        }
+
+        override fun createRenamer(
+            element: PsiElement,
+            newName: String,
+            usages: Collection<UsageInfo>
+        ): AutomaticRenamer {
+            return delegate.createRenamer(element, newName, usages).also { renamer ->
+                hasRecordedAutomaticRenameCandidates =
+                    hasRecordedAutomaticRenameCandidates || renamer.hasAnythingToRename()
+            }
+        }
+    }
+
+    /**
+     * Collects the same non-UI rename conflicts used by the processor without calling
+     * `preprocessUsages()` or `run()`. The former can open language-specific dialogs and the
+     * latter mutates PSI, neither of which is permitted during a dry-run.
+     */
+    fun collectPreviewConflicts(usages: Array<UsageInfo>): List<String> {
+        val conflicts = MultiMap<PsiElement, String>()
+        RenameUtil.addConflictDescriptions(usages, conflicts)
+
+        val allRenames = linkedMapOf<PsiElement, String>()
+        for (element in elements) {
+            allRenames[element] = getNewName(element)
+        }
+        allRenames.putIfAbsent(previewElement, previewNewName)
+
+        // RenameProcessor's file-existence check is part of its apply path and may display UI or
+        // perform VFS work. A preview needs the same fail-closed signal without entering that
+        // path, so inspect only the current directory PSI under the caller's read action.
+        for ((element, newName) in allRenames) {
+            val file = element as? PsiFile ?: continue
+            val existingSibling = file.containingDirectory?.findFile(newName)
+            if (existingSibling != null && existingSibling != file) {
+                conflicts.putValue(
+                    file,
+                    "Cannot rename '${file.name}' to '$newName': a file with that name already exists in its containing directory."
+                )
+            }
+        }
+
+        for ((element, newName) in allRenames) {
+            RenamePsiElementProcessor.forElement(element)
+                .findExistingNameConflicts(element, newName, conflicts, allRenames)
+        }
+        return ConflictMessages.sanitizeAll(conflicts.values())
+    }
 
     override fun showAutomaticRenamingDialog(automaticVariableRenamer: AutomaticRenamer): Boolean {
         for (element in automaticVariableRenamer.elements) {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MemberEditingUtils.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/MemberEditingUtils.kt
@@ -1,6 +1,7 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.*
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ResolvedSymbolInfo
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
@@ -19,7 +20,8 @@ data class MemberEditResult(
     val file: String,
     val message: String,
     val startLine: Int? = null,
-    val endLine: Int? = null
+    val endLine: Int? = null,
+    val updatedSymbol: ResolvedSymbolInfo? = null
 )
 
 @Serializable

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringPreviewModels.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringPreviewModels.kt
@@ -1,0 +1,27 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ResolvedSymbolInfo
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Common wire shape returned by refactoring tools when `dryRun=true`.
+ *
+ * [plannedChange] deliberately remains a JSON object: rename, safe delete, and change
+ * signature have materially different plans, while the safety/discovery metadata is shared.
+ */
+@Serializable
+data class RefactoringPreviewResult(
+    val dryRun: Boolean = true,
+    val canApply: Boolean,
+    val target: ResolvedSymbolInfo,
+    val plannedChange: JsonObject,
+    val affectedFiles: List<String>,
+    val usageCount: Int,
+    val conflictCount: Int,
+    val warnings: List<String>,
+    val elapsedMs: Long
+)
+
+internal fun elapsedMillisSince(startedAtNanos: Long): Long =
+    (System.nanoTime() - startedAtNanos) / 1_000_000

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringScopeGuard.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringScopeGuard.kt
@@ -1,5 +1,6 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ConflictMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.ProjectUtils
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
@@ -7,10 +8,15 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Ref
 import com.intellij.openapi.util.ThrowableComputable
+import com.intellij.psi.PsiElement
 import com.intellij.refactoring.BaseRefactoringProcessor
 import com.intellij.refactoring.RefactoringBundle
+import com.intellij.refactoring.rename.RenameUtil
 import com.intellij.usageView.UsageInfo
+import com.intellij.util.containers.MultiMap
+import java.lang.reflect.InvocationTargetException
 
 /**
  * Pre-flight writability check for the *full* refactoring scope (issue #310).
@@ -30,6 +36,18 @@ import com.intellij.usageView.UsageInfo
  */
 internal object RefactoringScopeGuard {
     private val LOG = Logger.getInstance(RefactoringScopeGuard::class.java)
+
+    /**
+     * The outcome of change-signature conflict discovery.
+     *
+     * [usages] is intentionally the value left in the extension-owned `Ref`, rather than the
+     * input array: a [com.intellij.refactoring.changeSignature.ChangeSignatureUsageProcessor]
+     * may filter or replace usages while collecting conflicts.
+     */
+    internal data class ChangeSignatureConflictResult(
+        val usages: Array<UsageInfo>,
+        val conflicts: List<String>
+    )
 
     /**
      * Runs the pre-check usage search off the EDT.
@@ -65,6 +83,25 @@ internal object RefactoringScopeGuard {
             LOG.info("Read-only scope pre-check cancelled — proceeding without it")
             null
         }
+    }
+
+    /**
+     * Preview variant of [computeUsagesOffEdt]. Cancellation and discovery failures propagate:
+     * a dry-run must never turn an incomplete search into an apparently safe zero-usage plan.
+     */
+    fun computeUsagesOffEdtStrict(project: Project, findUsages: () -> Array<UsageInfo>): Array<UsageInfo> {
+        if (!ApplicationManager.getApplication().isDispatchThread) {
+            return ReadAction.compute<Array<UsageInfo>, RuntimeException> { findUsages() }
+        }
+        val search = ThrowableComputable<Array<UsageInfo>, RuntimeException> {
+            ReadAction.compute<Array<UsageInfo>, RuntimeException> { findUsages() }
+        }
+        return ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            search,
+            RefactoringBundle.message("progress.text"),
+            true,
+            project
+        )
     }
 
     /** Relative paths of read-only files among the usages' containing files. */
@@ -103,6 +140,81 @@ internal object RefactoringScopeGuard {
             LOG.warn("Read-only scope pre-check skipped — findUsages() reflection failed: ${e.message}")
             null
         }
+    }
+
+    /** Strict counterpart used by previews, where reflective API drift must fail closed. */
+    fun findUsagesReflectivelyOrThrow(processor: BaseRefactoringProcessor): Array<UsageInfo> {
+        var cls: Class<*>? = processor.javaClass
+        while (cls != null) {
+            val method = try {
+                cls.getDeclaredMethod("findUsages")
+            } catch (_: NoSuchMethodException) {
+                cls = cls.superclass
+                continue
+            }
+            method.isAccessible = true
+            val result = try {
+                method.invoke(processor)
+            } catch (e: InvocationTargetException) {
+                val cause = e.cause ?: e
+                when (cause) {
+                    is ProcessCanceledException -> throw cause
+                    is RuntimeException -> throw cause
+                    else -> throw IllegalStateException(cause.message ?: "findUsages() failed", cause)
+                }
+            }
+            @Suppress("UNCHECKED_CAST")
+            return result as? Array<UsageInfo>
+                ?: throw IllegalStateException("findUsages() returned no usage array")
+        }
+        throw IllegalStateException("findUsages() is unavailable on ${processor.javaClass.name}")
+    }
+
+    /**
+     * Runs the conflict collectors used by Java change-signature processors.
+     * Reflection keeps the Java plugin optional, while a missing or changed API is surfaced to
+     * the caller so preview can report `canApply=false` instead of silently assuming no conflicts.
+     *
+     * Must be called on EDT without an enclosing read action. The platform method delegates its
+     * extension work through `ActionUtil.underModalProgress`; invoking it under a read lock can
+     * deadlock when the modal worker needs PSI access.
+     */
+    fun collectChangeSignatureConflictsReflectively(
+        changeInfo: Any,
+        usages: Array<UsageInfo>
+    ): ChangeSignatureConflictResult {
+        ApplicationManager.getApplication().assertIsDispatchThread()
+        val conflicts = MultiMap<PsiElement, String>()
+        val usagesRef = Ref.create(usages.copyOf())
+        val changeInfoClass = Class.forName("com.intellij.refactoring.changeSignature.ChangeInfo")
+        val processorBaseClass = Class.forName(
+            "com.intellij.refactoring.changeSignature.ChangeSignatureProcessorBase"
+        )
+        val method = processorBaseClass.getMethod(
+            "collectConflictsFromExtensions",
+            Ref::class.java,
+            MultiMap::class.java,
+            changeInfoClass
+        )
+        try {
+            method.invoke(null, usagesRef, conflicts, changeInfo)
+        } catch (e: InvocationTargetException) {
+            val cause = e.cause ?: e
+            when (cause) {
+                is ProcessCanceledException -> throw cause
+                is RuntimeException -> throw cause
+                else -> throw IllegalStateException(cause.message ?: "Conflict discovery failed", cause)
+            }
+        }
+        val effectiveUsages = usagesRef.get()
+            ?: throw IllegalStateException("Change signature conflict extension returned no usage array")
+        ReadAction.run<RuntimeException> {
+            RenameUtil.addConflictDescriptions(effectiveUsages, conflicts)
+        }
+        return ChangeSignatureConflictResult(
+            usages = effectiveUsages,
+            conflicts = ConflictMessages.sanitizeAll(conflicts.values()).distinct()
+        )
     }
 
     /** Builds the error message for a scope blocked by [readOnlyFiles]. */

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolTool.kt
@@ -1,9 +1,11 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.UnifiedTargetArguments
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
@@ -22,13 +24,20 @@ import com.intellij.refactoring.rename.RenamePsiElementProcessor
 import com.intellij.refactoring.rename.naming.AutomaticRenamerFactory
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.usageView.UsageInfo
 import com.intellij.util.Processor
 import com.intellij.util.containers.MultiMap
+import com.intellij.openapi.progress.ProcessCanceledException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.lang.reflect.InvocationTargetException
 
 /**
  * Universal rename tool that works across all languages supported by JetBrains IDEs.
@@ -47,6 +56,8 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 class RenameSymbolTool : AbstractMcpTool() {
 
+    override val supportsUnifiedTarget: Boolean = true
+
     companion object {
         private val LOG = com.intellij.openapi.diagnostic.Logger.getInstance(RenameSymbolTool::class.java)
 
@@ -61,6 +72,8 @@ class RenameSymbolTool : AbstractMcpTool() {
         internal sealed class RenameModeDecision {
             data object FileRenameMode : RenameModeDecision()
             data class SymbolRenameMode(val line: Int, val column: Int) : RenameModeDecision()
+            data class SymbolIdRenameMode(val symbolId: String) : RenameModeDecision()
+            data object QualifiedSymbolRenameMode : RenameModeDecision()
             data class InvalidRenameMode(val error: String) : RenameModeDecision()
         }
 
@@ -101,6 +114,51 @@ class RenameSymbolTool : AbstractMcpTool() {
 
         internal fun resolveRenameMode(arguments: JsonObject): RenameModeDecision {
             val targetType = arguments[ParamNames.TARGET_TYPE_CAMEL]?.jsonPrimitive?.content
+            if (
+                targetType == "file" &&
+                arguments[UnifiedTargetArguments.NORMALIZED_VARIANT]?.jsonPrimitive?.content == UnifiedTargetArguments.POSITION
+            ) {
+                return RenameModeDecision.InvalidRenameMode(
+                    "target.position selects a symbol and cannot be combined with targetType='file'"
+                )
+            }
+            val symbolId = (arguments[ParamNames.SYMBOL_ID] as? JsonPrimitive)
+                ?.takeIf { it.isString }
+                ?.content
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+            if (symbolId != null) {
+                val hasFile = (arguments[ParamNames.FILE] as? JsonPrimitive)
+                    ?.takeIf { it.isString }
+                    ?.content
+                    ?.isNotBlank() == true
+                val hasCoordinates = hasNonNullValue(arguments[ParamNames.LINE]) ||
+                    hasNonNullValue(arguments[ParamNames.COLUMN])
+                return if (targetType == "file" || hasFile || hasCoordinates) {
+                    RenameModeDecision.InvalidRenameMode(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE)
+                } else if (targetType == null || targetType == "symbol") {
+                    RenameModeDecision.SymbolIdRenameMode(symbolId)
+                } else {
+                    RenameModeDecision.InvalidRenameMode("Invalid targetType: '$targetType'. Must be 'symbol' or 'file'.")
+                }
+            }
+            val hasQualifiedSelector = hasNonBlankString(arguments[ParamNames.LANGUAGE]) ||
+                hasNonBlankString(arguments[ParamNames.SYMBOL])
+            if (hasQualifiedSelector) {
+                val hasFile = (arguments[ParamNames.FILE] as? JsonPrimitive)
+                    ?.takeIf { it.isString }
+                    ?.content
+                    ?.isNotBlank() == true
+                val hasCoordinates = hasNonNullValue(arguments[ParamNames.LINE]) ||
+                    hasNonNullValue(arguments[ParamNames.COLUMN])
+                return if (targetType == "file" || hasFile || hasCoordinates) {
+                    RenameModeDecision.InvalidRenameMode(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE)
+                } else if (targetType == null || targetType == "symbol") {
+                    RenameModeDecision.QualifiedSymbolRenameMode
+                } else {
+                    RenameModeDecision.InvalidRenameMode("Invalid targetType: '$targetType'. Must be 'symbol' or 'file'.")
+                }
+            }
             return when (targetType) {
                 "file" -> RenameModeDecision.FileRenameMode
                 "symbol" -> resolveRenameMode(
@@ -135,13 +193,18 @@ class RenameSymbolTool : AbstractMcpTool() {
         private fun readCoordinateValue(value: JsonElement?): CoordinateRead {
             return try {
                 when (value) {
-                    null -> CoordinateRead.Missing
+                    null, JsonNull -> CoordinateRead.Missing
                     else -> CoordinateRead.Present(value.jsonPrimitive.int)
                 }
             } catch (_: Exception) {
                 CoordinateRead.Invalid
             }
         }
+
+        private fun hasNonBlankString(value: JsonElement?): Boolean =
+            (value as? JsonPrimitive)?.takeIf { it.isString }?.content?.isNotBlank() == true
+
+        private fun hasNonNullValue(value: JsonElement?): Boolean = value != null && value != JsonNull
 
         /** Exposed for testing — builds the error message returned when the target is a compiled element. */
         fun buildCompiledElementErrorMessage(elementName: String?, path: String): String =
@@ -159,13 +222,21 @@ class RenameSymbolTool : AbstractMcpTool() {
     @org.jetbrains.annotations.TestOnly
     internal var processorRunHook: (() -> Unit)? = null
 
+    /** Lets behavior tests prove that an incomplete preview search fails closed. */
+    @org.jetbrains.annotations.TestOnly
+    internal var previewUsageSearchHook: (() -> Unit)? = null
+
+    /** Lets behavior tests verify that cancellation from deep-super resolution is not swallowed. */
+    @org.jetbrains.annotations.TestOnly
+    internal var deepestSuperMethodResolutionHook: ((PsiNamedElement) -> PsiNamedElement?)? = null
+
     override val name = "ide_refactor_rename"
 
     override val description = """
         Rename a symbol or file and update all references across the project. Use instead of find-and-replace for safe, semantic renaming that handles all usages correctly. Supports undo (Ctrl+Z).
 
         Two modes:
-        - **Symbol rename** (`targetType="symbol"`, file + line + column + newName): Rename a symbol at a specific position. `line` and `column` are 1-based and must be provided.
+        - **Symbol rename** (`targetType="symbol"`, symbolId + newName OR file + line + column + newName): Rename an exact saved symbol. `symbolId` is mutually exclusive with coordinates.
         - **File rename** (`targetType="file"`, file + newName): Rename the file itself. Any placeholder `line`/`column` values are ignored for mode selection. Works for all file types including binary files (images, etc.). Especially useful for Android resource files (.webp, .png, .xml in res/) where it updates all resource references across the project.
 
         Backward compatibility: if `targetType` is omitted, null/null line+column still means file rename; provided line+column still means symbol rename.
@@ -185,7 +256,7 @@ class RenameSymbolTool : AbstractMcpTool() {
 
         Returns: affected files list and change count. Modifies source files.
 
-        Parameters: file + newName (required). targetType is optional; line + column are only needed for symbol rename. overrideStrategy + relatedRenamingStrategy (optional).
+        Parameters: newName (required), plus symbolId or file target coordinates. targetType is optional; line + column are only needed for position-based symbol rename. overrideStrategy + relatedRenamingStrategy (optional).
 
         Examples:
         - Symbol rename: {"file": "src/UserService.java", "targetType": "symbol", "line": 15, "column": 18, "newName": "CustomerService"}
@@ -194,7 +265,10 @@ class RenameSymbolTool : AbstractMcpTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
-        .file(description = "Path to file relative to project root. REQUIRED.")
+        .target()
+        .symbolId()
+        .languageAndSymbol(required = false)
+        .file(required = false, description = "Path to file relative to project root. Required for file rename or position-based symbol rename; omit when symbolId is used.")
         .enumProperty(
             ParamNames.TARGET_TYPE_CAMEL,
             "What to rename: 'symbol' (requires 1-based line+column) or 'file' (renames the file itself and ignores placeholder line/column values). If omitted, legacy behavior applies.",
@@ -220,6 +294,10 @@ class RenameSymbolTool : AbstractMcpTool() {
                 "'ask': show the IDE dialog for each related rename for interactive choice.",
             listOf("all", "none", "accessors_and_tests", "ask")
         )
+        .booleanProperty(
+            ParamNames.DRY_RUN,
+            "Resolve and validate the target, then discover usages/conflicts without modifying files. Default: false."
+        )
         .build()
 
     /**
@@ -229,7 +307,8 @@ class RenameSymbolTool : AbstractMcpTool() {
         val element: PsiNamedElement,
         val oldName: String,
         val error: String? = null,
-        val newNameOverride: String? = null
+        val newNameOverride: String? = null,
+        val previewDiscoveryWarnings: List<String> = emptyList()
     )
 
     private data class JsTsFileRenameRetargeting(
@@ -249,13 +328,19 @@ class RenameSymbolTool : AbstractMcpTool() {
         val affectedFilesCount: Int,
         val relatedRenamesCount: Int,
         val warnings: List<String>?,
-        val unretargetedImporters: List<String>?
+        val unretargetedImporters: List<String>?,
+        val renamedElementPointer: SmartPsiElementPointer<PsiNamedElement>
+    )
+
+    private data class RenamePreviewSetup(
+        val targetElement: PsiNamedElement,
+        val effectiveNewName: String,
+        val processor: HeadlessRenameProcessor
     )
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
-        val file = requiredStringArg(arguments, "file").getOrElse {
-            return createErrorResult(it.message ?: "Missing required parameter: file")
-        }
+        val startedAtNanos = System.nanoTime()
+        val dryRun = arguments[ParamNames.DRY_RUN]?.jsonPrimitive?.booleanOrNull == true
         val newName = arguments["newName"]?.jsonPrimitive?.content
             ?: return createErrorResult("Missing required parameter: newName")
 
@@ -281,6 +366,12 @@ class RenameSymbolTool : AbstractMcpTool() {
             is RenameModeDecision.SymbolRenameMode -> {
                 // continue
             }
+            is RenameModeDecision.SymbolIdRenameMode -> {
+                // continue
+            }
+            RenameModeDecision.QualifiedSymbolRenameMode -> {
+                // continue
+            }
             is RenameModeDecision.InvalidRenameMode -> {
                 return createErrorResult(renameMode.error)
             }
@@ -292,11 +383,57 @@ class RenameSymbolTool : AbstractMcpTool() {
         // PHASE 1: BACKGROUND - Find element and validate (suspending read action)
         // ═══════════════════════════════════════════════════════════════════════
         val validation = suspendingReadAction {
-            if (renameMode is RenameModeDecision.FileRenameMode) {
-                validateAndPrepareFileRename(project, file, newName)
-            } else {
-                val symbolMode = renameMode as RenameModeDecision.SymbolRenameMode
-                validateAndPrepare(project, file, symbolMode.line, symbolMode.column, newName)
+            when (renameMode) {
+                RenameModeDecision.FileRenameMode -> {
+                    val file = optionalStringArg(arguments, ParamNames.FILE)
+                        ?: return@suspendingReadAction RenameValidation(
+                            DummyNamedElement,
+                            "",
+                            "Missing required parameter: ${ParamNames.FILE}"
+                        )
+                    validateAndPrepareFileRename(
+                        project,
+                        file,
+                        newName,
+                        requireWritable = !dryRun,
+                        detectConflicts = !dryRun,
+                        failClosedOnDiscoveryError = dryRun
+                    )
+                }
+                is RenameModeDecision.SymbolRenameMode -> {
+                    val file = optionalStringArg(arguments, ParamNames.FILE)
+                        ?: return@suspendingReadAction RenameValidation(
+                            DummyNamedElement,
+                            "",
+                            "Missing required parameter: ${ParamNames.FILE}"
+                        )
+                    validateAndPrepare(
+                        project,
+                        file,
+                        renameMode.line,
+                        renameMode.column,
+                        newName,
+                        requireWritable = !dryRun,
+                        detectConflicts = !dryRun
+                    )
+                }
+                is RenameModeDecision.SymbolIdRenameMode ->
+                    validateAndPrepareBySemanticTarget(
+                        project,
+                        arguments,
+                        newName,
+                        requireWritable = !dryRun,
+                        detectConflicts = !dryRun
+                    )
+                RenameModeDecision.QualifiedSymbolRenameMode ->
+                    validateAndPrepareBySemanticTarget(
+                        project,
+                        arguments,
+                        newName,
+                        requireWritable = !dryRun,
+                        detectConflicts = !dryRun
+                    )
+                is RenameModeDecision.InvalidRenameMode -> error("Invalid rename mode already returned")
             }
         }
 
@@ -305,16 +442,39 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         val element = validation.element
+        val requestedPointer = suspendingReadAction {
+            SmartPointerManager.getInstance(project).createSmartPsiElementPointer(element)
+        }
         val oldName = validation.oldName
         val effectiveNewName = validation.newNameOverride ?: newName
-        val jsTsFileRetargeting = if (
-            renameMode is RenameModeDecision.FileRenameMode &&
-            element is PsiFile &&
-            shouldRetargetJsTsFileRenameSemantically(element.language.id, overrideStrategy)
-        ) {
-            suspendingReadAction { collectJsTsFileRenameRetargeting(element) }
-        } else {
-            null
+        // File/language metadata belongs to PSI too. Keep the entire preview/apply
+        // retargeting decision under the read action rather than reading it while this
+        // coroutine is otherwise unlocked.
+        val jsTsFileRetargeting = suspendingReadAction {
+            if (
+                renameMode is RenameModeDecision.FileRenameMode &&
+                element is PsiFile &&
+                shouldRetargetJsTsFileRenameSemantically(element.language.id, overrideStrategy)
+            ) {
+                collectJsTsFileRenameRetargeting(element)
+            } else {
+                null
+            }
+        }
+
+        if (dryRun) {
+            return previewRename(
+                project = project,
+                element = element,
+                oldName = oldName,
+                requestedNewName = effectiveNewName,
+                renameMode = renameMode,
+                overrideStrategy = overrideStrategy,
+                relatedRenamingStrategy = relatedRenamingStrategy,
+                jsTsFileRetargeting = jsTsFileRetargeting,
+                initialDiscoveryWarnings = validation.previewDiscoveryWarnings,
+                startedAtNanos = startedAtNanos
+            )
         }
 
         // ═══════════════════════════════════════════════════════════════════════
@@ -352,6 +512,15 @@ class RenameSymbolTool : AbstractMcpTool() {
             createErrorResult("Rename failed: $errorMessage", ToolNames.DIAGNOSTICS)
         } else {
             val result = renameExecutionResult!!
+            val updatedSymbol = suspendingReadAction {
+                (requestedPointer.element ?: result.renamedElementPointer.element)?.let { renamedElement ->
+                    resolvedSymbolInfo(
+                        project,
+                        renamedElement,
+                        (renameMode as? RenameModeDecision.SymbolIdRenameMode)?.symbolId
+                    )
+                }
+            }
             val relatedNote = if (result.relatedRenamesCount > 0) {
                 " (also renamed ${result.relatedRenamesCount} related element(s))"
             } else ""
@@ -367,10 +536,197 @@ class RenameSymbolTool : AbstractMcpTool() {
                     changesCount = result.affectedFilesCount,
                     message = "Successfully renamed '$oldName' to '$effectiveNewName'$relatedNote$partialNote",
                     warnings = result.warnings,
-                    unretargetedImporters = result.unretargetedImporters
+                    unretargetedImporters = result.unretargetedImporters,
+                    updatedSymbol = updatedSymbol
                 )
             )
         }
+    }
+
+    private suspend fun previewRename(
+        project: Project,
+        element: PsiNamedElement,
+        oldName: String,
+        requestedNewName: String,
+        renameMode: RenameModeDecision,
+        overrideStrategy: String,
+        relatedRenamingStrategy: String,
+        jsTsFileRetargeting: JsTsFileRenameRetargeting?,
+        initialDiscoveryWarnings: List<String>,
+        startedAtNanos: Long
+    ): CallToolResult {
+        val warnings = initialDiscoveryWarnings.toMutableList()
+        val affectedFiles = linkedSetOf<String>()
+        var usageCount = 0
+        var conflicts = emptyList<String>()
+        var discoveryComplete = initialDiscoveryWarnings.isEmpty()
+        var hasPotentialAutomaticRenames = false
+        var resolvedPreviewTarget: PsiNamedElement? = null
+
+        val (targetPath, targetWritable) = suspendingReadAction {
+            val targetFile = element.containingFile?.virtualFile
+            targetFile?.let { getRelativePath(project, it) } to (targetFile?.isWritable == true)
+        }
+        targetPath?.let(affectedFiles::add)
+        if (!targetWritable) {
+            warnings.add("Target file is read-only or unavailable; the rename cannot be applied.")
+        }
+
+        val exactInteractivePlan = overrideStrategy != "ask" && relatedRenamingStrategy != "ask"
+        if (overrideStrategy == "ask") {
+            warnings.add(
+                "overrideStrategy='ask' requires interactive target selection; " +
+                    "choose rename_base or rename_only_current for an applicable headless plan."
+            )
+        }
+        if (relatedRenamingStrategy == "ask") {
+            warnings.add(
+                "relatedRenamingStrategy='ask' requires interactive choices; " +
+                    "choose all, none, or accessors_and_tests for an applicable headless plan."
+            )
+        }
+
+        var plannedNewName = requestedNewName
+        try {
+            val setup = suspendingReadAction {
+                val targetElement = if (overrideStrategy == "ask") {
+                    resolveNonDialogSubstitution(element, failClosedOnDiscoveryError = true)
+                } else {
+                    resolveRenameTarget(element, overrideStrategy, failClosedOnDiscoveryError = true)
+                }
+                val effectiveNewName = computeEffectiveNewName(
+                    element,
+                    targetElement,
+                    requestedNewName,
+                    failClosedOnDiscoveryError = true
+                )
+                val processor = createConfiguredRenameProcessor(
+                    project = project,
+                    targetElement = targetElement,
+                    effectiveNewName = effectiveNewName,
+                    relatedRenamingStrategy = relatedRenamingStrategy,
+                    forceHeadless = true,
+                    failClosedOnDiscoveryError = true
+                ) as HeadlessRenameProcessor
+                RenamePreviewSetup(targetElement, effectiveNewName, processor)
+            }
+            resolvedPreviewTarget = setup.targetElement
+            plannedNewName = setup.effectiveNewName
+
+            // RenameProcessor.doRun() expands the rename map through prepareRenaming() before
+            // it searches usages. Its public findUsages() does not perform that expansion, so a
+            // preview must do it explicitly or it can omit substituted targets (notably Android
+            // resource variants). Automatic renamers are selected later by preprocessUsages(),
+            // which can show UI; do not call it from a preview. Their concrete candidate lists
+            // become available only after findUsages(), so inspect those rather than treating a
+            // broadly applicable but empty factory as an incomplete plan.
+            // Match RenameProcessor.doRun(): language-specific prepareRenaming implementations
+            // can coordinate synchronous progress with the EDT and must not inherit a caller-held
+            // read lock. This only expands an in-memory rename plan; it does not enter a write
+            // action, save documents, run the processor, or create an undo command.
+            edtAction { setup.processor.preparePreviewRenaming() }
+
+            previewUsageSearchHook?.invoke()
+            val usages = RefactoringScopeGuard.computeUsagesOffEdtStrict(project) {
+                setup.processor.findUsages()
+            }
+            usageCount = usages.size
+            hasPotentialAutomaticRenames = setup.processor.hasPotentialAutomaticRenames()
+            if (hasPotentialAutomaticRenames) {
+                warnings.add(
+                    "An automatic related-rename rule found related symbols. Its selection requires the " +
+                        "IDE preprocess step, so this preview cannot promise a complete headless plan."
+                )
+            }
+
+            val discovered = suspendingReadAction {
+                val files = linkedSetOf<String>()
+                val renamedVirtualFiles = buildList {
+                    setup.targetElement.containingFile?.virtualFile?.let(::add)
+                    setup.processor.elements.mapNotNullTo(this) { renamedElement ->
+                        renamedElement.containingFile?.virtualFile
+                    }
+                }.distinct()
+                renamedVirtualFiles.forEach { files.add(getRelativePath(project, it)) }
+                usages.mapNotNullTo(files) { usage ->
+                    usage.virtualFile?.let { getRelativePath(project, it) }
+                }
+                val readOnlyFiles = (
+                    RefactoringScopeGuard.readOnlyFilesIn(project, usages) +
+                        renamedVirtualFiles.filterNot { it.isWritable }
+                            .map { getRelativePath(project, it) }
+                    ).distinct().sorted()
+                Triple(
+                    files,
+                    setup.processor.collectPreviewConflicts(usages),
+                    readOnlyFiles
+                )
+            }
+            affectedFiles.addAll(discovered.first)
+            conflicts = discovered.second
+            warnings.addAll(conflicts)
+            if (discovered.third.isNotEmpty()) {
+                warnings.add(RefactoringScopeGuard.blockedMessage(discovered.third))
+            }
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            discoveryComplete = false
+            val cause = (e as? java.lang.reflect.InvocationTargetException)?.cause ?: e
+            warnings.add(
+                "Usage/conflict discovery failed: ${cause.message ?: cause.javaClass.simpleName}. " +
+                    "The preview is not safe to apply."
+            )
+        }
+
+        if (jsTsFileRetargeting != null) {
+            val importerFiles = suspendingReadAction {
+                jsTsFileRetargeting.references.mapNotNull { reference ->
+                    reference.importerFilePointer?.element?.virtualFile?.let {
+                        getRelativePath(project, it)
+                    }
+                }
+            }
+            affectedFiles.addAll(importerFiles)
+        }
+
+        val metadataTarget = resolvedPreviewTarget ?: element
+        val target = suspendingReadAction {
+            resolvedSymbolInfo(
+                project,
+                metadataTarget,
+                (renameMode as? RenameModeDecision.SymbolIdRenameMode)
+                    ?.takeIf { metadataTarget == element }
+                    ?.symbolId
+            )
+        }
+        val readOnlyTarget = !targetWritable
+        val hasReadOnlyScope = warnings.any { it.startsWith("Blocked by read-only files") }
+        val plannedChange = buildJsonObject {
+            put("operation", "rename")
+            put(
+                "targetType",
+                if (renameMode is RenameModeDecision.FileRenameMode) "file" else "symbol"
+            )
+            put("from", oldName)
+            put("to", plannedNewName)
+            put("overrideStrategy", overrideStrategy)
+            put("relatedRenamingStrategy", relatedRenamingStrategy)
+        }
+        return createJsonResult(
+            RefactoringPreviewResult(
+                canApply = discoveryComplete && exactInteractivePlan && !readOnlyTarget &&
+                    !hasReadOnlyScope && conflicts.isEmpty() && !hasPotentialAutomaticRenames,
+                target = target,
+                plannedChange = plannedChange,
+                affectedFiles = affectedFiles.sorted(),
+                usageCount = usageCount,
+                conflictCount = conflicts.size,
+                warnings = warnings.distinct(),
+                elapsedMs = elapsedMillisSince(startedAtNanos)
+            )
+        )
     }
 
     /**
@@ -382,7 +738,9 @@ class RenameSymbolTool : AbstractMcpTool() {
         file: String,
         line: Int,
         column: Int,
-        newName: String
+        newName: String,
+        requireWritable: Boolean = true,
+        detectConflicts: Boolean = true
     ): RenameValidation {
         val psiFile = getPsiFile(project, file)
             ?: return RenameValidation(
@@ -390,7 +748,7 @@ class RenameSymbolTool : AbstractMcpTool() {
                 oldName = "",
                 error = "File not found: $file"
             )
-        if (psiFile.virtualFile?.isWritable == false) {
+        if (requireWritable && psiFile.virtualFile?.isWritable == false) {
             return RenameValidation(
                 element = DummyNamedElement,
                 oldName = "",
@@ -448,7 +806,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         }
 
         // Check for naming conflicts (would show dialog otherwise)
-        val conflictError = checkForConflicts(namedElement, newName)
+        val conflictError = if (detectConflicts) checkForConflicts(namedElement, newName) else null
         if (conflictError != null) {
             return RenameValidation(
                 element = DummyNamedElement,
@@ -461,6 +819,61 @@ class RenameSymbolTool : AbstractMcpTool() {
             element = namedElement,
             oldName = oldName
         )
+    }
+
+    /** Resolves an exact semantic selector without any coordinate/nearest-element fallback. */
+    private fun validateAndPrepareBySemanticTarget(
+        project: Project,
+        arguments: JsonObject,
+        newName: String,
+        requireWritable: Boolean = true,
+        detectConflicts: Boolean = true
+    ): RenameValidation {
+        val symbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+        val element = resolveElementFromArguments(project, arguments).getOrElse {
+            return RenameValidation(
+                DummyNamedElement,
+                "",
+                it.message ?: symbolId?.let(ErrorMessages::symbolIdExpired) ?: ErrorMessages.COULD_NOT_RESOLVE_SYMBOL
+            )
+        }
+        val namedElement = element as? PsiNamedElement
+            ?: return RenameValidation(
+                DummyNamedElement,
+                "",
+                symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target does not identify a renameable named symbol"
+            )
+        val virtualFile = namedElement.containingFile?.virtualFile
+        if (virtualFile == null || (requireWritable && !virtualFile.isWritable)) {
+            return RenameValidation(
+                DummyNamedElement,
+                "",
+                if (virtualFile == null) symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no editable source file"
+                else "File is read-only and cannot be modified: ${virtualFile.path}"
+            )
+        }
+
+        val oldName = namedElement.name
+            ?: return RenameValidation(DummyNamedElement, "", "Element has no name")
+        if (namedElement is PsiCompiledElement) {
+            return RenameValidation(
+                DummyNamedElement,
+                "",
+                buildCompiledElementErrorMessage(oldName, virtualFile.path)
+            )
+        }
+        if (oldName == newName) {
+            return RenameValidation(DummyNamedElement, oldName, "New name is the same as the current name")
+        }
+        validateNewName(project, namedElement, newName)?.let {
+            return RenameValidation(DummyNamedElement, oldName, it)
+        }
+        if (detectConflicts) {
+            checkForConflicts(namedElement, newName)?.let {
+                return RenameValidation(DummyNamedElement, oldName, it)
+            }
+        }
+        return RenameValidation(namedElement, oldName)
     }
 
     /**
@@ -480,7 +893,10 @@ class RenameSymbolTool : AbstractMcpTool() {
     private fun validateAndPrepareFileRename(
         project: Project,
         file: String,
-        newName: String
+        newName: String,
+        requireWritable: Boolean = true,
+        detectConflicts: Boolean = true,
+        failClosedOnDiscoveryError: Boolean = false
     ): RenameValidation {
         val psiFile = getPsiFile(project, file)
             ?: return RenameValidation(
@@ -488,7 +904,7 @@ class RenameSymbolTool : AbstractMcpTool() {
                 oldName = "",
                 error = "File not found: $file"
             )
-        if (psiFile.virtualFile?.isWritable == false) {
+        if (requireWritable && psiFile.virtualFile?.isWritable == false) {
             return RenameValidation(
                 element = DummyNamedElement,
                 oldName = "",
@@ -506,7 +922,14 @@ class RenameSymbolTool : AbstractMcpTool() {
             )
         }
 
-        retargetJavaFileRenameToClass(project, psiFile, oldName, newName)?.let { return it }
+        retargetJavaFileRenameToClass(
+            project,
+            psiFile,
+            oldName,
+            newName,
+            detectConflicts,
+            failClosedOnDiscoveryError
+        )?.let { return it }
 
         return RenameValidation(
             element = psiFile,
@@ -535,7 +958,9 @@ class RenameSymbolTool : AbstractMcpTool() {
         project: Project,
         psiFile: PsiFile,
         oldName: String,
-        newName: String
+        newName: String,
+        detectConflicts: Boolean = true,
+        failClosedOnDiscoveryError: Boolean = false
     ): RenameValidation? {
         val keepsJavaExtension = newName.endsWith(".java") || !newName.contains('.')
         if (!keepsJavaExtension) return null
@@ -557,7 +982,22 @@ class RenameSymbolTool : AbstractMcpTool() {
                 .filterIsInstance<PsiNamedElement>()
                 .filterNot { implicitClassClass?.isInstance(it) == true }
                 .firstOrNull { it.name == oldBase }
+        } catch (_: ClassNotFoundException) {
+            // Java PSI is optional for this universal tool; no retargeting is available.
+            null
         } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            if (failClosedOnDiscoveryError) {
+                val cause = (e as? InvocationTargetException)?.cause ?: e
+                return RenameValidation(
+                    element = psiFile,
+                    oldName = oldName,
+                    previewDiscoveryWarnings = listOf(
+                        "Java file rename retargeting discovery failed: " +
+                            "${cause.message ?: cause.javaClass.simpleName}. The preview is not safe to apply."
+                    )
+                )
+            }
             LOG.debug("Java file rename retargeting probe failed: ${e.message}")
             null
         } ?: return null
@@ -565,7 +1005,7 @@ class RenameSymbolTool : AbstractMcpTool() {
         val newBase = newName.substringBeforeLast('.')
         if (newBase.isEmpty() || newBase == psiClass.name) return null
         if (validateNewName(project, psiClass, newBase) != null) return null
-        if (checkForConflicts(psiClass, newBase) != null) return null
+        if (detectConflicts && checkForConflicts(psiClass, newBase) != null) return null
         val className = psiClass.name ?: return null
 
         return RenameValidation(
@@ -670,32 +1110,13 @@ class RenameSymbolTool : AbstractMcpTool() {
         val shouldRetargetJsTsFileRename =
             jsTsFileElement != null && jsTsFileRetargeting != null
 
-        // Create the RenameProcessor with language-appropriate settings.
-        // NOTE: We intentionally DON'T search in comments/text occurrences to avoid
-        // non-code usage dialogs. The basic rename is more predictable for agents.
-        // When relatedRenamingStrategy is "ask", use a standard RenameProcessor so the
-        // IDE shows its built-in dialog for each automatic renamer.
-        val renameProcessor = if (relatedRenamingStrategy == "ask") {
-            RenameProcessor(project, targetElement, effectiveNewName, false, false)
-        } else {
-            HeadlessRenameProcessor(project, targetElement, effectiveNewName, false, false)
-        }
-
-        // Register automatic renamers based on the relatedRenamingStrategy.
-        // Factories with null option names are already handled automatically by RenameProcessor.
-        if (relatedRenamingStrategy != "none") {
-            for (factory in AutomaticRenamerFactory.EP_NAME.extensionList) {
-                if (factory.optionName == null) continue
-                if (relatedRenamingStrategy == "accessors_and_tests" && !isAccessorOrTestFactory(factory)) continue
-                renameProcessor.addRenamerFactory(factory)
-            }
-        }
-
-        // Add constructor parameter -> field relation up front.
-        addParameterFieldRelations(project, targetElement, effectiveNewName, renameProcessor)
-
-        // Disable preview dialog for headless operation
-        renameProcessor.setPreviewUsages(false)
+        val renameProcessor = createConfiguredRenameProcessor(
+            project = project,
+            targetElement = targetElement,
+            effectiveNewName = effectiveNewName,
+            relatedRenamingStrategy = relatedRenamingStrategy,
+            forceHeadless = false
+        )
 
         // Collected partial-success data from JS/TS import retargeting.
         val retargetWarnings = mutableListOf<String>()
@@ -764,8 +1185,51 @@ class RenameSymbolTool : AbstractMcpTool() {
             affectedFilesCount = affectedFiles.size,
             relatedRenamesCount = relatedRenamesCount,
             warnings = (conflictWarnings + retargetWarnings).distinct().takeIf { it.isNotEmpty() },
-            unretargetedImporters = unretargetedImporters.distinct().takeIf { it.isNotEmpty() }
+            unretargetedImporters = unretargetedImporters.distinct().takeIf { it.isNotEmpty() },
+            renamedElementPointer = targetPointer
         )
+    }
+
+    /** Builds the same processor configuration for apply and dry-run discovery. */
+    private fun createConfiguredRenameProcessor(
+        project: Project,
+        targetElement: PsiNamedElement,
+        effectiveNewName: String,
+        relatedRenamingStrategy: String,
+        forceHeadless: Boolean,
+        failClosedOnDiscoveryError: Boolean = false
+    ): RenameProcessor {
+        // We intentionally do not search comments/text occurrences: those searches can add
+        // non-code confirmation dialogs and make both apply and preview less deterministic.
+        val renameProcessor = if (!forceHeadless && relatedRenamingStrategy == "ask") {
+            RenameProcessor(project, targetElement, effectiveNewName, false, false)
+        } else {
+            HeadlessRenameProcessor(
+                project,
+                targetElement,
+                effectiveNewName,
+                false,
+                false,
+                trackAutomaticRenameCandidates = forceHeadless
+            )
+        }
+
+        if (relatedRenamingStrategy != "none") {
+            for (factory in AutomaticRenamerFactory.EP_NAME.extensionList) {
+                if (factory.optionName == null) continue
+                if (relatedRenamingStrategy == "accessors_and_tests" && !isAccessorOrTestFactory(factory)) continue
+                renameProcessor.addRenamerFactory(factory)
+            }
+        }
+        addParameterFieldRelations(
+            project,
+            targetElement,
+            effectiveNewName,
+            renameProcessor,
+            failClosedOnDiscoveryError
+        )
+        renameProcessor.setPreviewUsages(false)
+        return renameProcessor
     }
 
     /**
@@ -815,7 +1279,8 @@ class RenameSymbolTool : AbstractMcpTool() {
     private fun computeEffectiveNewName(
         element: PsiNamedElement,
         targetElement: PsiNamedElement,
-        newName: String
+        newName: String,
+        failClosedOnDiscoveryError: Boolean = false
     ): String {
         if (element !is PsiFile) return newName
 
@@ -827,8 +1292,10 @@ class RenameSymbolTool : AbstractMcpTool() {
         val probeRenames = linkedMapOf<PsiElement, String>(targetElement to newName)
         try {
             processor.prepareRenaming(targetElement, newName, probeRenames)
-        } catch (_: Exception) {
-            // If probing fails, fall through to default behavior
+        } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            if (failClosedOnDiscoveryError) throw e
+            // Apply compatibility: if probing fails, fall through to default behavior.
         }
 
         val wasSubstituted = targetElement !in probeRenames && probeRenames.isNotEmpty()
@@ -1136,7 +1603,11 @@ class RenameSymbolTool : AbstractMcpTool() {
      *   - "rename_only_current": use the element as-is, skip substitution (no dialog)
      *   - "ask": delegate to substituteElementToRename (shows IDE dialog)
      */
-    private fun resolveRenameTarget(element: PsiNamedElement, overrideStrategy: String): PsiNamedElement {
+    private fun resolveRenameTarget(
+        element: PsiNamedElement,
+        overrideStrategy: String,
+        failClosedOnDiscoveryError: Boolean = false
+    ): PsiNamedElement {
         if (element is PsiFile && shouldBypassDialogSubstitutionForFileRename(element.language.id, overrideStrategy)) {
             return element
         }
@@ -1144,13 +1615,18 @@ class RenameSymbolTool : AbstractMcpTool() {
         when (overrideStrategy) {
             "rename_base" -> {
                 // Resolve to the deepest super method to avoid the dialog
-                val deepestSuper = resolveDeepestSuperMethod(element)
+                val deepestSuper = resolveDeepestSuperMethod(element, failClosedOnDiscoveryError)
                 if (deepestSuper != null) return deepestSuper
+                if (failClosedOnDiscoveryError) {
+                    // Preview cannot enter the standard substitution path because Java method
+                    // processors may ask the user which hierarchy level to rename.
+                    return resolveNonDialogSubstitution(element, failClosedOnDiscoveryError = true)
+                }
             }
             "rename_only_current" -> {
                 // Use the element directly — skip substituteElementToRename entirely
                 // to avoid the dialog. Only apply non-dialog substitutions.
-                return resolveNonDialogSubstitution(element)
+                return resolveNonDialogSubstitution(element, failClosedOnDiscoveryError)
             }
             "ask" -> {
                 // Fall through to substituteElementToRename (will show dialog)
@@ -1167,14 +1643,23 @@ class RenameSymbolTool : AbstractMcpTool() {
      * Applies non-dialog substitutions (e.g., record component for accessor).
      * Skips substituteElementToRename() which would trigger the super method dialog.
      */
-    private fun resolveNonDialogSubstitution(element: PsiNamedElement): PsiNamedElement {
+    private fun resolveNonDialogSubstitution(
+        element: PsiNamedElement,
+        failClosedOnDiscoveryError: Boolean = false
+    ): PsiNamedElement {
         try {
             // Check for record component accessor (Java 16+)
             val recordUtilClass = Class.forName("com.intellij.psi.util.JavaPsiRecordUtil")
-            val result = recordUtilClass.getMethod("getRecordComponentForAccessor", Class.forName("com.intellij.psi.PsiMethod"))
+            val psiMethodClass = Class.forName("com.intellij.psi.PsiMethod")
+            if (!psiMethodClass.isInstance(element)) return element
+            val result = recordUtilClass.getMethod("getRecordComponentForAccessor", psiMethodClass)
                 .invoke(null, element)
             if (result is PsiNamedElement) return result
+        } catch (_: ClassNotFoundException) {
+            // Record PSI is optional; retain the original target when Java is unavailable.
         } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            if (failClosedOnDiscoveryError) throw e
             LOG.warn("Failed to resolve record component for accessor: ${e.message}", e)
         }
         return element
@@ -1190,9 +1675,13 @@ class RenameSymbolTool : AbstractMcpTool() {
      *
      * Uses reflection to access language-specific APIs to keep the tool language-agnostic.
      */
-    private fun resolveDeepestSuperMethod(element: PsiNamedElement): PsiNamedElement? {
+    private fun resolveDeepestSuperMethod(
+        element: PsiNamedElement,
+        failClosedOnDiscoveryError: Boolean = false
+    ): PsiNamedElement? {
         // Try Java/Kotlin PsiMethod path (covers KtLightMethod too)
         try {
+            deepestSuperMethodResolutionHook?.let { return it(element) }
             val psiMethodClass = Class.forName("com.intellij.psi.PsiMethod")
             if (psiMethodClass.isInstance(element)) {
                 val deepestSuperMethods = psiMethodClass.getMethod("findDeepestSuperMethods")
@@ -1202,7 +1691,11 @@ class RenameSymbolTool : AbstractMcpTool() {
                 }
                 return null
             }
+        } catch (_: ClassNotFoundException) {
+            // Java PSI is optional for this universal tool.
         } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            if (failClosedOnDiscoveryError) throw e
             LOG.warn("Failed to resolve deepest super method via PsiMethod API: ${e.message}", e)
         }
 
@@ -1227,11 +1720,22 @@ class RenameSymbolTool : AbstractMcpTool() {
             if (deepestSuperMethods.isNotEmpty()) {
                 return deepestSuperMethods[0] as? PsiNamedElement
             }
+        } catch (_: ClassNotFoundException) {
+            // Kotlin PSI is optional for this universal tool.
         } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            if (failClosedOnDiscoveryError) throw e
             LOG.warn("Failed to resolve deepest super method via Kotlin KtNamedFunction API: ${e.message}", e)
         }
 
         return null
+    }
+
+    private fun rethrowProcessCanceled(throwable: Throwable) {
+        generateSequence(throwable) { it.cause }
+            .filterIsInstance<ProcessCanceledException>()
+            .firstOrNull()
+            ?.let { throw it }
     }
 
     /**
@@ -1251,7 +1755,8 @@ class RenameSymbolTool : AbstractMcpTool() {
         project: Project,
         element: PsiNamedElement,
         newName: String,
-        renameProcessor: RenameProcessor
+        renameProcessor: RenameProcessor,
+        failClosedOnDiscoveryError: Boolean = false
     ): Int {
         var count = 0
 
@@ -1336,6 +1841,8 @@ class RenameSymbolTool : AbstractMcpTool() {
                 count++
             }
         } catch (e: Exception) {
+            rethrowProcessCanceled(e)
+            if (failClosedOnDiscoveryError) throw e
             // Reflection failed - likely not a Java/Kotlin project or different PSI structure
             // This is expected for other languages, silently continue
         }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReplaceMemberTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/ReplaceMemberTool.kt
@@ -2,15 +2,20 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.AbstractMcpTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.UnifiedTargetArguments
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.*
 import com.intellij.openapi.project.Project
+import com.intellij.psi.SmartPointerManager
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class ReplaceMemberTool : AbstractMcpTool() {
+
+    override val supportsUnifiedTarget: Boolean = true
 
     override val name = ToolNames.REPLACE_MEMBER
 
@@ -21,19 +26,23 @@ class ReplaceMemberTool : AbstractMcpTool() {
         For fields/properties: replaces the initializer expression (after =).
         Auto-reformats the changed range by default.
 
-        Requires: file (always), member (always). class is optional for top-level members (Kotlin).
+        Target with symbolId, or with file + member. class is optional for top-level members (Kotlin).
         For overloaded methods, use parameterCount or line to disambiguate.
 
         Examples:
+        - {"symbolId": "<opaque-id>", "content": "return 42;"}
         - {"file": "src/Main.java", "class": "Main", "member": "getName", "content": "return this.name;"}
         - {"file": "src/Config.kt", "member": "defaultPort", "content": "8080"}
     """.trimIndent()
 
     override val inputSchema = SchemaBuilder.tool()
         .projectPath()
-        .file(description = "Path to file relative to project root. REQUIRED.")
+        .target()
+        .symbolId()
+        .languageAndSymbol(required = false)
+        .file(required = false, description = "Path to file relative to project root. Required with member selectors; omit when symbolId is used.")
         .stringProperty(ParamNames.CLASS, "Class/interface name containing the member. Optional for top-level members (Kotlin).")
-        .stringProperty(ParamNames.MEMBER, "Name of the method, function, field, or property to replace the body/initializer of.", required = true)
+        .stringProperty(ParamNames.MEMBER, "Name of the method, function, field, or property to replace the body/initializer of. Required unless symbolId is used.")
         .intProperty(ParamNames.PARAMETER_COUNT, "Number of parameters (for disambiguating overloaded methods).")
         .intProperty(ParamNames.LINE, "1-based line number of the member (for disambiguation when multiple members share the same name).")
         .stringProperty(ParamNames.CONTENT, "The new body content (without surrounding braces for methods) or new initializer expression.", required = true)
@@ -41,32 +50,104 @@ class ReplaceMemberTool : AbstractMcpTool() {
         .build()
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
-        val filePath = arguments[ParamNames.FILE]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: file")
-        val memberName = arguments[ParamNames.MEMBER]?.jsonPrimitive?.content
-            ?: return createErrorResult("Missing required parameter: member")
+        val requestedSymbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+        val hasQualifiedTarget = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
+            optionalStringArg(arguments, ParamNames.SYMBOL) != null
+        val hasStructuredTarget = optionalStringArg(arguments, UnifiedTargetArguments.NORMALIZED_VARIANT) != null
+        val memberName = optionalStringArg(arguments, ParamNames.MEMBER) ?: "<symbolId>"
         val content = arguments[ParamNames.CONTENT]?.jsonPrimitive?.content
             ?: return createErrorResult("Missing required parameter: content")
         val className = MemberEditingUtils.getOptionalString(arguments, ParamNames.CLASS)
         val parameterCount = MemberEditingUtils.getOptionalInt(arguments, ParamNames.PARAMETER_COUNT)
         val line = MemberEditingUtils.getOptionalInt(arguments, ParamNames.LINE)
         val reformat = MemberEditingUtils.getOptionalBoolean(arguments, ParamNames.REFORMAT)
-
-        val virtualFile = resolveFile(project, filePath)
-            ?: return createErrorResult("File not found: $filePath")
-        ensureWritable(virtualFile)?.let { return it }
+        val hasLegacyMemberSelector = listOf(ParamNames.FILE, ParamNames.CLASS, ParamNames.MEMBER).any {
+            optionalStringArg(arguments, it) != null
+        } || parameterCount != null || line != null
 
         val prep = suspendingReadAction {
-            prepareMemberEdit(project, virtualFile, filePath, className, memberName, parameterCount, line)
+            if (requestedSymbolId != null || hasQualifiedTarget || hasStructuredTarget) {
+                if (!hasStructuredTarget && hasLegacyMemberSelector) {
+                    Result.failure(IllegalArgumentException(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE))
+                } else {
+                    prepareMemberEditBySemanticTarget(project, arguments, requestedSymbolId)
+                }
+            } else {
+                val filePath = optionalStringArg(arguments, ParamNames.FILE)
+                    ?: return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.FILE}")
+                    )
+                if (memberName == "<symbolId>") {
+                    return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("Missing required parameter: ${ParamNames.MEMBER}")
+                    )
+                }
+                val virtualFile = resolveFile(project, filePath)
+                    ?: return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("File not found: $filePath")
+                    )
+                if (!virtualFile.isWritable) {
+                    return@suspendingReadAction Result.failure(
+                        IllegalArgumentException("File is read-only and cannot be modified: ${virtualFile.path}")
+                    )
+                }
+                prepareMemberEdit(project, virtualFile, filePath, className, memberName, parameterCount, line)
+            }
         }
 
         return when {
             prep.isFailure -> prep.exceptionOrNull()!!.let { handleError(it, memberName) }
             else -> {
                 val p = prep.getOrThrow()
-                applyBodyReplacement(project, p, content, reformat)
+                applyBodyReplacement(project, p, content, reformat, requestedSymbolId)
             }
         }
+    }
+
+    private fun prepareMemberEditBySemanticTarget(
+        project: Project,
+        arguments: JsonObject,
+        symbolId: String?
+    ): Result<MemberEditPreparation> {
+        val rawElement = resolveElementFromArguments(project, arguments).getOrElse { return Result.failure(it) }
+        // Position selectors start at a leaf PSI token; resolve that token to the exact semantic
+        // declaration. Other selector variants already return declarations directly.
+        val element = if (
+            optionalStringArg(arguments, UnifiedTargetArguments.NORMALIZED_VARIANT) == UnifiedTargetArguments.POSITION
+        ) {
+            PsiUtils.resolveTargetElement(rawElement) ?: rawElement
+        } else {
+            rawElement
+        }
+        val psiFile = element.containingFile
+            ?: return Result.failure(
+                IllegalArgumentException(symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no source file")
+            )
+        val virtualFile = psiFile.virtualFile
+            ?: return Result.failure(
+                IllegalArgumentException(symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no editable source file")
+            )
+        if (!virtualFile.isWritable) {
+            return Result.failure(IllegalArgumentException("File is read-only and cannot be modified: ${virtualFile.path}"))
+        }
+        val resolver = MemberEditingUtils.getResolver(psiFile, project)
+            ?: return Result.failure(
+                IllegalArgumentException("Member editing not supported for ${psiFile.language.displayName}. Supported: Java, Kotlin.")
+            )
+        val member = resolver.resolveMember(element)
+            ?: return Result.failure(IllegalArgumentException("Target does not identify an editable Java/Kotlin member"))
+        if (member.kind == "class") {
+            return Result.failure(
+                IllegalArgumentException(
+                    "Cannot replace body of a class declaration. Use ide_edit_member to replace the entire class declaration."
+                )
+            )
+        }
+        val document = MemberEditingUtils.getDocument(psiFile)
+            ?: return Result.failure(IllegalArgumentException("Cannot get document for file: ${virtualFile.path}"))
+        return Result.success(
+            MemberEditPreparation(psiFile, document, member, ProjectUtils.getToolFilePath(project, virtualFile))
+        )
     }
 
     private fun prepareMemberEdit(
@@ -113,9 +194,13 @@ class ReplaceMemberTool : AbstractMcpTool() {
         project: Project,
         prep: MemberEditPreparation,
         content: String,
-        reformat: Boolean
+        reformat: Boolean,
+        requestedSymbolId: String?
     ): CallToolResult {
         val member = prep.member
+        val pointer = suspendingReadAction {
+            SmartPointerManager.getInstance(project).createSmartPsiElementPointer(member.element)
+        }
         val originalBodyStart = member.bodyStartOffset
         val originalBodyEnd = member.bodyEndOffset
 
@@ -163,13 +248,18 @@ class ReplaceMemberTool : AbstractMcpTool() {
 
         edtAction { MemberEditingUtils.saveToDisk() }
 
+        val updatedSymbol = suspendingReadAction {
+            pointer.element?.let { resolvedSymbolInfo(project, it, requestedSymbolId) }
+        }
+
         return createJsonResult(
             MemberEditResult(
                 success = true,
                 file = prep.relativePath,
                 message = "Replaced body of ${member.kind} '${member.name}'",
                 startLine = startLine,
-                endLine = endLine
+                endLine = endLine,
+                updatedSymbol = updatedSymbol
             )
         )
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteTool.kt
@@ -1,6 +1,9 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ErrorMessages
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.schema.SchemaBuilder
@@ -20,14 +23,20 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiWhiteSpace
+import com.intellij.refactoring.safeDelete.SafeDeleteProcessor
+import com.intellij.psi.search.searches.OverridingMethodsSearch
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.rename.RenamePsiElementProcessor
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
@@ -43,6 +52,8 @@ import org.jetbrains.annotations.TestOnly
  * 2. **EDT Phase**: Apply deletion quickly (in write action)
  */
 class SafeDeleteTool : AbstractRefactoringTool() {
+
+    override val supportsUnifiedTarget: Boolean = true
 
     private companion object {
         /**
@@ -75,7 +86,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         Delete a symbol or file safely by first checking for usages. Use when removing code to avoid breaking references.
 
         Modes:
-        - target_type='symbol' (default): Delete the symbol at line/column (REQUIRED: file, line, column).
+        - target_type='symbol' (default): Delete the exact symbol selected by symbolId, or by file + line/column.
           If position is whitespace/comment, returns nearby symbol suggestions.
         - target_type='file': Delete the entire file (REQUIRED: file only).
           Only succeeds if no symbols have external usages. Internal call chains don't block deletion.
@@ -86,6 +97,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         Returns: success status and affected files, OR blocking usages list, OR nearby symbol suggestions.
 
         Examples:
+        - Symbol ID: {"symbolId": "<opaque-id>"}
         - Symbol: {"file": "src/OldClass.java", "line": 10, "column": 14}
         - Symbol with force: {"file": "src/OldClass.java", "line": 10, "column": 14, "force": true}
         - File: {"file": "src/UnusedUtils.java", "target_type": "file"}
@@ -93,7 +105,10 @@ class SafeDeleteTool : AbstractRefactoringTool() {
 
     override val inputSchema: ToolSchema = SchemaBuilder.tool()
         .projectPath()
-        .file(description = "Path to file relative to project root. REQUIRED.")
+        .target()
+        .symbolId()
+        .languageAndSymbol(required = false)
+        .file(required = false, description = "Path to file relative to project root. Required for file deletion or position-based symbol deletion; omit when symbolId is used.")
         .intProperty("line", "1-based line number where the symbol is located. REQUIRED when target_type='symbol' (default).")
         .intProperty("column", "1-based column number. REQUIRED when target_type='symbol' (default).")
         .property("target_type", buildJsonObject {
@@ -110,6 +125,10 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             put("default", false)
             put("description", "Force deletion even if usages exist. Default: false. Use with caution!")
         })
+        .booleanProperty(
+            ParamNames.DRY_RUN,
+            "Resolve the target and check usages without deleting anything. Default: false."
+        )
         .build()
 
     /**
@@ -120,7 +139,8 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         val elementName: String,
         val elementType: String,
         val usages: List<UsageInfo>,
-        val affectedFile: String
+        val affectedFile: String,
+        val symbolId: String? = null
     )
 
     /**
@@ -131,7 +151,10 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         val fileName: String,
         val filePath: String,
         val symbols: List<SymbolInfo>,
-        val externalUsages: List<UsageInfo>
+        val externalUsages: List<UsageInfo>,
+        /** A preview may report observed usages without pretending the search was exhaustive. */
+        val discoveryComplete: Boolean = true,
+        val incompleteDiscoveryReason: String? = null
     )
 
     /**
@@ -146,7 +169,11 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         data class FileNotFound(val file: String) : SymbolPreparationResult()
         data class ReadOnly(val file: String) : SymbolPreparationResult()
         data class PositionOutOfBounds(val line: Int, val column: Int) : SymbolPreparationResult()
-        data class UsageSearchFailed(val reason: String) : SymbolPreparationResult()
+        data class UsageSearchFailed(
+            val reason: String,
+            val partial: SymbolDeletePreparation? = null
+        ) : SymbolPreparationResult()
+        data class InvalidSymbolId(val message: String) : SymbolPreparationResult()
     }
 
     /**
@@ -157,7 +184,10 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         data object FileNotFound : FilePreparationResult()
         data class ReadOnly(val file: String) : FilePreparationResult()
         data class NonPhysicalFile(val fileName: String) : FilePreparationResult()
-        data class UsageSearchFailed(val reason: String) : FilePreparationResult()
+        data class UsageSearchFailed(
+            val reason: String,
+            val partial: FileDeletePreparation? = null
+        ) : FilePreparationResult()
     }
 
     /**
@@ -167,22 +197,52 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     private class UsageSearchException(cause: Exception) : RuntimeException(cause)
 
     override suspend fun doExecute(project: Project, arguments: JsonObject): CallToolResult {
-        val file = requiredStringArg(arguments, "file").getOrElse {
-            return createErrorResult(it.message ?: "Missing required parameter: file")
-        }
+        val startedAtNanos = System.nanoTime()
+        val dryRun = arguments[ParamNames.DRY_RUN]?.jsonPrimitive?.booleanOrNull == true
+        val symbolId = optionalStringArg(arguments, ParamNames.SYMBOL_ID)
+        val hasQualifiedTarget = optionalStringArg(arguments, ParamNames.LANGUAGE) != null ||
+            optionalStringArg(arguments, ParamNames.SYMBOL) != null
         val targetType = arguments["target_type"]?.jsonPrimitive?.content ?: "symbol"
         val force = arguments["force"]?.jsonPrimitive?.content?.toBoolean() ?: false
 
         requireSmartMode(project)
 
         return when (targetType) {
-            "file" -> executeFileDelete(project, file, force)
+            "file" -> {
+                if (symbolId != null || hasQualifiedTarget ||
+                    arguments[ParamNames.LINE]?.let { it != JsonNull } == true ||
+                    arguments[ParamNames.COLUMN]?.let { it != JsonNull } == true
+                ) {
+                    return createErrorResult("target_type='file' accepts only the file path; omit symbol selectors and coordinates")
+                }
+                val file = optionalStringArg(arguments, ParamNames.FILE)
+                    ?: return createErrorResult("Missing required parameter: ${ParamNames.FILE}")
+                executeFileDelete(project, file, force, dryRun, startedAtNanos)
+            }
             "symbol" -> {
+                if (symbolId != null || hasQualifiedTarget) {
+                    if (optionalStringArg(arguments, ParamNames.FILE) != null ||
+                        arguments[ParamNames.LINE]?.let { it != JsonNull } == true ||
+                        arguments[ParamNames.COLUMN]?.let { it != JsonNull } == true
+                    ) {
+                        return createErrorResult(ErrorMessages.SYMBOL_ID_AND_OTHER_TARGET_EXCLUSIVE)
+                    }
+                    return executeSymbolDeleteBySemanticTarget(
+                        project,
+                        arguments,
+                        symbolId,
+                        force,
+                        dryRun,
+                        startedAtNanos
+                    )
+                }
+                val file = optionalStringArg(arguments, ParamNames.FILE)
+                    ?: return createErrorResult("Missing required parameter: ${ParamNames.FILE}")
                 val line = arguments["line"]?.jsonPrimitive?.int
                     ?: return createErrorResult("Missing required parameter 'line' for target_type='symbol'")
                 val column = arguments["column"]?.jsonPrimitive?.int
                     ?: return createErrorResult("Missing required parameter 'column' for target_type='symbol'")
-                executeSymbolDelete(project, file, line, column, force)
+                executeSymbolDelete(project, file, line, column, force, dryRun, startedAtNanos)
             }
             else -> createErrorResult("Invalid target_type: '$targetType'. Must be 'symbol' or 'file'.")
         }
@@ -197,18 +257,30 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         file: String,
         line: Int,
         column: Int,
-        force: Boolean
+        force: Boolean,
+        dryRun: Boolean,
+        startedAtNanos: Long
     ): CallToolResult {
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Find element and check usages (suspending read action)
         // ═══════════════════════════════════════════════════════════════════════
         val preparationResult = suspendingReadAction {
-            prepareSymbolDelete(project, file, line, column, force)
+            prepareSymbolDelete(
+                project,
+                file,
+                line,
+                column,
+                force = if (dryRun) false else force,
+                allowReadOnly = dryRun
+            )
         }
 
         return when (preparationResult) {
             is SymbolPreparationResult.Success -> {
                 val preparation = preparationResult.data
+                if (dryRun) {
+                    return createSymbolDeletePreview(project, preparation, force, startedAtNanos)
+                }
                 // If there are usages and force is false, return them without deleting
                 if (preparation.usages.isNotEmpty() && !force) {
                     return createJsonResult(
@@ -254,8 +326,87 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 createErrorResult("Position out of bounds: line ${preparationResult.line}, column ${preparationResult.column}")
             }
             is SymbolPreparationResult.UsageSearchFailed -> {
-                createErrorResult(usageSearchFailedMessage(preparationResult.reason))
+                if (dryRun && preparationResult.partial != null) {
+                    createSymbolDeletePreview(
+                        project,
+                        preparationResult.partial,
+                        force,
+                        startedAtNanos,
+                        discoveryError = preparationResult.reason
+                    )
+                } else {
+                    createErrorResult(usageSearchFailedMessage(preparationResult.reason))
+                }
             }
+            is SymbolPreparationResult.InvalidSymbolId -> {
+                // This variant is only produced by the symbolId path, but keeping the branch
+                // explicit makes this exhaustive if preparation logic is shared in the future.
+                createErrorResult(preparationResult.message)
+            }
+        }
+    }
+
+    /** Exact semantic target path, with no nearby-symbol suggestions or coordinate fallback. */
+    private suspend fun executeSymbolDeleteBySemanticTarget(
+        project: Project,
+        arguments: JsonObject,
+        symbolId: String?,
+        force: Boolean,
+        dryRun: Boolean,
+        startedAtNanos: Long
+    ): CallToolResult {
+        val preparationResult = suspendingReadAction {
+            prepareSymbolDeleteBySemanticTarget(
+                project,
+                arguments,
+                symbolId,
+                force = if (dryRun) false else force,
+                allowReadOnly = dryRun
+            )
+        }
+
+        return when (preparationResult) {
+            is SymbolPreparationResult.Success -> {
+                val preparation = preparationResult.data
+                if (dryRun) {
+                    return createSymbolDeletePreview(project, preparation, force, startedAtNanos)
+                }
+                if (preparation.usages.isNotEmpty() && !force) {
+                    createJsonResult(
+                        SafeDeleteBlockedResult(
+                            canDelete = false,
+                            elementName = preparation.elementName,
+                            elementType = preparation.elementType,
+                            usageCount = preparation.usages.size,
+                            blockingUsages = preparation.usages.take(20),
+                            message = "Cannot delete '${preparation.elementName}': found ${preparation.usages.size} usage(s). Use force=true to delete anyway.",
+                            symbolId = symbolId
+                        )
+                    )
+                } else {
+                    beforeDeletionHook?.invoke()
+                    applySymbolDeletion(project, preparation, force)
+                }
+            }
+            is SymbolPreparationResult.InvalidSymbolId -> createErrorResult(preparationResult.message)
+            is SymbolPreparationResult.ReadOnly ->
+                createErrorResult("File is read-only and cannot be modified: ${preparationResult.file}")
+            is SymbolPreparationResult.UsageSearchFailed -> {
+                if (dryRun && preparationResult.partial != null) {
+                    createSymbolDeletePreview(
+                        project,
+                        preparationResult.partial,
+                        force,
+                        startedAtNanos,
+                        discoveryError = preparationResult.reason
+                    )
+                } else {
+                    createErrorResult(usageSearchFailedMessage(preparationResult.reason))
+                }
+            }
+            else -> createErrorResult(
+                symbolId?.let(ErrorMessages::symbolIdExpired) ?: ErrorMessages.COULD_NOT_RESOLVE_SYMBOL
+            )
         }
     }
 
@@ -265,18 +416,28 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     private suspend fun executeFileDelete(
         project: Project,
         file: String,
-        force: Boolean
+        force: Boolean,
+        dryRun: Boolean,
+        startedAtNanos: Long
     ): CallToolResult {
         // ═══════════════════════════════════════════════════════════════════════
         // PHASE 1: BACKGROUND - Collect symbols and find external usages
         // ═══════════════════════════════════════════════════════════════════════
         val preparationResult = suspendingReadAction {
-            prepareFileDelete(project, file, force)
+            prepareFileDelete(
+                project,
+                file,
+                force = if (dryRun) false else force,
+                allowReadOnly = dryRun
+            )
         }
 
         return when (preparationResult) {
             is FilePreparationResult.Success -> {
                 val preparation = preparationResult.data
+                if (dryRun) {
+                    return createFileDeletePreview(project, preparation, force, startedAtNanos)
+                }
                 // If there are external usages and force is false, return them
                 if (preparation.externalUsages.isNotEmpty() && !force) {
                     return createJsonResult(
@@ -308,7 +469,17 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 createErrorResult("Cannot delete non-physical file '${preparationResult.fileName}' (e.g., in-memory or generated file)")
             }
             is FilePreparationResult.UsageSearchFailed -> {
-                createErrorResult(usageSearchFailedMessage(preparationResult.reason))
+                if (dryRun && preparationResult.partial != null) {
+                    createFileDeletePreview(
+                        project,
+                        preparationResult.partial,
+                        force,
+                        startedAtNanos,
+                        discoveryError = preparationResult.reason
+                    )
+                } else {
+                    createErrorResult(usageSearchFailedMessage(preparationResult.reason))
+                }
             }
         }
     }
@@ -316,6 +487,112 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     private fun usageSearchFailedMessage(reason: String): String =
         "Usage search failed ($reason) — refusing to delete without a complete usage check. " +
             "Retry, or use force=true to delete anyway."
+
+    private suspend fun createSymbolDeletePreview(
+        project: Project,
+        preparation: SymbolDeletePreparation,
+        force: Boolean,
+        startedAtNanos: Long,
+        discoveryError: String? = null
+    ): CallToolResult {
+        val (writable, target) = suspendingReadAction {
+            val targetFile = preparation.element.containingFile?.virtualFile
+            (targetFile?.isWritable == true) to
+                resolvedSymbolInfo(project, preparation.element, preparation.symbolId)
+        }
+        val warnings = mutableListOf<String>()
+        if (!writable) {
+            warnings.add("Target file is read-only or unavailable; the deletion cannot be applied.")
+        }
+        if (discoveryError != null) {
+            warnings.add(
+                "Usage discovery failed: $discoveryError. Refusing to mark this preview as applicable."
+            )
+        } else if (preparation.usages.isNotEmpty()) {
+            warnings.add(
+                if (force) {
+                    "Force deletion would leave ${preparation.usages.size} usage(s) unresolved."
+                } else {
+                    "Deletion is blocked by ${preparation.usages.size} usage(s); set force=true to override."
+                }
+            )
+        }
+
+        return createJsonResult(
+            RefactoringPreviewResult(
+                canApply = discoveryError == null && writable &&
+                    (force || preparation.usages.isEmpty()),
+                target = target,
+                plannedChange = buildJsonObject {
+                    put("operation", "safeDelete")
+                    put("targetType", "symbol")
+                    put("name", preparation.elementName)
+                    put("force", force)
+                },
+                affectedFiles = listOf(preparation.affectedFile),
+                usageCount = preparation.usages.size,
+                conflictCount = preparation.usages.size,
+                warnings = warnings,
+                elapsedMs = elapsedMillisSince(startedAtNanos)
+            )
+        )
+    }
+
+    private suspend fun createFileDeletePreview(
+        project: Project,
+        preparation: FileDeletePreparation,
+        force: Boolean,
+        startedAtNanos: Long,
+        discoveryError: String? = null
+    ): CallToolResult {
+        val (writable, target) = suspendingReadAction {
+            val targetFile = preparation.psiFile.virtualFile
+            (targetFile?.isWritable == true) to resolvedSymbolInfo(project, preparation.psiFile)
+        }
+        val warnings = mutableListOf<String>()
+        if (!writable) {
+            warnings.add("Target file is read-only or unavailable; the deletion cannot be applied.")
+        }
+        if (discoveryError != null) {
+            warnings.add(
+                "Usage discovery failed: $discoveryError. Refusing to mark this preview as applicable."
+            )
+        } else if (preparation.externalUsages.isNotEmpty()) {
+            warnings.add(
+                if (force) {
+                    "Force deletion would leave ${preparation.externalUsages.size} external usage(s) unresolved."
+                } else {
+                    "Deletion is blocked by ${preparation.externalUsages.size} external usage(s); " +
+                        "set force=true to override."
+                }
+            )
+        }
+        if (preparation.symbols.isEmpty()) {
+            warnings.add(
+                preparation.incompleteDiscoveryReason
+                    ?: "No top-level declarations were found; complete usage discovery cannot be proven."
+            )
+        }
+
+        return createJsonResult(
+            RefactoringPreviewResult(
+                canApply = discoveryError == null && preparation.discoveryComplete && writable &&
+                    (force || preparation.externalUsages.isEmpty()),
+                target = target,
+                plannedChange = buildJsonObject {
+                    put("operation", "safeDelete")
+                    put("targetType", "file")
+                    put("name", preparation.fileName)
+                    put("force", force)
+                },
+                affectedFiles = listOf(preparation.filePath),
+                usageCount = preparation.externalUsages.size,
+                conflictCount = preparation.externalUsages.size,
+                warnings = warnings,
+                elapsedMs = elapsedMillisSince(startedAtNanos)
+            )
+        )
+    }
 
     private suspend fun applySymbolDeletion(
         project: Project,
@@ -332,8 +609,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 .run<Throwable> {
                     try {
                         if (!preparation.element.isValid) {
-                            errorMessage = "Element '${preparation.elementName}' is no longer valid — " +
-                                "the file changed since usages were checked. Retry the operation."
+                            errorMessage = preparation.symbolId?.let(ErrorMessages::symbolIdExpired)
+                                ?: "Element '${preparation.elementName}' is no longer valid — " +
+                                    "the file changed since usages were checked. Retry the operation."
                             return@run
                         }
                         preparation.element.delete()
@@ -349,6 +627,7 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         }
 
         return if (success) {
+            preparation.symbolId?.let(SymbolIdRegistry.getInstance()::invalidate)
             createJsonResult(
                 RefactoringResult(
                     success = true,
@@ -358,11 +637,16 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                         "Force-deleted '${preparation.elementName}' (had ${preparation.usages.size} usage(s) that may now be broken)"
                     } else {
                         "Successfully deleted '${preparation.elementName}'"
-                    }
+                    },
+                    invalidatedSymbolId = preparation.symbolId
                 )
             )
         } else {
-            createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}", ToolNames.DIAGNOSTICS)
+            if (errorMessage?.startsWith("SYMBOL_ID_EXPIRED:") == true) {
+                createErrorResult(errorMessage!!)
+            } else {
+                createErrorResult("Safe delete failed: ${errorMessage ?: "Unknown error"}", ToolNames.DIAGNOSTICS)
+            }
         }
     }
 
@@ -429,11 +713,12 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         file: String,
         line: Int,
         column: Int,
-        force: Boolean
+        force: Boolean,
+        allowReadOnly: Boolean = false
     ): SymbolPreparationResult {
         val psiFile = PsiUtils.getPsiFile(project, file)
             ?: return SymbolPreparationResult.FileNotFound(file)
-        if (psiFile.virtualFile?.isWritable == false) {
+        if (!allowReadOnly && psiFile.virtualFile?.isWritable == false) {
             return SymbolPreparationResult.ReadOnly(psiFile.virtualFile.path)
         }
 
@@ -478,7 +763,16 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             findUsages(project, element, excludeWithin = element)
         } catch (e: UsageSearchException) {
             if (!force) {
-                return SymbolPreparationResult.UsageSearchFailed(searchFailureReason(e))
+                return SymbolPreparationResult.UsageSearchFailed(
+                    searchFailureReason(e),
+                    SymbolDeletePreparation(
+                        element = element,
+                        elementName = elementName,
+                        elementType = elementType,
+                        usages = emptyList(),
+                        affectedFile = affectedFile
+                    )
+                )
             }
             // force=true means "delete regardless of usages", so a failed search cannot block it.
             emptyList()
@@ -491,6 +785,70 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 elementType = elementType,
                 usages = usages,
                 affectedFile = affectedFile
+            )
+        )
+    }
+
+    private fun prepareSymbolDeleteBySemanticTarget(
+        project: Project,
+        arguments: JsonObject,
+        symbolId: String?,
+        force: Boolean,
+        allowReadOnly: Boolean = false
+    ): SymbolPreparationResult {
+        val resolved = resolveElementFromArguments(project, arguments).getOrElse {
+            return SymbolPreparationResult.InvalidSymbolId(
+                it.message ?: symbolId?.let(ErrorMessages::symbolIdExpired) ?: ErrorMessages.COULD_NOT_RESOLVE_SYMBOL
+            )
+        }
+        val element = resolved as? PsiNamedElement
+            ?: return SymbolPreparationResult.InvalidSymbolId(
+                if (symbolId != null) "symbolId '$symbolId' does not identify a deletable named symbol"
+                else "Target does not identify a deletable named symbol"
+            )
+        if (element is PsiFile) {
+            return SymbolPreparationResult.InvalidSymbolId(
+                if (symbolId != null) "symbolId '$symbolId' identifies a file; use target_type='file' with its file path"
+                else "Target identifies a file; use target_type='file' with its file path"
+            )
+        }
+        val virtualFile = element.containingFile?.virtualFile
+            ?: return SymbolPreparationResult.InvalidSymbolId(
+                symbolId?.let(ErrorMessages::symbolIdExpired) ?: "Target has no editable source file"
+            )
+        if (!allowReadOnly && !virtualFile.isWritable) {
+            return SymbolPreparationResult.ReadOnly(virtualFile.path)
+        }
+
+        val elementName = element.name ?: "unnamed"
+        val elementType = getElementType(element)
+        val affectedFile = getRelativePath(project, virtualFile)
+        val usages = try {
+            findUsages(project, element, excludeWithin = element)
+        } catch (e: UsageSearchException) {
+            if (!force) {
+                return SymbolPreparationResult.UsageSearchFailed(
+                    searchFailureReason(e),
+                    SymbolDeletePreparation(
+                        element = element,
+                        elementName = elementName,
+                        elementType = elementType,
+                        usages = emptyList(),
+                        affectedFile = affectedFile,
+                        symbolId = symbolId
+                    )
+                )
+            }
+            emptyList()
+        }
+        return SymbolPreparationResult.Success(
+            SymbolDeletePreparation(
+                element = element,
+                elementName = elementName,
+                elementType = elementType,
+                usages = usages,
+                affectedFile = affectedFile,
+                symbolId = symbolId
             )
         )
     }
@@ -581,11 +939,12 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     private fun prepareFileDelete(
         project: Project,
         file: String,
-        force: Boolean
+        force: Boolean,
+        allowReadOnly: Boolean = false
     ): FilePreparationResult {
         val psiFile = PsiUtils.getPsiFile(project, file)
             ?: return FilePreparationResult.FileNotFound
-        if (psiFile.virtualFile?.isWritable == false) {
+        if (!allowReadOnly && psiFile.virtualFile?.isWritable == false) {
             return FilePreparationResult.ReadOnly(psiFile.virtualFile.path)
         }
 
@@ -622,13 +981,22 @@ class SafeDeleteTool : AbstractRefactoringTool() {
 
             // Layer 2: Check if the file maps to a resource element (e.g., Android resource).
             // Uses the same prepareRenaming probe as RenameSymbolTool.computeEffectiveNewName.
-            if (externalUsages.isEmpty()) {
+            // Apply may stop after a blocking usage, but a preview must account for every
+            // discovery layer: with force=true its count is otherwise deceptively partial.
+            if (externalUsages.isEmpty() || allowReadOnly) {
                 ProgressManager.checkCanceled()
-                externalUsages.addAll(findResourceElementUsages(project, psiFile, filePath))
+                externalUsages.addAll(
+                    findResourceElementUsages(
+                        project,
+                        psiFile,
+                        filePath,
+                        failClosed = allowReadOnly
+                    )
+                )
             }
 
             // Layer 3: Search top-level declarations for external usages.
-            if (externalUsages.isEmpty()) {
+            if (externalUsages.isEmpty() || allowReadOnly) {
                 for ((element, _, _) in topLevelElements) {
                     ProgressManager.checkCanceled()
                     for (usage in findUsages(project, element)) {
@@ -640,7 +1008,18 @@ class SafeDeleteTool : AbstractRefactoringTool() {
             }
         } catch (e: UsageSearchException) {
             if (!force) {
-                return FilePreparationResult.UsageSearchFailed(searchFailureReason(e))
+                return FilePreparationResult.UsageSearchFailed(
+                    searchFailureReason(e),
+                    FileDeletePreparation(
+                        psiFile = psiFile,
+                        fileName = fileName,
+                        filePath = filePath,
+                        symbols = symbols,
+                        externalUsages = previewUsageList(externalUsages, allowReadOnly),
+                        discoveryComplete = topLevelElements.isNotEmpty(),
+                        incompleteDiscoveryReason = incompleteFileDiscoveryReason(topLevelElements)
+                    )
+                )
             }
             // force=true means "delete regardless of usages", so a failed search cannot block it.
         }
@@ -651,7 +1030,9 @@ class SafeDeleteTool : AbstractRefactoringTool() {
                 fileName = fileName,
                 filePath = filePath,
                 symbols = symbols,
-                externalUsages = externalUsages
+                externalUsages = previewUsageList(externalUsages, allowReadOnly),
+                discoveryComplete = topLevelElements.isNotEmpty(),
+                incompleteDiscoveryReason = incompleteFileDiscoveryReason(topLevelElements)
             )
         )
     }
@@ -670,13 +1051,21 @@ class SafeDeleteTool : AbstractRefactoringTool() {
     private fun findResourceElementUsages(
         project: Project,
         psiFile: PsiFile,
-        filePath: String
+        filePath: String,
+        failClosed: Boolean
     ): List<UsageInfo> {
         val processor = RenamePsiElementProcessor.forElement(psiFile)
         val probeRenames = linkedMapOf<PsiElement, String>(psiFile to psiFile.name)
         try {
             processor.prepareRenaming(psiFile, psiFile.name, probeRenames)
-        } catch (_: Exception) {
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: IndexNotReadyException) {
+            throw e
+        } catch (e: Exception) {
+            if (failClosed) {
+                throw if (e is UsageSearchException) e else UsageSearchException(e)
+            }
             return emptyList()
         }
 
@@ -690,6 +1079,26 @@ class SafeDeleteTool : AbstractRefactoringTool() {
 
         return emptyList()
     }
+
+    /**
+     * File deletion has no generic semantic target when a language exposes no top-level
+     * declarations. Direct file/resource references are useful evidence, but not proof that a
+     * cross-language reference search is complete, so previews must remain inapplicable.
+     */
+    private fun incompleteFileDiscoveryReason(
+        topLevelElements: List<Triple<PsiNamedElement, Int, Int>>
+    ): String? = if (topLevelElements.isEmpty()) {
+        "No top-level declarations were found; direct file/resource references were checked, " +
+            "but complete usage discovery cannot be proven."
+    } else {
+        null
+    }
+
+    /** Avoid double-counting the same location when preview runs every discovery layer. */
+    private fun previewUsageList(
+        usages: List<UsageInfo>,
+        preview: Boolean
+    ): List<UsageInfo> = if (preview) usages.distinct() else usages
 
     /**
      * Collects the file's top-level declarations — the symbols whose *external* references are
@@ -867,30 +1276,67 @@ class SafeDeleteTool : AbstractRefactoringTool() {
         excludeWithin: PsiElement? = null
     ): List<UsageInfo> {
         val usages = mutableListOf<UsageInfo>()
+        val seenLocations = mutableSetOf<String>()
+
+        fun recordUsage(usageElement: PsiElement) {
+            if (excludeWithin != null && PsiTreeUtil.isAncestor(excludeWithin, usageElement, false)) {
+                return
+            }
+            val usageFile = usageElement.containingFile
+            val virtualFile = usageFile?.virtualFile ?: return
+            val document = PsiDocumentManager.getInstance(project).getDocument(usageFile)
+            val (lineNumber, columnNumber) = positionOf(document, usageElement.textOffset)
+            val filePath = getRelativePath(project, virtualFile)
+            if (!seenLocations.add("$filePath:$lineNumber:$columnNumber")) return
+
+            usages.add(
+                UsageInfo(
+                    file = filePath,
+                    line = lineNumber,
+                    column = columnNumber,
+                    context = getContextLine(document, lineNumber)
+                )
+            )
+        }
 
         try {
             usageSearchHook?.invoke()
             ReferencesSearch.search(element).forEach { reference ->
                 ProgressManager.checkCanceled() // Allow cancellation
+                recordUsage(reference.element)
+            }
 
-                val refElement = reference.element
-                if (excludeWithin != null && PsiTreeUtil.isAncestor(excludeWithin, refElement, false)) {
-                    return@forEach
+            // A Java override/implementation is a semantic dependency, not a PsiReference to
+            // the base declaration, so ReferencesSearch alone can report a dangerously clean
+            // result. The apply path performs a literal element.delete(); it cannot repair or
+            // remove overriding declarations. Treat every descendant override as blocking unless
+            // the caller explicitly opts into force=true.
+            if (element is PsiMethod) {
+                OverridingMethodsSearch.search(element, true).forEach { overridingMethod ->
+                    ProgressManager.checkCanceled()
+                    recordUsage(overridingMethod.nameIdentifier ?: overridingMethod)
                 }
-                val refFile = refElement.containingFile?.virtualFile
+            }
 
-                if (refFile != null) {
-                    val document = PsiDocumentManager.getInstance(project).getDocument(refElement.containingFile)
-                    val (lineNumber, columnNumber) = positionOf(document, refElement.textOffset)
-
-                    usages.add(
-                        UsageInfo(
-                            file = getRelativePath(project, refFile),
-                            line = lineNumber,
-                            column = columnNumber,
-                            context = getContextLine(document, lineNumber)
-                        )
-                    )
+            // Call-site arguments do not reference their declaration's PsiParameter, so a plain
+            // ReferencesSearch(parameter) is always incomplete. Ask the platform safe-delete
+            // delegates for parameter-specific usages (Java call arguments, override chains, and
+            // the equivalent contributed by an installed Kotlin plugin), but keep the apply path
+            // conservative: every discovered external element blocks our literal delete unless
+            // force=true.
+            val isKotlinParameter = element.javaClass.name == "org.jetbrains.kotlin.psi.KtParameter"
+            if (element is PsiParameter || isKotlinParameter) {
+                val processor = SafeDeleteProcessor.createInstance(
+                    project,
+                    Runnable {},
+                    arrayOf(element),
+                    false,
+                    true
+                )
+                RefactoringScopeGuard.findUsagesReflectivelyOrThrow(processor).forEach { usage ->
+                    ProgressManager.checkCanceled()
+                    val usageElement = usage.element ?: return@forEach
+                    if (usageElement !== element) recordUsage(usageElement)
                 }
             }
         } catch (e: ProcessCanceledException) {
@@ -936,7 +1382,8 @@ data class SafeDeleteBlockedResult(
     val elementType: String,
     val usageCount: Int,
     val blockingUsages: List<UsageInfo>,
-    val message: String
+    val message: String,
+    val symbolId: String? = null
 )
 
 @Serializable

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/SchemaBuilder.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/schema/SchemaBuilder.kt
@@ -4,6 +4,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ParamNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.SchemaConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.UnifiedTargetArguments
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
 
@@ -65,6 +66,73 @@ class SchemaBuilder private constructor() {
         if (required) {
             requiredFields.add(ParamNames.LANGUAGE)
             requiredFields.add(ParamNames.SYMBOL)
+        }
+    }
+
+    fun symbolId() = apply {
+        properties[ParamNames.SYMBOL_ID] = buildJsonObject {
+            put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+            put(
+                SchemaConstants.DESCRIPTION,
+                "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. " +
+                    "It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. " +
+                    "The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality."
+            )
+        }
+    }
+
+    /**
+     * Additive nested selector contract. `oneOf` is intentionally expressed in prose and checked
+     * at runtime because some MCP clients reject top-level combinator schemas.
+     */
+    fun target() = apply {
+        properties[UnifiedTargetArguments.TARGET] = buildJsonObject {
+            put(SchemaConstants.TYPE, SchemaConstants.TYPE_OBJECT)
+            put(
+                SchemaConstants.DESCRIPTION,
+                "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. " +
+                    "Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors " +
+                    "and with className where that legacy selector is supported."
+            )
+            putJsonObject(SchemaConstants.PROPERTIES) {
+                putJsonObject(ParamNames.SYMBOL_ID) {
+                    put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                    put(
+                        SchemaConstants.DESCRIPTION,
+                        "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality."
+                    )
+                }
+                putJsonObject(UnifiedTargetArguments.POSITION) {
+                    put(SchemaConstants.TYPE, SchemaConstants.TYPE_OBJECT)
+                    putJsonObject(SchemaConstants.PROPERTIES) {
+                        putJsonObject(ParamNames.FILE) {
+                            put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                            put(SchemaConstants.DESCRIPTION, SchemaConstants.DESC_FILE)
+                        }
+                        putJsonObject(ParamNames.LINE) {
+                            put(SchemaConstants.TYPE, SchemaConstants.TYPE_INTEGER)
+                            put(SchemaConstants.DESCRIPTION, SchemaConstants.DESC_LINE)
+                        }
+                        putJsonObject(ParamNames.COLUMN) {
+                            put(SchemaConstants.TYPE, SchemaConstants.TYPE_INTEGER)
+                            put(SchemaConstants.DESCRIPTION, SchemaConstants.DESC_COLUMN)
+                        }
+                    }
+                    putJsonArray(SchemaConstants.REQUIRED) {
+                        add(ParamNames.FILE)
+                        add(ParamNames.LINE)
+                        add(ParamNames.COLUMN)
+                    }
+                }
+                putJsonObject(UnifiedTargetArguments.QUALIFIED_NAME) {
+                    put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                    put(SchemaConstants.DESCRIPTION, "Language-qualified symbol reference, for example com.example.Foo#bar.")
+                }
+                putJsonObject(ParamNames.LANGUAGE) {
+                    put(SchemaConstants.TYPE, SchemaConstants.TYPE_STRING)
+                    put(SchemaConstants.DESCRIPTION, "Language used to resolve qualifiedName.")
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/IdeStructureViewExtractor.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/IdeStructureViewExtractor.kt
@@ -138,7 +138,8 @@ object IdeStructureViewExtractor {
                 signature = info.signature?.takeIf { it.isNotBlank() },
                 line = resolvedLine ?: children.firstOrNull()?.line ?: 1,
                 endLine = resolvedEndLine,
-                children = children
+                children = children,
+                pointerTarget = value as? PsiElement
             )
         )
     }

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/JavaMemberResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/JavaMemberResolver.kt
@@ -80,6 +80,14 @@ class JavaMemberResolver(private val project: Project) : MemberResolver {
         return results
     }
 
+    override fun resolveMember(element: PsiElement): ResolvedMember? = when (element) {
+        is PsiMethod -> resolveMethod(element)
+        is PsiField -> resolveField(element)
+        is PsiClass -> resolveClass(element)
+        is PsiClassInitializer -> resolveInitializer(element)
+        else -> null
+    }
+
     override fun getInsertionOffset(scope: PsiElement, position: String, anchor: ResolvedMember?): Int? {
         if (scope !is PsiClass) return null
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/KotlinMemberResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/KotlinMemberResolver.kt
@@ -94,6 +94,8 @@ class KotlinMemberResolver(private val project: Project) : MemberResolver {
         return results
     }
 
+    override fun resolveMember(element: PsiElement): ResolvedMember? = resolveDeclaration(element)
+
     override fun getInsertionOffset(scope: PsiElement, position: String, anchor: ResolvedMember?): Int? {
         return when (position) {
             "before" -> {

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/MemberResolver.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/MemberResolver.kt
@@ -23,6 +23,8 @@ interface MemberResolver {
     fun isAvailable(): Boolean
     fun findClass(psiFile: PsiFile, className: String?): PsiElement?
     fun findMembers(scope: PsiElement, memberName: String): List<ResolvedMember>
+    /** Resolves this exact declaration; must not walk to a parent or nearby member. */
+    fun resolveMember(element: PsiElement): ResolvedMember?
     fun getInsertionOffset(scope: PsiElement, position: String, anchor: ResolvedMember?): Int?
 }
 

--- a/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
+++ b/src/main/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/PsiUtils.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.toNioPathOrNull
+import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -315,6 +316,14 @@ object PsiUtils {
     fun qualifiedName(element: PsiElement): String? {
         (element as? PsiQualifiedNamedElement)?.qualifiedName?.takeIf { it.isNotBlank() }?.let { return it }
 
+        return reflectiveQualifiedName(element)
+    }
+
+    /**
+     * Reflection-only half of [qualifiedName]. Kept separate so optional-language behavior can
+     * be covered by headless tests without putting the Kotlin or PHP plugin on the test classpath.
+     */
+    internal fun reflectiveQualifiedName(element: Any): String? {
         for (accessor in QUALIFIED_NAME_ACCESSORS) {
             val value = runCatching {
                 element.javaClass.getMethod(accessor).invoke(element)?.toString()
@@ -385,8 +394,79 @@ object PsiUtils {
     private val ktClassOrObjectClass: Class<*>? by lazy {
         runCatching { Class.forName("org.jetbrains.kotlin.psi.KtClassOrObject") }.getOrNull()
     }
+    private val ktClassClass: Class<*>? by lazy {
+        runCatching { Class.forName("org.jetbrains.kotlin.psi.KtClass") }.getOrNull()
+    }
+    private val ktObjectDeclarationClass: Class<*>? by lazy {
+        runCatching { Class.forName("org.jetbrains.kotlin.psi.KtObjectDeclaration") }.getOrNull()
+    }
     private val lightClassUtilsClass: Class<*>? by lazy {
         runCatching { Class.forName("org.jetbrains.kotlin.asJava.LightClassUtilsKt") }.getOrNull()
+    }
+
+    /**
+     * Returns the declaration kind for a physical Kotlin class/object PSI element.
+     *
+     * `KtClass` is the runtime type for classes, interfaces, enum classes, and annotation
+     * classes, so inspecting the implementation class name cannot distinguish them. The Kotlin
+     * PSI's semantic flags are the source of truth. Objects use the sibling
+     * `KtObjectDeclaration` type and are checked first.
+     */
+    internal fun kotlinClassKind(element: PsiElement): String? =
+        reflectiveKotlinClassKind(element, ktClassClass, ktObjectDeclarationClass)
+
+    /** Reflection seam used by headless tests; production passes the optional Kotlin PSI types. */
+    internal fun reflectiveKotlinClassKind(
+        element: Any,
+        ktClassType: Class<*>?,
+        ktObjectDeclarationType: Class<*>?
+    ): String? {
+        if (ktObjectDeclarationType?.isInstance(element) == true) return "OBJECT"
+        if (ktClassType?.isInstance(element) != true) return null
+
+        fun flag(methodName: String): Boolean = runCatching {
+            element.javaClass.getMethod(methodName).invoke(element) == true
+        }.getOrDefault(false)
+
+        return when {
+            flag("isAnnotation") -> "ANNOTATION"
+            flag("isEnum") -> "ENUM"
+            flag("isInterface") -> "INTERFACE"
+            else -> "CLASS"
+        }
+    }
+
+    /**
+     * User-facing simple name for a class-like element. Anonymous Java classes and Kotlin object
+     * expressions have no declaration name, so describe the implemented/base type and exact
+     * source location instead of returning `unknown` or silently dropping the result.
+     */
+    fun classDisplayName(project: Project, element: PsiElement): String? {
+        (element as? PsiNamedElement)?.name?.takeIf { it.isNotBlank() }?.let { return it }
+        runCatching {
+            element.javaClass.getMethod("getName").invoke(element) as? String
+        }.getOrNull()?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val psiClass = resolveAsPsiClass(element) ?: return null
+        psiClass.name?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val anonymousClass = psiClass as? PsiAnonymousClass
+        val baseName = anonymousClass?.baseClassType?.resolve()?.name
+            ?: anonymousClass?.baseClassType?.presentableText
+            ?: psiClass.interfaces.firstOrNull()?.name
+            ?: psiClass.superClass
+                ?.takeUnless { it.qualifiedName == "java.lang.Object" }
+                ?.name
+            ?: "unknown type"
+
+        val sourceElement = resolveNavigationTarget(element)
+        val fileName = sourceElement.containingFile?.name
+            ?: psiClass.containingFile?.name
+            ?: "unknown file"
+        val line = PsiSourcePosition.line(project, sourceElement)
+            ?: PsiSourcePosition.line(project, psiClass)
+
+        return "<anonymous implementation of $baseName at $fileName:${line ?: "?"}>"
     }
 
     /**

--- a/src/main/resources/skill/ide-index-mcp/SKILL.md
+++ b/src/main/resources/skill/ide-index-mcp/SKILL.md
@@ -101,41 +101,55 @@ When working in a git worktree (e.g., `/project/.claude/worktrees/agent-xyz` or 
 1. **Line and column are 1-based** (first line = 1, first column = 1)
 2. **Project file paths are relative** to project root (e.g., `src/main/java/App.java`, NOT absolute paths). If an IDE tool returns a dependency/library file, keep the returned absolute path or `jar://` URL unchanged when passing it back to read-only navigation tools or `ide_read_file`
 3. **Column must point to the symbol name**, not whitespace or punctuation. For `public void myMethod()`, column should land on `m` of `myMethod`. For dotted expressions like `json.dumps()` or `os.path.join()`, put the column on the member token (`dumps`, `join`) when you want the member definition rather than the module/package.
-4. **project_path is only needed** for multi-project workspaces. Omit for single-project setups. When needed, use the absolute path to the project root.
+4. **project_path is only needed** for multi-project workspaces. Omit for single-project setups. A valid `symbolId` also routes directly to its owning project instance, so an ID-only call may omit it even with multiple projects open. When needed, use the absolute path to the project root.
 5. **Use built-in search scope intentionally**: `ide_find_references`, `ide_find_implementations`, `ide_type_hierarchy`, `ide_call_hierarchy`, `ide_find_class`, `ide_find_file`, and `ide_find_symbol` accept `scope`. Use `project_files` for the default project-only view, `project_and_libraries` when dependency code matters, `project_production_files` to stay out of tests, and `project_test_files` when you want test-only results.
 6. **Narrow by directory with `paths`**: `ide_search_text`, `ide_find_references`, and `ide_structural_search_replace` accept `paths`, an array of project-relative globs where a leading `!` excludes — e.g. `{"paths": ["src/main/kotlin/**/handlers/**", "!**/*Test.kt"]}`. Prefer one scoped call over a project-wide search you filter yourself: filtering client-side pays tokens for every discarded hit, and with pagination a whole page can be filtered away and look like an empty result. Composes with `scope` and `filePattern`.
+7. **Prefer `symbolId` when chaining semantic calls**: `ide_find_symbol`, `ide_find_class`, `ide_find_definition`, references, and hierarchy results expose opaque handles. Pass one by itself (plus operation options) to semantic target tools and symbol refactorings instead of repeating coordinates/name selectors. IDs are non-canonical: one PSI symbol may have multiple unequal, simultaneously valid handles, so never compare IDs for symbol equality. Reusing a concrete handle follows line shifts and rename. IDs are valid only for the current MCP server session and exact project instance, expire after one hour idle or LRU eviction, and return `SYMBOL_ID_EXPIRED` after deletion/restart; rediscover the symbol rather than guessing a nearby position. After refactoring, continue with `updatedSymbol.symbolId`; after safe delete, treat `invalidatedSymbolId` as unusable. Target-aware tools also accept exactly one nested `target`: `{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`; do not mix it with legacy top-level selectors.
+8. **Preview risky refactorings first**: set `dryRun: true` on rename, safe delete, or change signature. Check `canApply`, `plannedChange`, `affectedFiles`, usage/conflict counts, and `warnings`; preview does not write or save files and creates no undo entry. Apply with a second call only after reviewing the result.
+9. **Page hierarchies explicitly**: set a suitable `maxNodes`, then follow `cursor` while `hasMore` is true. Type/call hierarchy pages are flat deterministic breadth-first slices; `returnedNodes` excludes the repeated root. For type hierarchy, read `traversal: [{direction, element}]` when exact combined order matters; `supertypes` and `subtypes` remain compatible filtered views and cannot be concatenated to recover that order. Do not wait for live progress on stateless HTTP. Cursors expire after ten minutes idle, LRU eviction, restart, or project change; restart the query without `cursor` if one expires.
+10. **Use the right diagnostics scope**: use `file` for intentions or line/range filters; use mutually exclusive `files` for a small batch. A `files` request shares one timeout budget and returns aggregate `problems` plus per-path `fileAnalyses`. Code problems share a 100-item response cap: inspect aggregate/per-file `problemsTruncated` and per-file returned `problemCount`; a fresh file may still have omitted problems. Re-query truncated paths with `file`, narrowing line ranges if needed. Use `ide_project_diagnostics` for broad, fail-closed project coverage.
+11. **Inspect structured outlines when chaining**: `ide_file_structure.structure` is the compatible display string; prefer `nodes` for automation. Nodes include semantic kind, signature, modifiers, line range, children, and an optional ID bound to the exact PSI declaration. All nodes remain present, but at most 500 receive handles per response; `symbolIdsTruncated`/`symbolIdsOmitted` report handle-budget omissions. Use targeted discovery for a missing handle. Kotlin kinds distinguish interface/class/enum/annotation/object; anonymous implementations have readable location names and no qualified name.
+12. **Reconnect after plugin updates**: the MCP client may cache `ALL_TOOLS` for the connection. After installing/reloading a new plugin build, reconnect or restart the client before relying on new schemas. The server intentionally advertises `listChanged: false` because every transport does not yet deliver tool-list notifications.
 
 ## Tool Selection by Task
 
 ### "I need to understand how X is used"
+
 1. `ide_find_references` - all call sites, field accesses, imports
 2. `ide_call_hierarchy` with `direction: "callers"` - full call chain upward
 
 ### "I need to understand what X is"
+
 1. `ide_symbol_info` - resolved signature + doc comment without reading the file (disabled by default)
 2. `ide_find_definition` - jump to source
 3. `ide_type_hierarchy` - inheritance chain
 4. `ide_find_super_methods` - what interface/base method it implements
 
 ### "I need to find a class/file/symbol"
+
 1. `ide_find_class` - classes by name (CamelCase: `USvc` finds `UserService`)
 2. `ide_find_file` - files by name
 3. `ide_search_text` - substring text search across project (regex via `"regex": true`)
 
 ### "I need to refactor"
-1. `ide_refactor_rename` - rename symbol + all references atomically
-2. `ide_move_file` - move file and let the IDE apply semantic updates when that language/backend supports them
-3. `ide_refactor_safe_delete` - delete with usage checking (Java/Kotlin only)
-4. `ide_replace_text_in_file`, `ide_reformat_code` - apply project code style (disabled by default)
+
+1. Preview rename/safe delete/change signature with `dryRun: true`; inspect blockers and affected files
+2. `ide_refactor_rename` - rename symbol + all references atomically
+3. `ide_move_file` - move file and let the IDE apply semantic updates when that language/backend supports them
+4. `ide_refactor_safe_delete` - delete with usage checking (Java/Kotlin only)
+5. `ide_replace_text_in_file`, `ide_reformat_code` - apply project code style (disabled by default)
 
 ### "I need to check for problems"
-1. `ide_diagnostics` - compiler errors, warnings, quick fixes for one file (plus build/test results)
+
+1. `ide_diagnostics` - compiler errors/warnings for one `file` or a small `files` batch; quick fixes and ranges are single-file only (plus build/test results)
 2. `ide_project_diagnostics` - batch/project scope including unopened files, with fail-closed coverage metadata (`complete` flag, per-file states); long analyses return an `analysisId` to poll (disabled by default)
 
 ### "I need to find implementations of an interface"
+
 1. `ide_find_implementations` - cursor on interface/abstract class/method
 
 ### "I need to trace call chains"
+
 1. `ide_call_hierarchy` with `direction: "callers"` - who calls this?
 2. `ide_call_hierarchy` with `direction: "callees"` - what does this call?
 
@@ -156,6 +170,8 @@ When working in a git worktree (e.g., `/project/.claude/worktrees/agent-xyz` or 
 7. **Rewriting plugin-returned library paths**: If a search or read tool returns an absolute path or `jar://` URL for a dependency/library file, pass that path back unchanged to read-only navigation tools or `ide_read_file`.
 
 8. **Not syncing after external file changes**: After creating files via Write tool, call `ide_sync_files` before searching.
+
+   Deleted paths are valid sync targets: the tool refreshes their nearest existing parent and reports `requestedPaths`, `refreshedRoots`, and `deletedPaths`. Never pass absolute paths or traversal segments.
 
 9. **Assuming regex is the default in `ide_search_text`**: Regex requires `"regex": true`; otherwise the tool does plain-text substring matching.
 
@@ -180,6 +196,8 @@ These tools exist but are disabled by default. They are omitted from `tools/list
 `ide_build_project`, `ide_change_signature`, `ide_close_project`, `ide_convert_java_to_kotlin`, `ide_create_file`, `ide_create_module`, `ide_edit_member`, `ide_enroll_all_projects`, `ide_file_structure`, `ide_find_symbol`, `ide_get_active_file`, `ide_get_project_modes`, `ide_import_modules`, `ide_insert_member`, `ide_install_plugin`, `ide_lifecycle_log`, `ide_link_build_system`, `ide_list_tests`, `ide_open_file`, `ide_open_project`, `ide_open_workspace`, `ide_optimize_imports`, `ide_project_diagnostics`, `ide_read_file`, `ide_reformat_code`, `ide_release_all_projects`, `ide_release_project`, `ide_reload_project`, `ide_replace_member`, `ide_replace_text_in_file`, `ide_restart`, `ide_run_tests`, `ide_set_all_project_modes`, `ide_set_lifecycle_log_file`, `ide_set_power_save_mode`, `ide_set_project_mode`, `ide_structural_search_replace`, `ide_symbol_info`
 
 Note: `ide_restart` terminates the MCP connection — reconnect your client after calling it.
+After any plugin install/update, reconnect or restart the MCP client once the IDE reloads the plugin;
+clients such as Codex cache `ALL_TOOLS` and otherwise keep the old schema.
 Note: `ide_close_project` refuses to close the last open project; `ide_open_project` requires an absolute path and may take up to `timeoutSeconds` (default 600) while the project indexes.
 
 ## Enforcing IDE Tool Usage with Hooks

--- a/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
+++ b/src/main/resources/skill/ide-index-mcp/references/tools-reference.md
@@ -6,14 +6,56 @@ Complete parameter reference for all IDE MCP tools. All tools use JSON-RPC via M
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `project_path` | string, optional | Absolute path to project root. Required for multi-project workspaces. Omit for single-project setups. |
+| `project_path` | string, optional | Absolute path to project root. Required for multi-project workspaces unless a valid `symbolId` routes the call to its owning project. Omit for single-project setups. |
 | `file` | string | For project files, path relative to project root (e.g., `src/main/App.java`). `ide_read_file` and some read-only position-based navigation tools also accept dependency/library paths returned by the plugin as absolute paths or `jar://` URLs; check each tool section because support is tool-specific. |
 | `line` | integer | **1-based** line number |
 | `column` | integer | **1-based** column number. Place on the symbol name, not whitespace. For dotted expressions like `json.dumps()` or `os.path.join()`, point to the member token (`dumps`, `join`) when targeting the member definition. |
 | `language` | string | Language of the symbol (e.g., `"Java"`, `"PHP"`). Required when using `symbol`. |
 | `symbol` | string | Fully qualified symbol reference. Java format: `com.example.ClassName`, `com.example.ClassName#memberName`. PHP format: `\\App\\Service\\UserService`, `\\App\\Service\\UserService::method()`, `\\App\\Service\\UserService::CONSTANT`, `\\App\\Service\\UserService::$property`, `\\App\\Service\\StatusEnum::ACTIVE`. PHP properties require the `$property` form; plain `::name` resolves enum cases (on enum types), constants, or methods. Python format: see **Python symbol grammar** below. |
+| `symbolId` | string | Opaque handle returned with a semantic symbol result. Use by itself instead of coordinates or `language` + `symbol`. |
 
-**Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. The two groups are **mutually exclusive**. Supported languages: Java, PHP, JavaScript, TypeScript, Python. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
+**Opaque symbol IDs:** Search/definition/reference/hierarchy results expose IDs backed by
+server-side IntelliJ `SmartPsiElementPointer`s. They disambiguate overloads and local symbols and
+follow line shifts. IDs belong to one exact project instance and MCP server generation, use a
+4,096-entry access-order LRU, and expire after one hour idle. Restart, TTL/LRU eviction, deletion,
+or an unrestorable PSI pointer returns `SYMBOL_ID_EXPIRED`; no coordinate/name/nearest-element
+fallback occurs. Symbol refactorings return `updatedSymbol` with current metadata and the retained
+or replacement ID; safe delete returns `invalidatedSymbolId`.
+
+The ID is a non-canonical session handle. The same PSI symbol may receive several unequal handles
+that remain valid simultaneously; never compare IDs for symbol equality. Reusing one particular
+handle stays stable across line shifts and rename until its session/project/TTL/LRU bound ends.
+
+**Structured target:** Target-aware semantic and symbol-refactoring tools accept exactly one of:
+`{"target":{"symbolId":"sym_..."}}`,
+`{"target":{"position":{"file":"src/Foo.kt","line":12,"column":9}}}`, or
+`{"target":{"qualifiedName":"com.example.Foo#bar","language":"Kotlin"}}`.
+Do not mix nested `target` with legacy top-level selectors, including tool-specific selectors such
+as `className`. Legacy `symbolId`, coordinates, and `language` + `symbol` remain supported. A
+nested `target.symbolId` routes to the owning project.
+
+**Schema refresh:** After installing/reloading a new plugin build, reconnect or restart the MCP
+client. Clients such as Codex cache `ALL_TOOLS`, so an existing connection may retain an old
+schema. A fresh `initialize` → `tools/list` is authoritative. The server deliberately advertises
+`tools.listChanged: false`; current transports do not promise tool-list change notifications.
+
+**Kotlin class metadata:** Kotlin PSI is classified semantically as `INTERFACE`, `CLASS`, `ENUM`,
+`ANNOTATION`, or `OBJECT`. Qualified names use Kotlin `getFqName()` through the common
+`PsiUtils.qualifiedName` path. Anonymous implementations use a readable display name such as
+`<anonymous implementation of SomeInterface at File.kt:42>` and have `qualifiedName: null`.
+
+**Refactoring previews:** `ide_refactor_rename`, `ide_refactor_safe_delete`, and
+`ide_change_signature` accept `dryRun: true`. They resolve and validate the target, search usages
+and conflicts, and return:
+
+`{ dryRun: true, canApply, target: {symbolId, name?, kind?, container?, file?, line?, column?, qualifiedName?, language?}, plannedChange: {...}, affectedFiles: [...], usageCount, conflictCount, warnings: [...], elapsedMs }`
+
+Preview never enters the refactoring/source-write phase, mutates/saves documents, or creates an
+undo command. If
+`canApply` is false, inspect `warnings` and `conflictCount`. Apply with a later call that omits
+`dryRun`; the preview does not reserve state.
+
+**Symbol reference:** Some tools accept `language` + `symbol` as an alternative to `file` + `line` + `column`. A `symbolId`, coordinates, and `language` + `symbol` are **mutually exclusive** target forms. Supported languages: Java, PHP, JavaScript, TypeScript, Python. Unsupported languages are rejected explicitly; use `file` + `line` + `column` for other languages.
 
 **Python symbol grammar:** Symbols must be module-qualified (dotted path with ≥2 segments):
 - `pkg.mod.ClassName` — class
@@ -59,10 +101,11 @@ Parse the `text` field as JSON for structured data.
 ### ide_find_references
 Find all usages of a symbol (semantic, not text search).
 
-**Target (mutually exclusive):** `file`+`line`+`column` OR `language`+`symbol`
+**Target (mutually exclusive):** `symbolId` OR `file`+`line`+`column` OR `language`+`symbol`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | conditional | Exact declaration handle from a previous result. |
 | `file` | string | conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | conditional | 1-based line. Required for position-based lookup. |
 | `column` | integer | conditional | 1-based column. Required for position-based lookup. |
@@ -78,16 +121,17 @@ Find all usages of a symbol (semantic, not text search).
 
 **Returns**: `{ usages: [{ file, line, column, context, type, astPath }], totalCount, totalIsExact, resolvedSymbol, truncated, nextCursor?, hasMore, totalCollected, offset, pageSize, stale }`
 **Pagination note**: `truncated` mirrors `hasMore`; when `hasMore` is `true`, pass `nextCursor` to fetch the next page.
-**Resolution note**: `resolvedSymbol` echoes the declaration that was actually searched — positions on comments or whitespace snap to the nearest enclosing named element, so check it matches the symbol you intended. When `totalIsExact` is `false`, `totalCount` is a lower bound.
+**Resolution note**: `resolvedSymbol` includes `symbolId` and echoes the declaration that was actually searched — positions on comments or whitespace snap to the nearest enclosing named element, so check it matches the symbol you intended. When `totalIsExact` is `false`, `totalCount` is a lower bound.
 **type values**: `METHOD_CALL`, `FIELD_ACCESS`, `IMPORT`, `PARAMETER`, `VARIABLE`, `REFERENCE`
 
 ### ide_find_definition
 Go to where a symbol is defined.
 
-**Target (mutually exclusive):** `file`+`line`+`column` OR `language`+`symbol`
+**Target (mutually exclusive):** `symbolId` OR `file`+`line`+`column` OR `language`+`symbol`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | conditional | Exact declaration handle from a previous result. |
 | `file` | string | conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | conditional | 1-based line. Required for position-based lookup. |
 | `column` | integer | conditional | 1-based column. Required for position-based lookup. |
@@ -97,7 +141,7 @@ Go to where a symbol is defined.
 | `maxPreviewLines` | integer | no | Max lines for full preview (default 50, max 500) |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ file, line, column, preview, symbolName, astPath }`
+**Returns**: `{ symbolId, file, line, column, preview, symbolName, astPath }`
 Handles: packages, compiled classes, library sources (jar: URLs).
 
 ### ide_symbol_info (disabled by default)
@@ -105,10 +149,11 @@ Resolved signature and documentation of the symbol at a position — the declara
 `ide_find_definition` cannot give, because its preview is source text with unresolved short type
 names and no doc comment.
 
-**Target (mutually exclusive):** `file`+`line`+`column` OR `language`+`symbol`
+**Target (mutually exclusive):** `symbolId` OR `file`+`line`+`column` OR `language`+`symbol`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | conditional | Exact declaration handle from a previous result. |
 | `file` | string | conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | conditional | 1-based line. Required for position-based lookup. |
 | `column` | integer | conditional | 1-based column. Required for position-based lookup. |
@@ -118,7 +163,7 @@ names and no doc comment.
 | `maxDocLength` | integer | no | Truncate documentation beyond this many characters. Default 4000, max 20000 |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ name, kind, qualifiedName, signature, signatureSource, parameters: [{name, type}], returnType, typeParameters, thrownTypes, modifiers, visibility, containingDeclaration, documentation, documentationTruncated, file, line, column, language }`
+**Returns**: `{ symbolId, name, kind, qualifiedName, signature, signatureSource, parameters: [{name, type}], returnType, typeParameters, thrownTypes, modifiers, visibility, containingDeclaration, documentation, documentationTruncated, file, line, column, language }`
 
 **Type resolution**: `signatureSource` says how far the types were resolved.
 - `java_psi` — Java declarations. Parameter and return types are fully qualified
@@ -152,7 +197,7 @@ Search for classes/interfaces by name using IDE's class index. Equivalent to Ctr
 | `pageSize` | integer | no | Results per page. Default 25, max 500 |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ classes: [{name, qualifiedName, file, line, kind, language}], totalCount, query }`
+**Returns**: `{ classes: [{symbolId, name, qualifiedName, file, line, kind, language}], totalCount, query }`
 **Path note**: Project results use relative paths. Dependency/library results may use absolute paths or `jar://` URLs.
 **Matching**: CamelCase (`USvc` -> `UserService`), substring, wildcard (`User*Impl`).
 
@@ -195,10 +240,11 @@ Search for text using IntelliJ Find in Files. Plain-text queries do substring ma
 ### ide_find_implementations
 Find implementations of interfaces, abstract classes, or abstract methods.
 
-**Target (mutually exclusive):** `file`+`line`+`column` OR `language`+`symbol`
+**Target (mutually exclusive):** `symbolId` OR `file`+`line`+`column` OR `language`+`symbol`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | conditional | Exact type/method handle from a previous result. |
 | `file` | string | conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | conditional | 1-based line. Required for position-based lookup. |
 | `column` | integer | conditional | 1-based column. Required for position-based lookup. |
@@ -210,7 +256,7 @@ Find implementations of interfaces, abstract classes, or abstract methods.
 | `pageSize` | integer | no | Results per page. Default 100, max 500 |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ implementations: [{name, file, line, column, kind, language}], totalCount, nextCursor?, hasMore, totalCollected, offset, pageSize, stale }`
+**Returns**: `{ implementations: [{symbolId?, name, file, line, column, kind, language}], totalCount, nextCursor?, hasMore, totalCollected, offset, pageSize, stale }`
 **Languages**: Java, Kotlin, Python, JS/TS, PHP, Rust (not Go).
 
 ### ide_find_symbol (disabled by default)
@@ -227,17 +273,18 @@ Search for any code symbol (classes, methods, fields, functions) by name.
 | `pageSize` | integer | no | Results per page. Default 25, max 500 |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ symbols: [{name, qualifiedName, file, line, kind, language}], totalCount, query }`
+**Returns**: `{ symbols: [{symbolId, name, qualifiedName, file, line, kind, language}], totalCount, query }`
 **Languages**: Java, Kotlin, Python, JS/TS, Go, PHP, Rust, plus other IDE-supplied symbol contributors where available.
 **Path note**: Project results use relative paths. Dependency/library results may use absolute paths or `jar://` URLs.
 
 ### ide_find_super_methods
 Find parent methods that a given method overrides or implements.
 
-**Target (mutually exclusive):** `file`+`line`+`column` OR `language`+`symbol`
+**Target (mutually exclusive):** `symbolId` OR `file`+`line`+`column` OR `language`+`symbol`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | conditional | Exact method handle from a previous result. |
 | `file` | string | conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | conditional | 1-based line. Required for position-based lookup. |
 | `column` | integer | conditional | 1-based column (anywhere in method body works). Required for position-based lookup. |
@@ -245,47 +292,60 @@ Find parent methods that a given method overrides or implements.
 | `symbol` | string | conditional | Fully qualified symbol reference. For JS/TS, use module-qualified forms: `modulePath#exportName`, `modulePath#default`, or `modulePath#ClassName.memberName`. Required for symbol-based lookup. |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ method: {name, class, file, line}, hierarchy: [{name, class, file, line, isInterface}], totalCount }`
+**Returns**: `{ method: {symbolId?, name, class, file, line}, hierarchy: [{symbolId?, name, class, file, line, isInterface}], totalCount }`
 **Languages**: Java, Kotlin, Python, JS/TS, PHP (NOT Go, Rust).
 
 ### ide_type_hierarchy
-Get complete type inheritance hierarchy (supertypes and subtypes).
+
+Get bounded type-inheritance pages (supertypes and subtypes) in deterministic breadth-first order.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | no | Exact type handle from a previous result. |
 | `className` | string | no | FQN (preferred, faster). E.g., `com.example.MyClass` |
 | `file` | string | no | Alternative: project-relative file path. Unlike other read-only navigation tools, `ide_type_hierarchy` file mode does not resolve dependency/library absolute paths or `jar://` URLs. |
 | `line` | integer | no | Required with file |
 | `column` | integer | no | Required with file |
+| `language` | string | no | Language for a qualified semantic target; requires an installed symbol-reference handler |
+| `symbol` | string | no | Fully qualified symbol reference used with `language` |
+| `maxNodes` | integer | no | Maximum nodes returned and expanded on this page. Default 100, max 500 |
+| `cursor` | string | no | Opaque continuation from the previous page. Target/search parameters are ignored; `maxNodes` may set the next page size |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `includeGenerated` | boolean | no | Include supertypes/subtypes in generated sources (KSP/Dagger/annotation-processor output). Default true — keeps generated types in the hierarchy |
 | `project_path` | string | no | Project root path |
 
-**Provide either** `className` **or** `file`+`line`+`column`.
-**Returns**: `{ element: {name, file, kind, language, supertypes?}, supertypes: [{name, file, kind, language, supertypes?}], subtypes: [{name, file, kind, language, supertypes?}] }`
+**Provide exactly one target:** one nested `target` variant, or legacy `symbolId`, `className`, `language`+`symbol`, or `file`+`line`+`column`.
+**Returns**: `{ element: {symbolId?, name, file, kind, language}, supertypes: [{symbolId?, name, file, kind, language}], subtypes: [{symbolId?, name, file, kind, language}], traversal: [{direction: "supertype"|"subtype", element: {...}}], returnedNodes, truncated, elapsedMs, hasMore, cursor? }`
+**Pagination**: `traversal` is the exact combined BFS wire order and `returnedNodes == traversal.size`; the repeated root is excluded. Legacy `supertypes` and `subtypes` remain direction-filtered views, but concatenating them does not recover a potentially interleaved combined order. `truncated` mirrors `hasMore`; continue with `cursor`. `maxNodes` is enforced during traversal, not after building a full graph. Pages are flat BFS slices.
 **Languages**: Java, Kotlin, Python, JS/TS, PHP, Rust.
 
 ### ide_call_hierarchy
+
 Build call tree showing who calls a method or what a method calls.
 
-**Target (mutually exclusive):** `file`+`line`+`column` OR `language`+`symbol`
+**Target (mutually exclusive):** `symbolId` OR `file`+`line`+`column` OR `language`+`symbol`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `symbolId` | string | conditional | Exact callable handle from a previous result. |
 | `file` | string | conditional | Project-relative file path, or a dependency/library absolute path or `jar://` URL previously returned by the plugin. Required for position-based lookup. |
 | `line` | integer | conditional | 1-based line. Required for position-based lookup. |
 | `column` | integer | conditional | 1-based column. Required for position-based lookup. |
 | `language` | string | conditional | Symbol language (e.g., `"Java"`). Required for symbol-based lookup. |
 | `symbol` | string | conditional | Fully qualified symbol reference. For JS/TS, use module-qualified forms: `modulePath#exportName`, `modulePath#default`, or `modulePath#ClassName.memberName`. Required for symbol-based lookup. |
 | `direction` | enum | yes | `callers` or `callees` |
-| `depth` | integer | no | Recursion depth (default 3, max 5) |
+| `depth` | integer | no | Traversal depth across all pages (default 3, max 5) |
+| `maxNodes` | integer | no | Maximum nodes returned and expanded on this page. Default 20 on a fresh call, 100 on continuation; max 500 |
+| `cursor` | string | no | Opaque continuation from the previous page. Target/search parameters are ignored; `maxNodes` may set the next page size |
 | `scope` | enum | no | One of `project_files` (default), `project_and_libraries`, `project_production_files`, `project_test_files` |
 | `includeGenerated` | boolean | no | Include callers/callees in generated sources (KSP/Dagger/annotation-processor output). Default true |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ element: {name, file, line, column, language}, calls: [{name, file, line, column, language, children: [...]}] }`
+**Returns**: `{ element: {symbolId?, name, file, line, column, language}, calls: [{symbolId?, name, file, line, column, language}], returnedNodes, truncated, elapsedMs, hasMore, cursor? }`
+**Pagination**: `calls` is a flat deterministic BFS page and `returnedNodes` excludes the root. Continue while `hasMore` is true. Hierarchy cursors are exact-session/project smart-pointer frontiers with a ten-minute inactivity TTL, at most 128 snapshots overall and ten per traversal, plus aggregate pointer/text budgets. Eviction prefers old replay snapshots to current frontiers; returned handles are rebound on each page. Expired/evicted/wrong-project/wrong-tool cursors require a fresh query. Stateless HTTP provides pages and response metadata, not reliable live progress.
 
 ### ide_file_structure (disabled by default)
+
 Get hierarchical file structure like IDE's Structure panel. Each element includes both start and end line numbers (e.g., `(lines 42-65)` for multi-line elements, `(line 42)` for single-line elements).
 
 | Parameter | Type | Required | Description |
@@ -293,7 +353,9 @@ Get hierarchical file structure like IDE's Structure panel. Each element include
 | `file` | string | yes | Relative file path |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ file, language, structure }` (formatted tree with types, modifiers, signatures, and start/end line numbers)
+**Returns**: `{ file, language, structure, nodes: [{name, kind, signature?, modifiers, line, endLine?, children, symbolId?}], symbolIdsTruncated, symbolIdsOmitted }`
+`structure` is retained for compatibility. `nodes` is the same hierarchy as structured data; IDs are bound to the exact extracted PSI elements rather than reconstructed from line numbers. Kotlin node kinds distinguish `INTERFACE`, `CLASS`, `ENUM`, `ANNOTATION`, and `OBJECT`.
+All nodes are retained; handles are limited to the first 500 eligible nodes in preorder. `symbolIdsTruncated` flags this handle budget and `symbolIdsOmitted` counts budget omissions. Query a handle-less node through targeted semantic discovery.
 **Languages**: Java, Kotlin, Python, JS/TS, PHP, Markdown.
 
 PHP support requires the PHP plugin and is available in PhpStorm or IntelliJ IDEA Ultimate with the PHP plugin enabled.
@@ -317,15 +379,17 @@ Read file content by path or qualified name, including library/jar sources.
 ## Intelligence Tools
 
 ### ide_diagnostics
-Get code diagnostics from multiple sources: per-file analysis (errors, warnings, quick fixes/intentions), build output from the last build, and test results from open test run tabs. At least one source must be active: provide `file` for code analysis, `includeBuildErrors` for build output, or `includeTestResults` for test results. Can combine all three.
+
+Get code diagnostics from multiple sources: one `file` or a small `files` batch, build output from the last build, and test results from open test run tabs. At least one source must be active: provide exactly one of `file`/`files` for code analysis, `includeBuildErrors` for build output, or `includeTestResults` for test results. Sources can be combined.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | no | Relative file path. Optional — enables per-file code analysis |
-| `line` | integer | no | For intention lookup (default 1, requires `file`) |
-| `column` | integer | no | For intention lookup (default 1, requires `file`) |
-| `startLine` | integer | no | Filter problems to range (requires `file`) |
-| `endLine` | integer | no | Filter problems to range (requires `file`) |
+| `file` | string | no | One relative file path. Mutually exclusive with `files` |
+| `files` | string[] | no | Up to 100 non-empty unique relative paths analyzed under one shared timeout budget. Mutually exclusive with `file` |
+| `line` | integer | no | For intention lookup (default 1, single `file` only) |
+| `column` | integer | no | For intention lookup (default 1, single `file` only) |
+| `startLine` | integer | no | Filter problems to range (single `file` only) |
+| `endLine` | integer | no | Filter problems to range (single `file` only) |
 | `includeBuildErrors` | boolean | no | Include errors/warnings from the last build. Default false |
 | `includeTestResults` | boolean | no | Include test results from open test run tabs. Default false |
 | `severity` | enum | no | Filter by severity across all sources: `all` (default), `errors`, `warnings` |
@@ -334,8 +398,9 @@ Get code diagnostics from multiple sources: per-file analysis (errors, warnings,
 | `maxTestResults` | integer | no | Max test results to return. Default 100, max 500 |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ problems: [{message, severity, file, line, column, endLine?, endColumn?}], intentions: [{name, description}], problemCount, intentionCount, analysisFresh, analysisTimedOut, analysisMessage, buildErrors?, buildErrorCount?, buildWarningCount?, buildErrorsTruncated?, buildTimestamp?, testResults?, testResultsTruncated?, testSummary? }`
-**Notes**: Open files use fresh daemon highlights. Closed files use public batch analysis, so `WEAK_WARNING` results and quick-fix intentions may be less complete unless the file is already open in an editor. The `analysisMode` field reports which path ran: `open_daemon` or `closed_batch` (null when no analysis ran). The file is refreshed from disk before analysis, so no `ide_sync_files` call is needed after editing it with an external tool.
+**Returns**: `{ problems: [{message, severity, file, line, column, endLine?, endColumn?}], intentions?, problemCount, problemsTruncated?, intentionCount?, analysisFresh?, analysisTimedOut?, analysisMessage?, analysisMode?, fileAnalyses?: [{file, mode?, fresh, timedOut, message?, problemCount, problemsTruncated}], buildErrors?, buildErrorCount?, buildWarningCount?, buildErrorsTruncated?, buildTimestamp?, testResults?, testResultsTruncated?, testSummary? }`
+**Output cap**: At most 100 code problems across the response. Aggregate/per-file `problemsTruncated` flags known omissions; per-file `problemCount` counts only returned problems. Freshness is independent of completeness. Re-query a truncated path with `file`, narrowing `startLine`/`endLine` if needed. False truncation does not imply successful analysis; also inspect freshness/timeouts.
+**Notes**: Single-file mode keeps the legacy top-level analysis metadata and supports intentions/range filters. Multi-file mode returns one aggregate `problems` list and one `fileAnalyses` entry for every requested path; all files consume one shared deadline, and files left after expiry are marked timed out rather than receiving a fresh timeout. Open files use fresh daemon highlights; closed files use public batch analysis. Files are refreshed from disk first, so no `ide_sync_files` call is needed after an external edit.
 **Severity levels**: `ERROR`, `WARNING`, `WEAK_WARNING`
 
 ### ide_project_diagnostics (disabled by default)
@@ -362,22 +427,29 @@ Each call blocks at most `waitSeconds` (default 45) so the MCP client's request 
 ## Refactoring Tools
 
 ### ide_refactor_rename
+
 Rename a symbol or file and update ALL references (semantic rename, not find-replace). Works across ALL languages.
 
-**Target:** `file` + `targetType="file"` for file rename, or `file` + `targetType="symbol"` + `line` + `column` for symbol rename. Without `targetType`, legacy `null/null => file` and `line`+`column => symbol` behavior remains.
+**Target:** `file` + `targetType="file"` for file rename; for symbol rename use `symbolId`, or `file` + `targetType="symbol"` + `line` + `column`. Without `targetType`, legacy `null/null => file` and `line`+`column => symbol` behavior remains.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
+| `target` | object | conditional | Structured symbol selector containing exactly one of `symbolId`, `position: {file, line, column}`, or `qualifiedName` + `language`. Mutually exclusive with legacy top-level selectors. |
+| `symbolId` | string | conditional | Exact symbol handle. Mutually exclusive with `file`/coordinates. |
 | `file` | string | conditional | Relative file path. Required for position-based lookup. |
+| `language` | string | conditional | Legacy qualified-name selector language; requires `symbol`. |
+| `symbol` | string | conditional | Legacy qualified symbol name; requires `language`. |
 | `targetType` | string | no | `symbol` or `file`. When `file`, placeholder `line`/`column` values are ignored. |
 | `line` | integer | no | 1-based line for symbol rename. |
 | `column` | integer | no | 1-based column for symbol rename. |
 | `newName` | string | yes | New name for the symbol |
 | `overrideStrategy` | enum | no | `rename_base` (default), `rename_only_current`, `ask` |
 | `relatedRenamingStrategy` | enum | no | Controls automatic renaming of related symbols (same-named properties, getters/setters, test classes, variables): `all` (default) renames all related symbols, `none` renames only the targeted symbol, `accessors_and_tests` renames only getters/setters and test classes/methods, `ask` shows the IDE dialog for each related rename |
+| `dryRun` | boolean | no | Resolve/validate and discover usages/conflicts without writing or saving files. Default false |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ success, affectedFiles: [paths], changesCount, message }`
+**Returns**: `{ success, affectedFiles: [paths], changesCount, message, updatedSymbol? }`
+**Returns with `dryRun: true`**: common preview shape; rename `plannedChange` contains `{operation: "rename", targetType, from, to, overrideStrategy, relatedRenamingStrategy}`.
 **Auto-renames**: getters/setters, overriding methods, constructor params <-> fields, test classes.
 **Supports IDE undo** (Ctrl+Z).
 
@@ -394,19 +466,26 @@ Move a file to a new directory. Applies language-aware reference, import, and pa
 **Supports IDE undo** (Ctrl+Z).
 
 ### ide_refactor_safe_delete (Java, Kotlin)
+
 Delete a symbol or file, checking for usages first.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | yes | Relative file path |
+| `target` | object | conditional | Structured symbol selector containing exactly one of `symbolId`, `position: {file, line, column}`, or `qualifiedName` + `language`. Mutually exclusive with legacy top-level selectors. |
+| `symbolId` | string | conditional | Exact symbol handle for `target_type="symbol"`. Mutually exclusive with coordinates. |
+| `file` | string | conditional | Relative file path. Required for position-based symbol deletion and file deletion. |
+| `language` | string | conditional | Legacy qualified-name selector language; requires `symbol`. |
+| `symbol` | string | conditional | Legacy qualified symbol name; requires `language`. |
 | `line` | integer | no | Required for target_type="symbol" |
 | `column` | integer | no | Required for target_type="symbol" |
 | `target_type` | enum | no | `symbol` (default) or `file` |
 | `force` | boolean | no | Force delete even with usages (default false) |
+| `dryRun` | boolean | no | Resolve target and discover usages/blockers without deleting or saving. Default false |
 | `project_path` | string | no | Project root path |
 
-**Returns (success)**: `{ success, affectedFiles, changesCount, message }`
+**Returns (success)**: `{ success, affectedFiles, changesCount, message, invalidatedSymbolId? }`
 **Returns (blocked)**: `{ canDelete: false, elementName, usageCount, blockingUsages: [...], message }`
+**Returns with `dryRun: true`**: common preview shape; `plannedChange` contains `{operation: "safeDelete", targetType, name, force}`. Usages contribute to `conflictCount`; without `force`, they make `canApply` false. Preview leaves `symbolId` valid.
 **Only available in**: IntelliJ IDEA, Android Studio (requires Java plugin).
 
 ### ide_reformat_code (disabled by default)
@@ -460,21 +539,28 @@ Pattern-based code search and transformation using IntelliJ's Structural Search 
 **Languages**: Java, Kotlin.
 
 ### ide_change_signature (disabled by default)
+
 Change method signature (name, return type, visibility, parameters) with automatic caller updates.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | yes | Relative file path containing the method |
-| `line` | integer | yes | 1-based line of the method |
-| `column` | integer | yes | 1-based column on the method name |
+| `target` | object | conditional | Structured method selector containing exactly one of `symbolId`, `position: {file, line, column}`, or `qualifiedName` + `language`. Mutually exclusive with legacy top-level selectors. |
+| `symbolId` | string | conditional | Exact method handle. Mutually exclusive with coordinates. |
+| `file` | string | conditional | Relative file path containing the method. Required without `symbolId`. |
+| `line` | integer | conditional | 1-based line of the method. Required without `symbolId`. |
+| `column` | integer | conditional | 1-based column on the method name. Required without `symbolId`. |
+| `language` | string | conditional | Legacy qualified-name selector language; requires `symbol`. |
+| `symbol` | string | conditional | Legacy qualified method name; requires `language`. |
 | `newName` | string | no | New method name (unchanged if omitted) |
 | `newReturnType` | string | no | New return type (unchanged if omitted) |
 | `newVisibility` | string | no | `public`, `protected`, `private`, or `package-local` (unchanged if omitted) |
 | `newParameters` | array | no | Array of `{ oldIndex, name, type, defaultValue }`. Use `oldIndex: -1` for new params |
 | `generateDelegate` | boolean | no | Generate delegate with old signature (default false) |
+| `dryRun` | boolean | no | Resolve/validate and discover callers/conflicts without writing or saving files. Default false |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ success, file, message, affectedFiles, changesCount }`
+**Returns**: `{ success, file, message, affectedFiles, changesCount, updatedSymbol? }`
+**Returns with `dryRun: true`**: common preview shape; `plannedChange` contains `{operation: "changeSignature", before: {...}, requested: {...}}`.
 **Language**: Java only.
 
 ### ide_create_file (disabled by default)
@@ -507,16 +593,20 @@ Replace an entire member declaration (signature + body) with new content.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | yes | Relative file path |
+| `target` | object | conditional | Exactly one nested selector: `{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`. Mutually exclusive with all legacy target/member selectors (`symbolId`, `language`+`symbol`, `file`, `class`, `member`, `parameterCount`, `line`). |
+| `symbolId` | string | conditional | Exact member handle. Mutually exclusive with member selectors. |
+| `language` | string | conditional | Legacy semantic lookup language. Required with `symbol`; mutually exclusive with `target`, `symbolId`, and member selectors. |
+| `symbol` | string | conditional | Legacy qualified member name. Required with `language`; mutually exclusive with `target`, `symbolId`, and member selectors. |
+| `file` | string | conditional | Relative file path. Required without `symbolId`. |
 | `class` | string | no | Class name to scope the search |
-| `member` | string | yes | Name of the member to replace |
+| `member` | string | conditional | Name of the member to replace. Required without `symbolId`. |
 | `parameterCount` | integer | no | Parameter count to disambiguate overloads |
 | `line` | integer | no | 1-based line to disambiguate same-name members |
 | `content` | string | yes | Full replacement declaration (signature + body) |
 | `reformat` | boolean | no | Reformat after replacement (default true) |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ success, file, message, startLine, endLine }`
+**Returns**: `{ success, file, message, startLine, endLine, updatedSymbol? }`
 
 ### ide_insert_member (disabled by default, Java, Kotlin)
 Insert a new member at a structural position in a class or file.
@@ -540,16 +630,20 @@ Replace a method body or field initializer only, preserving the signature.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file` | string | yes | Relative file path |
+| `target` | object | conditional | Exactly one nested selector: `{symbolId}`, `{position:{file,line,column}}`, or `{qualifiedName,language}`. Mutually exclusive with all legacy target/member selectors (`symbolId`, `language`+`symbol`, `file`, `class`, `member`, `parameterCount`, `line`). |
+| `symbolId` | string | conditional | Exact member handle. Mutually exclusive with member selectors. |
+| `language` | string | conditional | Legacy semantic lookup language. Required with `symbol`; mutually exclusive with `target`, `symbolId`, and member selectors. |
+| `symbol` | string | conditional | Legacy qualified member name. Required with `language`; mutually exclusive with `target`, `symbolId`, and member selectors. |
+| `file` | string | conditional | Relative file path. Required without `symbolId`. |
 | `class` | string | no | Class name to scope the search |
-| `member` | string | yes | Name of the member whose body/initializer to replace |
+| `member` | string | conditional | Name of the member whose body/initializer to replace. Required without `symbolId`. |
 | `parameterCount` | integer | no | Parameter count to disambiguate overloads |
 | `line` | integer | no | 1-based line to disambiguate same-name members |
 | `content` | string | yes | New method body (without braces) or field initializer (without `=`) |
 | `reformat` | boolean | no | Reformat after replacement (default true) |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ success, file, message, startLine, endLine }`
+**Returns**: `{ success, file, message, startLine, endLine, updatedSymbol? }`
 
 ---
 
@@ -566,14 +660,16 @@ Check if IDE is ready for code intelligence operations.
 When `isDumbMode: true`, most tools will fail. Wait and retry.
 
 ### ide_sync_files
+
 Force sync IDE's virtual file system with external file changes.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `paths` | string[] | no | Relative paths to sync (empty = sync entire project) |
+| `paths` | string[] | no | Paths relative to the selected project/content root. Deleted targets refresh their nearest existing parent. Absolute paths, traversal, and symlink escapes are rejected. Empty/omitted = sync entire selected root |
 | `project_path` | string | no | Project root path |
 
-**Returns**: `{ syncedPaths, syncedAll, message }`
+**Returns**: `{ syncedPaths, syncedAll, message, requestedPaths, refreshedRoots, deletedPaths }`
+`requestedPaths` echoes targeted input, `refreshedRoots` reports the minimal existing roots actually refreshed, and `deletedPaths` identifies targets absent on disk. The full batch is validated inside project/content roots before refresh begins.
 Call this when files were created/modified outside the IDE and search tools miss them.
 
 ### ide_build_project (disabled by default)

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/PaginationServiceUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/PaginationServiceUnitTest.kt
@@ -1,15 +1,41 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerEpoch
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.CacheEvictionReason
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.PaginationService
+import com.intellij.openapi.project.Project
 import junit.framework.TestCase
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonPrimitive
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicLong
 
 class PaginationServiceUnitTest : TestCase() {
+
+    private val testServices = mutableListOf<Pair<PaginationService, CoroutineScope>>()
+
+    override fun tearDown() {
+        try {
+            for ((service, scope) in testServices) {
+                try {
+                    service.dispose()
+                } finally {
+                    scope.cancel()
+                }
+            }
+            testServices.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
 
     // --- Encoding tests ---
 
@@ -112,6 +138,33 @@ class PaginationServiceUnitTest : TestCase() {
         val newToken = service.createCursor("tool", emptyList(), emptySet(), null, 0L, "/path")
         assertNotNull(newToken)
         assertTrue(newToken.isNotEmpty())
+        assertEquals(PaginationService.MAX_CURSORS, service.sizeForTesting())
+        runBlocking {
+            val oldest = service.getPage(tokens.first(), 1, "/path", 0L)
+            assertTrue("the least-recently-used cursor must be evicted", oldest is PaginationService.GetPageResult.Error)
+            assertEquals(
+                PaginationService.CursorError.NOT_FOUND,
+                (oldest as PaginationService.GetPageResult.Error).reason
+            )
+            assertTrue(service.getPage(newToken, 1, "/path", 0L) is PaginationService.GetPageResult.Success)
+        }
+    }
+
+    fun testConcurrentCreationKeepsStrictCursorCap() = runBlocking {
+        val service = createTestService()
+        val tokens = coroutineScope {
+            (1..(PaginationService.MAX_CURSORS * 4)).map {
+                async(Dispatchers.Default) {
+                    service.createCursor("tool", emptyList(), emptySet(), null, 0L, "/path")
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(PaginationService.MAX_CURSORS, service.sizeForTesting())
+        val liveCount = tokens.count {
+            service.getPage(it, 1, "/path", 0L) is PaginationService.GetPageResult.Success
+        }
+        assertEquals(PaginationService.MAX_CURSORS, liveCount)
     }
 
     // --- getPage core logic ---
@@ -157,6 +210,49 @@ class PaginationServiceUnitTest : TestCase() {
         assertEquals(PaginationService.CursorError.MALFORMED, (result as PaginationService.GetPageResult.Error).reason)
     }
 
+    fun testRejectsNegativeOffsetAndInvalidEmbeddedPageSizes() = runBlocking {
+        val service = createTestService()
+        val token = service.createCursor("tool", emptyList(), emptySet(), null, 42L, "/project")
+        val entryId = service.decodeCursor(token)!!.entryId
+
+        val negativeOffset = service.getPage(service.encodeCursor(entryId, -1), 10, "/project", 42L)
+        val zeroPageSize = service.getPage(service.encodeCursor(entryId, 0, 0), null, "/project", 42L)
+        val oversizedPageSize = service.getPage(
+            service.encodeCursor(entryId, 0, PaginationService.MAX_PAGE_SIZE + 1),
+            null,
+            "/project",
+            42L
+        )
+
+        listOf(negativeOffset, zeroPageSize, oversizedPageSize).forEach { result ->
+            assertTrue(result is PaginationService.GetPageResult.Error)
+            assertEquals(
+                PaginationService.CursorError.MALFORMED,
+                (result as PaginationService.GetPageResult.Error).reason
+            )
+        }
+    }
+
+    fun testRejectsInvalidRequestedPageSizeAndAvoidsOffsetOverflow() = runBlocking {
+        val service = createTestService()
+        val token = service.createCursor("tool", emptyList(), emptySet(), null, 42L, "/project")
+        val entryId = service.decodeCursor(token)!!.entryId
+
+        val zero = service.getPage(token, 0, "/project", 42L)
+        val oversized = service.getPage(token, PaginationService.MAX_PAGE_SIZE + 1, "/project", 42L)
+        assertEquals(PaginationService.CursorError.MALFORMED, (zero as PaginationService.GetPageResult.Error).reason)
+        assertEquals(PaginationService.CursorError.MALFORMED, (oversized as PaginationService.GetPageResult.Error).reason)
+
+        val overflowAttempt = service.getPage(
+            service.encodeCursor(entryId, Int.MAX_VALUE),
+            PaginationService.MAX_PAGE_SIZE,
+            "/project",
+            42L
+        ) as PaginationService.GetPageResult.Success
+        assertTrue(overflowAttempt.page.items.isEmpty())
+        assertEquals(Int.MAX_VALUE, overflowAttempt.page.offset)
+    }
+
     /**
      * Contract: PaginationService.getPage() rejects malformed non-empty cursors with MALFORMED error.
      * Blank cursors ("", whitespace) are NOT normalized here — that is a tool-layer responsibility.
@@ -177,6 +273,56 @@ class PaginationServiceUnitTest : TestCase() {
         val result = service.getPage(token, 10, "/project-b", 42L)
         assertTrue(result is PaginationService.GetPageResult.Error)
         assertEquals(PaginationService.CursorError.WRONG_PROJECT, (result as PaginationService.GetPageResult.Error).reason)
+    }
+
+    fun testProductionCursorBelongsToExactProjectInstanceNotOnlyItsPath() = runBlocking {
+        val service = createTestService()
+        val owner = projectProxy("/same/project")
+        val reopenedAtSamePath = projectProxy("/same/project")
+        val token = service.createCursor(
+            toolName = "tool",
+            results = emptyList(),
+            seenKeys = emptySet(),
+            searchExtender = null,
+            psiModCount = 42L,
+            project = owner
+        )
+
+        assertTrue(service.getPage(token, 10, owner, 42L) is PaginationService.GetPageResult.Success)
+        val wrongInstance = service.getPage(token, 10, reopenedAtSamePath, 42L)
+        assertTrue(wrongInstance is PaginationService.GetPageResult.Error)
+        assertEquals(
+            PaginationService.CursorError.WRONG_PROJECT,
+            (wrongInstance as PaginationService.GetPageResult.Error).reason
+        )
+    }
+
+    fun testProductionCursorCannotBeReadThroughLegacyPathOverload() = runBlocking {
+        val service = createTestService()
+        val owner = projectProxy("/same/project")
+        val token = service.createCursor("tool", emptyList(), emptySet(), null, 42L, owner)
+
+        val result = service.getPage(token, 10, "/same/project", 42L)
+
+        assertTrue(result is PaginationService.GetPageResult.Error)
+        assertEquals(
+            PaginationService.CursorError.WRONG_PROJECT,
+            (result as PaginationService.GetPageResult.Error).reason
+        )
+    }
+
+    fun testProductionCursorIsBoundToOriginatingTool() = runBlocking {
+        val service = createTestService()
+        val owner = projectProxy("/same/project")
+        val token = service.createCursor("origin-tool", emptyList(), emptySet(), null, 42L, owner)
+
+        val result = service.getPage(token, 10, owner, 42L, expectedToolName = "other-tool")
+
+        assertTrue(result is PaginationService.GetPageResult.Error)
+        assertEquals(
+            PaginationService.CursorError.WRONG_TOOL,
+            (result as PaginationService.GetPageResult.Error).reason
+        )
     }
 
     fun testGetPageStaleDetection() = runBlocking {
@@ -248,7 +394,123 @@ class PaginationServiceUnitTest : TestCase() {
         val cursor = service.encodeCursor(service.decodeCursor(token)!!.entryId, lastOffset)
         val result = service.getPage(cursor, 100, "/project", 42L) as PaginationService.GetPageResult.Success
         assertFalse(extenderCalled)
-        assertFalse(result.page.hasMore)
+        assertTrue("the hard cache cap must not be reported as source exhaustion", result.page.hasMore)
+        assertNull("a capped cache cannot offer an unusable continuation", result.page.nextCursor)
+    }
+
+    fun testInitialResultsAreCappedWithoutClaimingExhaustion() = runBlocking {
+        val service = createTestService()
+        val max = PaginationService.MAX_CACHED_RESULTS_PER_CURSOR
+        val results = (1..(max + 25)).map {
+            PaginationService.SerializedResult("key$it", JsonPrimitive("data$it"))
+        }
+        val token = service.createCursor("tool", results, results.map { it.key }.toSet(), null, 42L, "/project")
+        val entryId = service.decodeCursor(token)!!.entryId
+        val lastPage = service.getPage(
+            service.encodeCursor(entryId, max - 1),
+            PaginationService.MAX_PAGE_SIZE,
+            "/project",
+            42L
+        ) as PaginationService.GetPageResult.Success
+
+        assertEquals(max, lastPage.page.totalCollected)
+        assertEquals(listOf(JsonPrimitive("data$max")), lastPage.page.items)
+        assertTrue(lastPage.page.hasMore)
+        assertNull(lastPage.page.nextCursor)
+    }
+
+    fun testExtensionIsDeduplicatedAndCapped() = runBlocking {
+        val service = createTestService()
+        val max = PaginationService.MAX_CACHED_RESULTS_PER_CURSOR
+        val initial = (1 until max).map {
+            PaginationService.SerializedResult("key$it", JsonPrimitive("data$it"))
+        }
+        val extender: suspend (Set<String>, Int) -> List<PaginationService.SerializedResult> = { _, _ ->
+            listOf(
+                PaginationService.SerializedResult("key${max - 1}", JsonPrimitive("duplicate-initial")),
+                PaginationService.SerializedResult("new-a", JsonPrimitive("new-a")),
+                PaginationService.SerializedResult("new-a", JsonPrimitive("duplicate-extension")),
+                PaginationService.SerializedResult("new-b", JsonPrimitive("overflow"))
+            )
+        }
+        val token = service.createCursor("tool", initial, initial.map { it.key }.toSet(), extender, 42L, "/project")
+        val entryId = service.decodeCursor(token)!!.entryId
+        val lastPage = service.getPage(
+            service.encodeCursor(entryId, max - 2),
+            2,
+            "/project",
+            42L
+        ) as PaginationService.GetPageResult.Success
+
+        assertEquals(max, lastPage.page.totalCollected)
+        assertEquals(
+            listOf(JsonPrimitive("data${max - 1}"), JsonPrimitive("new-a")),
+            lastPage.page.items
+        )
+        assertTrue(lastPage.page.hasMore)
+        assertNull(lastPage.page.nextCursor)
+    }
+
+    fun testStaleCursorNeverInvokesExtender() = runBlocking {
+        val service = createTestService()
+        var extenderCalled = false
+        val token = service.createCursor(
+            "tool",
+            listOf(PaginationService.SerializedResult("key", JsonPrimitive("data"))),
+            setOf("key"),
+            { _, _ ->
+                extenderCalled = true
+                emptyList()
+            },
+            42L,
+            "/project"
+        )
+
+        val result = service.getPage(token, 1, "/project", 43L)
+
+        assertFalse(extenderCalled)
+        assertEquals(
+            PaginationService.CursorError.SEARCH_INVALIDATED,
+            (result as PaginationService.GetPageResult.Error).reason
+        )
+    }
+
+    fun testModCountChangeDuringExtenderFailsClosedBeforeAppend() = runBlocking {
+        val service = createTestService()
+        val modCount = AtomicLong(42L)
+        val extenderEntered = CompletableDeferred<Unit>()
+        val releaseExtender = CompletableDeferred<Unit>()
+        val token = service.createCursor(
+            "tool",
+            listOf(PaginationService.SerializedResult("key1", JsonPrimitive("data1"))),
+            setOf("key1"),
+            { _, _ ->
+                extenderEntered.complete(Unit)
+                releaseExtender.await()
+                listOf(PaginationService.SerializedResult("key2", JsonPrimitive("data2")))
+            },
+            42L,
+            "/project"
+        )
+
+        val request = async {
+            service.getPage(
+                token,
+                1,
+                "/project",
+                42L,
+                currentModCountAfterSuspension = modCount::get
+            )
+        }
+        extenderEntered.await()
+        modCount.set(43L)
+        releaseExtender.complete(Unit)
+
+        val result = request.await()
+        assertEquals(
+            PaginationService.CursorError.SEARCH_INVALIDATED,
+            (result as PaginationService.GetPageResult.Error).reason
+        )
     }
 
     fun testExtenderFailureReturnsSearchInvalidated() = runBlocking {
@@ -386,6 +648,126 @@ class PaginationServiceUnitTest : TestCase() {
         assertEquals(PaginationService.CursorError.NOT_FOUND, (result as PaginationService.GetPageResult.Error).reason)
     }
 
+    fun testResetSessionClearsAllEntries() = runBlocking {
+        val service = createTestService()
+        val token = service.createCursor("tool", emptyList(), emptySet(), null, 0L, "/project")
+        service.resetSession()
+        val result = service.getPage(token, 10, "/project", 0L)
+        assertTrue(result is PaginationService.GetPageResult.Error)
+        assertEquals(PaginationService.CursorError.NOT_FOUND, (result as PaginationService.GetPageResult.Error).reason)
+    }
+
+    fun testReadOnlyStatsTrackOccupancyHitsMissesAndExpiry() = runBlocking {
+        val service = createTestService()
+        val results = listOf(
+            PaginationService.SerializedResult("one", JsonPrimitive("one")),
+            PaginationService.SerializedResult("two", JsonPrimitive("two"))
+        )
+        val cursor = service.createCursor("tool", results, emptySet(), null, 0L, "/project")
+        service.getPage(cursor, 1, "/project", 0L)
+        service.getPage(service.encodeCursor("missing", 0), 1, "/project", 0L)
+        val occupied = service.stats()
+        assertEquals(1, occupied.entries)
+        assertEquals(2L, occupied.storedResults)
+        assertEquals(1L, occupied.hits)
+        assertEquals(1L, occupied.misses)
+        service.expireEntryForTesting(service.decodeCursor(cursor)!!.entryId)
+        assertEquals("stats must not sweep or refresh expiry", 1, service.stats().entries)
+        service.getPage(cursor, 1, "/project", 0L)
+        assertEquals(0, service.stats().entries)
+        assertEquals(0L, service.stats().storedResults)
+        assertEquals(1L, service.stats().evictions[CacheEvictionReason.TTL])
+    }
+
+    fun testProjectCloseCleanupUsesExactProjectIdentity() = runBlocking {
+        val service = createTestService()
+        val owner = projectProxy("/project")
+        val other = projectProxy("/project")
+        val first = service.createCursor("tool", emptyList(), emptySet(), null, 0L, owner)
+        val second = service.createCursor("tool", emptyList(), emptySet(), null, 0L, other)
+        service.removeProject(owner)
+        assertEquals(1, service.stats().entries)
+        assertTrue(service.getPage(first, 1, owner, 0L) is PaginationService.GetPageResult.Error)
+        assertTrue(service.getPage(second, 1, other, 0L) is PaginationService.GetPageResult.Success)
+        assertEquals(1L, service.stats().evictions[CacheEvictionReason.PROJECT_CLOSED])
+    }
+
+    fun testOldGenerationCannotCreateCursorAfterReset() = runBlocking {
+        val service = createTestService()
+        val oldContext = service.generationContext()
+        val releaseRequest = CompletableDeferred<Unit>()
+        val request = async {
+            withContext(oldContext) {
+                releaseRequest.await()
+                runCatching {
+                    service.createCursor("tool", emptyList(), emptySet(), null, 0L, "/project")
+                }
+            }
+        }
+
+        service.resetSession()
+        releaseRequest.complete(Unit)
+
+        assertTrue(request.await().isFailure)
+        assertEquals(0, service.sizeForTesting())
+    }
+
+    fun testOldGenerationCannotLookUpCursorAfterReset() = runBlocking {
+        val service = createTestService()
+        val token = service.createCursor("tool", emptyList(), emptySet(), null, 0L, "/project")
+        val oldContext = service.generationContext()
+        val releaseRequest = CompletableDeferred<Unit>()
+        val request = async {
+            withContext(oldContext) {
+                releaseRequest.await()
+                service.getPage(token, 1, "/project", 0L)
+            }
+        }
+
+        service.resetSession()
+        releaseRequest.complete(Unit)
+
+        val result = request.await()
+        assertEquals(
+            PaginationService.CursorError.SEARCH_INVALIDATED,
+            (result as PaginationService.GetPageResult.Error).reason
+        )
+    }
+
+    fun testResetDuringExtenderPreventsOldPageReturn() = runBlocking {
+        val service = createTestService()
+        val extenderEntered = CompletableDeferred<Unit>()
+        val releaseExtender = CompletableDeferred<Unit>()
+        val token = service.createCursor(
+            "tool",
+            listOf(PaginationService.SerializedResult("key1", JsonPrimitive("data1"))),
+            setOf("key1"),
+            { _, _ ->
+                extenderEntered.complete(Unit)
+                releaseExtender.await()
+                listOf(PaginationService.SerializedResult("key2", JsonPrimitive("data2")))
+            },
+            42L,
+            "/project"
+        )
+        val oldContext = service.generationContext()
+        val request = async {
+            withContext(oldContext) {
+                service.getPage(token, 1, "/project", 42L)
+            }
+        }
+
+        extenderEntered.await()
+        service.resetSession()
+        releaseExtender.complete(Unit)
+
+        val result = request.await()
+        assertEquals(
+            PaginationService.CursorError.SEARCH_INVALIDATED,
+            (result as PaginationService.GetPageResult.Error).reason
+        )
+    }
+
     // --- Metadata round-trip ---
 
     fun testMetadataRoundTrip() = runBlocking {
@@ -400,6 +782,29 @@ class PaginationServiceUnitTest : TestCase() {
     // --- Helper ---
 
     private fun createTestService(): PaginationService {
-        return PaginationService(CoroutineScope(Dispatchers.Default))
+        val scope = CoroutineScope(Dispatchers.Default)
+        return PaginationService(scope, McpServerEpoch()).also { testServices += it to scope }
+    }
+
+    private fun projectProxy(basePath: String): Project {
+        return Proxy.newProxyInstance(
+            Project::class.java.classLoader,
+            arrayOf(Project::class.java)
+        ) { proxy, method, args ->
+            when (method.name) {
+                "getBasePath" -> basePath
+                "isDisposed" -> false
+                "getName" -> "pagination-test"
+                "equals" -> proxy === args?.firstOrNull()
+                "hashCode" -> System.identityHashCode(proxy)
+                "toString" -> "PaginationProjectProxy($basePath)"
+                else -> when (method.returnType) {
+                    java.lang.Boolean.TYPE -> false
+                    java.lang.Integer.TYPE -> 0
+                    java.lang.Long.TYPE -> 0L
+                    else -> null
+                }
+            }
+        } as Project
     }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ResultShapeContractUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ResultShapeContractUnitTest.kt
@@ -9,6 +9,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallHierarchy
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DefinitionResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DiagnosticsResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileCoverageInfo
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileDiagnosticsAnalysis
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileStructureResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindClassResult
@@ -51,6 +52,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TestSummary
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TextMatch
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeElement
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyTraversalNode
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.UsageLocation
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ChangeSignatureTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ConversionStatus
@@ -64,6 +66,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.MemberEr
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.NoSymbolFoundResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.PositionInfo
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ReplaceTextInFileTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RefactoringPreviewResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.SafeDeleteBlockedResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.SafeDeleteFileBlockedResult
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.StructuralSearchReplaceTool
@@ -379,7 +382,8 @@ class ResultShapeContractUnitTest : TestCase() {
             line = 42,
             column = 17,
             containerName = "Service",
-            language = "JAVA"
+            language = "JAVA",
+            symbolId = "sym_match"
         )
         val buildMessage = BuildMessage(
             category = "ERROR",
@@ -403,6 +407,15 @@ class ResultShapeContractUnitTest : TestCase() {
             state = "timed_out",
             reason = "File analysis timed out."
         )
+        val fileDiagnosticsAnalysis = FileDiagnosticsAnalysis(
+            file = "src/main/java/com/example/Service.java",
+            mode = "closed_batch",
+            fresh = true,
+            timedOut = true,
+            message = "Analysis completed using the shared deadline.",
+            problemCount = 1,
+            problemsTruncated = true
+        )
         val testResultInfo = TestResultInfo(
             name = "testHandle",
             suite = "com.example.ServiceTest",
@@ -425,15 +438,21 @@ class ResultShapeContractUnitTest : TestCase() {
             file = "src/main/java/com/example/Service.java",
             kind = "class",
             language = "JAVA",
+            symbolId = "sym_type",
             supertypes = listOf(
                 TypeElement(
                     name = "AbstractService",
                     file = "src/main/java/com/example/AbstractService.java",
                     kind = "class",
                     language = "JAVA",
+                    symbolId = "sym_supertype",
                     supertypes = null
                 )
             )
+        )
+        val typeHierarchyTraversalNode = TypeHierarchyTraversalNode(
+            direction = "supertype",
+            element = typeElement
         )
         val callElement = CallElement(
             name = "handle",
@@ -441,6 +460,7 @@ class ResultShapeContractUnitTest : TestCase() {
             line = 42,
             column = 17,
             language = "JAVA",
+            symbolId = "sym_call",
             children = listOf(
                 CallElement(
                     name = "validate",
@@ -448,6 +468,7 @@ class ResultShapeContractUnitTest : TestCase() {
                     line = 51,
                     column = 9,
                     language = "JAVA",
+                    symbolId = "sym_child_call",
                     children = null
                 )
             )
@@ -458,7 +479,9 @@ class ResultShapeContractUnitTest : TestCase() {
             line = 12,
             column = 14,
             kind = "class",
-            language = "JAVA"
+            language = "JAVA",
+            qualifiedName = "com.example.DefaultService",
+            symbolId = "sym_implementation"
         )
         val methodInfo = MethodInfo(
             name = "handle",
@@ -467,6 +490,18 @@ class ResultShapeContractUnitTest : TestCase() {
             file = "src/main/java/com/example/Service.java",
             line = 42,
             column = 17,
+            language = "JAVA",
+            symbolId = "sym_method"
+        )
+        val updatedSymbol = ResolvedSymbolInfo(
+            symbolId = "sym_updated",
+            name = "process",
+            kind = "method",
+            container = "com.example.Service",
+            file = "src/main/java/com/example/Service.java",
+            line = 43,
+            column = 17,
+            qualifiedName = "com.example.Service#process",
             language = "JAVA"
         )
         val usageInfo = UsageInfo(
@@ -497,9 +532,11 @@ class ResultShapeContractUnitTest : TestCase() {
                     signature = "handle(Request): Response",
                     line = 42,
                     endLine = 55,
-                    children = listOf()
+                    children = listOf(),
+                    symbolId = "sym_structure_method"
                 )
-            )
+            ),
+            symbolId = "sym_structure_class"
         )
         val ssrMatch = StructuralSearchReplaceTool.SsrMatch(
             file = "src/main/java/com/example/Service.java",
@@ -537,6 +574,7 @@ class ResultShapeContractUnitTest : TestCase() {
                     pageSize = 25,
                     stale = true,
                     resolvedSymbol = ResolvedSymbolInfo(
+                        symbolId = "sym_resolved",
                         name = "handle",
                         kind = "method",
                         container = "com.example.Service",
@@ -546,9 +584,11 @@ class ResultShapeContractUnitTest : TestCase() {
                     totalIsExact = false
                 )
             ),
+            struct(ResolvedSymbolInfo.serializer(), updatedSymbol),
             struct(
                 DefinitionResult.serializer(),
                 DefinitionResult(
+                    symbolId = "sym_definition",
                     file = "src/main/java/com/example/Service.java",
                     line = 42,
                     column = 17,
@@ -564,6 +604,7 @@ class ResultShapeContractUnitTest : TestCase() {
             struct(
                 SymbolInfoResult.serializer(),
                 SymbolInfoResult(
+                    symbolId = "sym_info",
                     name = "handle",
                     kind = "method",
                     qualifiedName = "com.example.Service#handle",
@@ -601,13 +642,31 @@ class ResultShapeContractUnitTest : TestCase() {
                 TypeHierarchyResult(
                     element = typeElement,
                     supertypes = listOf(typeElement),
-                    subtypes = listOf(typeElement)
+                    subtypes = listOf(typeElement),
+                    traversal = listOf(
+                        typeHierarchyTraversalNode,
+                        typeHierarchyTraversalNode.copy(direction = "subtype")
+                    ),
+                    returnedNodes = 2,
+                    truncated = true,
+                    elapsedMs = 37L,
+                    hasMore = true,
+                    cursor = "hier_type_page_2"
                 )
             ),
+            struct(TypeHierarchyTraversalNode.serializer(), typeHierarchyTraversalNode),
             struct(TypeElement.serializer(), typeElement),
             struct(
                 CallHierarchyResult.serializer(),
-                CallHierarchyResult(element = callElement, calls = listOf(callElement))
+                CallHierarchyResult(
+                    element = callElement,
+                    calls = listOf(callElement),
+                    returnedNodes = 1,
+                    truncated = true,
+                    elapsedMs = 29L,
+                    hasMore = true,
+                    cursor = "hier_call_page_2"
+                )
             ),
             struct(CallElement.serializer(), callElement),
             struct(
@@ -630,11 +689,13 @@ class ResultShapeContractUnitTest : TestCase() {
                     problems = listOf(problemInfo),
                     intentions = listOf(intentionInfo),
                     problemCount = 1,
+                    problemsTruncated = true,
                     intentionCount = 1,
                     analysisFresh = true,
                     analysisTimedOut = true,
                     analysisMessage = "analysis finished",
                     analysisMode = "closed_batch",
+                    fileAnalyses = listOf(fileDiagnosticsAnalysis),
                     buildErrors = listOf(buildMessage),
                     buildErrorCount = 1,
                     buildWarningCount = 2,
@@ -645,6 +706,7 @@ class ResultShapeContractUnitTest : TestCase() {
                     testResultsTruncated = true
                 )
             ),
+            struct(FileDiagnosticsAnalysis.serializer(), fileDiagnosticsAnalysis),
             struct(ProblemInfo.serializer(), problemInfo),
             struct(IntentionInfo.serializer(), intentionInfo),
             struct(TestResultInfo.serializer(), testResultInfo),
@@ -694,7 +756,25 @@ class ResultShapeContractUnitTest : TestCase() {
                     changesCount = 3,
                     message = "Renamed 'handle' to 'process'",
                     warnings = listOf("1 usage in a comment was not updated"),
-                    unretargetedImporters = listOf("src/main/java/com/example/Caller.java")
+                    unretargetedImporters = listOf("src/main/java/com/example/Caller.java"),
+                    updatedSymbol = updatedSymbol,
+                    invalidatedSymbolId = "sym_invalidated"
+                )
+            ),
+            struct(
+                RefactoringPreviewResult.serializer(),
+                RefactoringPreviewResult(
+                    dryRun = true,
+                    canApply = true,
+                    target = updatedSymbol,
+                    plannedChange = JsonObject(
+                        mapOf("newName" to JsonPrimitive("process"))
+                    ),
+                    affectedFiles = listOf("src/main/java/com/example/Service.java"),
+                    usageCount = 3,
+                    conflictCount = 1,
+                    warnings = listOf("1 usage in a comment would not be updated"),
+                    elapsedMs = 31L
                 )
             ),
             struct(
@@ -706,7 +786,10 @@ class ResultShapeContractUnitTest : TestCase() {
                 SyncFilesResult(
                     syncedPaths = listOf("/Users/dev/project/src"),
                     syncedAll = true,
-                    message = "Synced 1 path"
+                    message = "Synced 1 path",
+                    requestedPaths = listOf("src/main/java/com/example/Removed.java"),
+                    refreshedRoots = listOf("src/main/java/com/example"),
+                    deletedPaths = listOf("src/main/java/com/example/Removed.java")
                 )
             ),
             struct(BuildMessage.serializer(), buildMessage),
@@ -773,7 +856,8 @@ class ResultShapeContractUnitTest : TestCase() {
                             column = 21,
                             isInterface = true,
                             depth = 2,
-                            language = "JAVA"
+                            language = "JAVA",
+                            symbolId = "sym_super_method_nested"
                         )
                     ),
                     totalCount = 1
@@ -792,7 +876,8 @@ class ResultShapeContractUnitTest : TestCase() {
                     column = 21,
                     isInterface = true,
                     depth = 2,
-                    language = "JAVA"
+                    language = "JAVA",
+                    symbolId = "sym_super_method"
                 )
             ),
             struct(
@@ -982,7 +1067,10 @@ class ResultShapeContractUnitTest : TestCase() {
                 FileStructureResult(
                     file = "src/main/java/com/example/Service.java",
                     language = "JAVA",
-                    structure = "Service\n  handle(Request): Response"
+                    structure = "Service\n  handle(Request): Response",
+                    nodes = listOf(structureNode),
+                    symbolIdsTruncated = true,
+                    symbolIdsOmitted = 1
                 )
             ),
             struct(
@@ -993,7 +1081,8 @@ class ResultShapeContractUnitTest : TestCase() {
                     elementType = "method",
                     usageCount = 2,
                     blockingUsages = listOf(usageInfo),
-                    message = "2 usages block deletion"
+                    message = "2 usages block deletion",
+                    symbolId = "sym_safe_delete"
                 )
             ),
             struct(UsageInfo.serializer(), usageInfo),
@@ -1038,7 +1127,8 @@ class ResultShapeContractUnitTest : TestCase() {
                     file = "src/main/java/com/example/Service.java",
                     message = "Replaced 'handle'",
                     startLine = 42,
-                    endLine = 55
+                    endLine = 55,
+                    updatedSymbol = updatedSymbol
                 )
             ),
             struct(
@@ -1077,7 +1167,8 @@ class ResultShapeContractUnitTest : TestCase() {
                     file = "src/main/java/com/example/Service.java",
                     message = "Signature changed",
                     affectedFiles = listOf("src/main/java/com/example/Caller.java"),
-                    changesCount = 2
+                    changesCount = 2,
+                    updatedSymbol = updatedSymbol
                 )
             ),
             struct(

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ToolManifestContractUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/contract/ToolManifestContractUnitTest.kt
@@ -21,7 +21,7 @@ import java.io.File
  * fail here rather than silently shipping.
  *
  * Two limits worth knowing before trusting it:
- * - It covers the tools that register headlessly — currently 49 of the 52 in [ToolNames.ALL].
+ * - It covers the tools that register headlessly — currently 51 of the 54 in [ToolNames.ALL].
  *   The three in [NOT_REGISTRABLE_HEADLESS] are guarded by set-equality in
  *   [testEveryDeclaredToolNameIsRegistered] instead, so they cannot vanish unnoticed, but their
  *   schemas are not snapshotted.

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaCallHierarchyPagingBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaCallHierarchyPagingBehaviorTest.kt
@@ -1,0 +1,109 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.java
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.HierarchyPageRequest
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.searches.MethodReferencesSearch
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.QueryExecutor
+import org.junit.Assume
+
+class JavaCallHierarchyPagingBehaviorTest : McpPlatformTestCase() {
+
+    fun testCallerPagingCountsUniqueCallersInsteadOfRawReferenceSites() {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val sourcePath = writeProjectFile(
+            "src/paging/CallerSites.java",
+            """
+                package paging;
+
+                class CallerSites {
+                    void target() {}
+                    void unrelated() {}
+
+                    void noisy() {
+                        unrelated(); unrelated(); unrelated(); unrelated();
+                        unrelated(); unrelated(); unrelated(); unrelated();
+                        unrelated(); unrelated();
+                    }
+
+                    void lateOne() { unrelated(); }
+                    void lateTwo() { unrelated(); }
+                }
+            """.trimIndent()
+        )
+        val virtualFile = requireNotNull(
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(sourcePath.toString())
+        )
+        val psiFile = requireNotNull(PsiManager.getInstance(project).findFile(virtualFile)) as PsiJavaFile
+        val psiClass = psiFile.classes.single()
+        val target = psiClass.findMethodsByName("target", false).single()
+        val noisy = psiClass.findMethodsByName("noisy", false).single()
+        val lateOne = psiClass.findMethodsByName("lateOne", false).single()
+        val lateTwo = psiClass.findMethodsByName("lateTwo", false).single()
+
+        fun callReferencesIn(methodName: String): List<PsiReference> {
+            val method = psiClass.findMethodsByName(methodName, false).single()
+            return PsiTreeUtil.findChildrenOfType(
+                requireNotNull(method.body),
+                PsiMethodCallExpression::class.java
+            )
+                .sortedBy { it.textOffset }
+                .map { requireNotNull(it.methodExpression.reference) }
+        }
+
+        val references = buildList {
+            addAll(callReferencesIn(noisy.name))
+            addAll(callReferencesIn(lateOne.name))
+            addAll(callReferencesIn(lateTwo.name))
+        }
+        // The target has no real usages. Injecting through the platform's actual query EP gives
+        // the handler a deterministic stream: ten distinct sites from one semantic caller first,
+        // followed by two callers that the former `2 * maxResults` raw-site cap could not reach.
+        val executor = QueryExecutor<PsiReference, MethodReferencesSearch.SearchParameters> { parameters, consumer ->
+            parameters.method != target || references.all(consumer::process)
+        }
+        MethodReferencesSearch.EP_NAME.point.registerExtension(executor, testRootDisposable)
+
+        val handler = JavaCallHierarchyHandler()
+        val first = requireNotNull(
+            handler.getCallHierarchy(
+                target,
+                project,
+                direction = "callers",
+                depth = 1,
+                scope = BuiltInSearchScope.PROJECT_FILES,
+                excludeGenerated = false,
+                page = HierarchyPageRequest(offset = 0, limit = 2)
+            )
+        )
+
+        assertEquals(
+            "many sites in one method must not hide callers encountered later",
+            listOf("CallerSites.noisy()", "CallerSites.lateOne()"),
+            first.calls.map { it.name }
+        )
+        assertEquals("the third unique caller is the page look-ahead", 2, first.nextOffset)
+
+        val second = requireNotNull(
+            handler.getCallHierarchy(
+                target,
+                project,
+                direction = "callers",
+                depth = 1,
+                scope = BuiltInSearchScope.PROJECT_FILES,
+                excludeGenerated = false,
+                page = HierarchyPageRequest(offset = 2, limit = 2)
+            )
+        )
+        assertEquals(listOf("CallerSites.lateTwo()"), second.calls.map { it.name })
+        assertNull("the unique caller stream is exhausted", second.nextOffset)
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaTypeHierarchyPagingBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/java/JavaTypeHierarchyPagingBehaviorTest.kt
@@ -1,0 +1,78 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.java
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScopeResolver
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.HierarchyPageRequest
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyDirection
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.PsiTestUtil
+import org.junit.Assume
+
+class JavaTypeHierarchyPagingBehaviorTest : McpPlatformTestCase() {
+    fun testResolvedInterfacesAreFilteredBeforeThePageLimit() {
+        verifyLateProjectSupertypes(isInterface = false)
+    }
+
+    fun testExtendsFallbackDoesNotRelabelExcludedResolvedTypesAsUnresolved() {
+        verifyLateProjectSupertypes(isInterface = true)
+    }
+
+    private fun verifyLateProjectSupertypes(isInterface: Boolean) {
+        Assume.assumeTrue("Java plugin required", PluginDetectors.java.isAvailable)
+        // Light fixtures reuse the project: keep source-folder registrations independent of
+        // test order instead of recreating a previously registered root with another type.
+        val fixturePrefix = if (isInterface) "interface-filtering" else "class-filtering"
+        val productionPath = "$fixturePrefix-prod-src"
+        val testPath = "$fixturePrefix-test-src"
+        registerSourceRoot(productionPath)
+        val testRoot = registerSourceRoot(testPath)
+        PsiTestUtil.removeSourceRoot(module, testRoot)
+        PsiTestUtil.addSourceRoot(module, testRoot, true)
+        writeProjectFile("$productionPath/filtering/Visible.java", """
+            package filtering;
+            interface VisibleOne {}
+            interface VisibleTwo {}
+        """.trimIndent())
+        val declaration = if (isInterface) "interface Root extends" else "class Root implements"
+        writeProjectFile("$testPath/filtering/Root.java", """
+            package filtering;
+            interface HiddenOne {}
+            interface HiddenTwo {}
+            interface HiddenThree {}
+            $declaration HiddenOne, HiddenTwo, HiddenThree, VisibleOne, VisibleTwo {}
+        """.trimIndent())
+        // A test-source seed can resolve both source sets, while the requested result scope
+        // deliberately excludes its first three interfaces.
+        val root = requireNotNull(JavaPsiFacade.getInstance(project).findClass(
+            "filtering.Root", GlobalSearchScope.projectScope(project)
+        ))
+        assertEquals("all interfaces must really resolve in this fixture", 5, root.interfaces.size)
+        assertEquals("the fixture must expose the requested declaration kind", isInterface, root.isInterface)
+        val resultScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, BuiltInSearchScope.PROJECT_PRODUCTION_FILES)
+        assertEquals(
+            "the first three interfaces must actually be outside the result scope",
+            listOf(false, false, false, true, true),
+            root.interfaces.map { resultScope.contains(requireNotNull(it.containingFile.virtualFile)) }
+        )
+        val handler = JavaTypeHierarchyHandler()
+        val first = requireNotNull(handler.getTypeHierarchy(
+            root, project, BuiltInSearchScope.PROJECT_PRODUCTION_FILES, excludeGenerated = false,
+            directOnly = true, direction = TypeHierarchyDirection.SUPERTYPE,
+            page = HierarchyPageRequest(offset = 0, limit = 1)
+        ))
+        assertEquals(listOf("filtering.VisibleOne"), first.supertypes.map { it.qualifiedName })
+        assertNotNull("an included declaration must retain its real pointer", first.supertypes.single().pointerTarget)
+        assertEquals("the later included interface is look-ahead, not false exhaustion", 1, first.nextOffset)
+
+        val second = requireNotNull(handler.getTypeHierarchy(
+            root, project, BuiltInSearchScope.PROJECT_PRODUCTION_FILES, excludeGenerated = false,
+            directOnly = true, direction = TypeHierarchyDirection.SUPERTYPE,
+            page = HierarchyPageRequest(offset = 1, limit = 1)
+        ))
+        assertEquals(listOf("filtering.VisibleTwo"), second.supertypes.map { it.qualifiedName })
+        assertNull(second.nextOffset)
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonCallerCollectionBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/handlers/python/PythonCallerCollectionBehaviorTest.kt
@@ -1,0 +1,60 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.python
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScopeResolver
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.HierarchyPageRequest
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.applyHierarchyPage
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.PsiTestUtil
+import org.junit.Assume
+
+/** Tests the real post-native-lookup collector without impersonating optional Python PSI types. */
+class PythonCallerCollectionBehaviorTest : McpPlatformTestCase() {
+    fun testExcludedPrefixDoesNotHideLateUniqueCallers() {
+        Assume.assumeTrue("Java PSI is used as language-neutral named declaration fixtures", PluginDetectors.java.isAvailable)
+        registerSourceRoot("prod-src")
+        val testRoot = registerSourceRoot("test-src")
+        PsiTestUtil.removeSourceRoot(module, testRoot)
+        PsiTestUtil.addSourceRoot(module, testRoot, true)
+        writeProjectFile("test-src/callers/Excluded.java", """
+            package callers;
+            class Excluded {
+                void first() {} void second() {} void third() {}
+                void fourth() {} void fifth() {} void sixth() {}
+            }
+        """.trimIndent())
+        writeProjectFile("prod-src/callers/First.java", "package callers; class First { void call() {} }")
+        writeProjectFile("prod-src/callers/Second.java", "package callers; class Second { void call() {} }")
+        writeProjectFile("prod-src/callers/Third.java", "package callers; class Third { void call() {} }")
+
+        fun methods(owner: String): List<PsiMethod> = requireNotNull(
+            JavaPsiFacade.getInstance(project).findClass("callers.$owner", GlobalSearchScope.projectScope(project))
+        ).methods.toList()
+
+        val included = listOf("First", "Second", "Third").map { methods(it).single() }
+        val candidates = methods("Excluded") + List(5) { included[0] } + included.drop(1)
+        val pageRequest = HierarchyPageRequest(offset = 0, limit = 2)
+        val results = PythonCallHierarchyHandler().collectIncludedCallers(
+            project = project,
+            // Mirrors the native API's semantic callable candidates. The shared PSI fields used
+            // here (file, name, offset, scope) do not require an installed Python plugin.
+            directCallers = candidates.asSequence(),
+            depth = 1,
+            visited = mutableSetOf(),
+            stackDepth = 0,
+            searchScope = BuiltInSearchScopeResolver.resolveGlobalScope(project, BuiltInSearchScope.PROJECT_PRODUCTION_FILES),
+            maxResults = pageRequest.collectionLimit
+        )
+        val (first, nextOffset) = results.applyHierarchyPage(pageRequest)
+        assertEquals("same short name in different files is three distinct callers", 3, results.size)
+        assertEquals(listOf(included[0], included[1]), first.map { it.pointerTarget })
+        assertEquals(2, nextOffset)
+        val (second, lastOffset) = results.applyHierarchyPage(HierarchyPageRequest(offset = 2, limit = 2))
+        assertEquals(listOf(included[2]), second.map { it.pointerTarget })
+        assertNull(lastOffset)
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/HierarchyContinuationRegistryBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/HierarchyContinuationRegistryBehaviorTest.kt
@@ -1,0 +1,418 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry.TypeContinuation
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallElement
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeElement
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.SmartPointerManager
+
+class HierarchyContinuationRegistryBehaviorTest : McpPlatformTestCase() {
+
+    private val serverEpoch = McpServerEpoch()
+
+    fun testDefaultsUseIndependentTenMinuteTtlAndBoundedLru() {
+        assertEquals(128, HierarchyContinuationRegistry.DEFAULT_MAX_ENTRIES)
+        assertEquals(10 * 60 * 1_000L, HierarchyContinuationRegistry.DEFAULT_TTL_MILLIS)
+    }
+
+    fun testAccessOrderLruEvictsTheLeastRecentlyUsedCursor() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            maxEntries = 2,
+            ttlMillis = 10_000,
+            clock = { 1_000L },
+            idGenerator = { "cursor-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val continuation = fixtureContinuation()
+
+        val first = registry.register(project, continuation)
+        val second = registry.register(project, continuation)
+        assertTrue(registry.resolve(project, first).isSuccess)
+        val third = registry.register(project, continuation)
+
+        assertTrue("second cursor should be evicted as LRU", registry.resolve(project, second).isFailure)
+        assertTrue(registry.resolve(project, first).isSuccess)
+        assertTrue(registry.resolve(project, third).isSuccess)
+        assertEquals(2, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testTtlRefreshesOnAccessAndExpiresAtBoundary() {
+        var now = 1_000L
+        val registry = HierarchyContinuationRegistry(
+            maxEntries = 2,
+            ttlMillis = 100,
+            clock = { now },
+            idGenerator = { "ttl-cursor" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val cursor = registry.register(project, fixtureContinuation())
+
+        now = 1_099L
+        assertTrue(registry.resolve(project, cursor).isSuccess)
+        now = 1_198L
+        assertTrue(registry.resolve(project, cursor).isSuccess)
+        now = 1_298L
+        assertTrue("cursor must expire at the exact TTL boundary", registry.resolve(project, cursor).isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testCursorIsBoundToExactProjectInstanceWithoutDestroyingOwnerState() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "project-cursor" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val cursor = registry.register(project, fixtureContinuation())
+        val otherProject = ProjectManager.getInstance().defaultProject
+
+        assertNotSame(project, otherProject)
+        assertTrue(registry.resolve(otherProject, cursor).isFailure)
+        assertTrue("wrong-project lookup must not consume the owner's cursor", registry.resolve(project, cursor).isSuccess)
+        Disposer.dispose(registry)
+    }
+
+    fun testWrongProjectLookupDoesNotPromoteForeignCursorInAccessOrder() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            maxEntries = 2,
+            idGenerator = { "foreign-lru-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val first = registry.register(project, fixtureContinuation())
+        val second = registry.register(project, fixtureContinuation())
+        val otherProject = ProjectManager.getInstance().defaultProject
+
+        assertTrue(registry.resolve(otherProject, first).isFailure)
+        val third = registry.register(project, fixtureContinuation())
+
+        assertTrue("foreign lookup must not save the oldest cursor from eviction", registry.resolve(project, first).isFailure)
+        assertTrue(registry.resolve(project, second).isSuccess)
+        assertTrue(registry.resolve(project, third).isSuccess)
+        Disposer.dispose(registry)
+    }
+
+    fun testResetRejectsRegisterFromPreviousGeneration() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "stale-register" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val generation = registry.currentGeneration()
+
+        registry.resetSession()
+        val result = registry.register(project, generation, fixtureContinuation())
+
+        assertTrue("an in-flight old-session query must not resurrect a cursor", result.isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testResolvedLeaseCannotRegisterAfterSessionReset() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "lease-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val cursor = registry.register(project, fixtureContinuation())
+        val lease = registry.resolveLease(project, cursor).getOrThrow()
+
+        registry.resetSession()
+        val result = registry.register(project, lease.generation, lease.continuation)
+
+        assertTrue(result.isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testResetSessionInvalidatesAllContinuations() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "reset-cursor" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val cursor = registry.register(project, fixtureContinuation())
+
+        registry.resetSession()
+
+        assertTrue(registry.resolve(project, cursor).isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testMcpServerStopInvalidatesApplicationContinuationRegistry() {
+        val registry = HierarchyContinuationRegistry.getInstance()
+        registry.resetSession()
+        val cursor = registry.register(project, fixtureContinuation())
+
+        McpServerService.getInstance().stopServer()
+
+        assertTrue("server generation boundary must expire hierarchy cursors", registry.resolve(project, cursor).isFailure)
+    }
+
+    fun testRegistryRetainsHistoricalSmartPointerIdentityBeyondFormerTruncationLimit() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "bounded-pointers" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val fixture = fixtureContinuation()
+        val continuation = fixture.copy(
+            visitedPointers = List(4_097) {
+                fixture.rootPointer
+            }
+        )
+
+        val cursor = registry.register(project, continuation)
+        val restored = registry.resolve(project, cursor).getOrThrow() as TypeContinuation
+
+        assertEquals(
+            4_097,
+            restored.visitedPointers.size
+        )
+        Disposer.dispose(registry)
+    }
+
+    fun testReplayHistoryIsBoundedWithoutConsumingLiveCursors() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "history-${++generated}" }, serverEpoch = serverEpoch,
+            maxSnapshotsPerTraversal = 2
+        ).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val state = fixtureContinuation()
+            val generation = registry.currentGeneration()
+            val first = registry.register(project, state)
+            val second = registry.register(project, generation, state, first, "1:0").getOrThrow()
+            val replayed = registry.register(project, generation, state, first, "1:0").getOrThrow()
+            assertEquals("retrying the same live page must reuse its successor", second, replayed)
+            assertEquals(2, registry.stats().entries)
+            val third = registry.register(project, generation, state, second, "1:0").getOrThrow()
+            assertTrue(registry.resolve(project, first).isFailure)
+            assertTrue(registry.resolve(project, second).isSuccess)
+            assertTrue(registry.resolve(project, second).isSuccess)
+            assertTrue(registry.resolve(project, third).isSuccess)
+            assertEquals(2, registry.stats().entries)
+            assertEquals(1L, registry.stats().evictions[CacheEvictionReason.REPLAY_LIMIT])
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testAggregatePointerBudgetEvictsBeforeEntryCountLimit() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "weighted-${++generated}" }, serverEpoch = serverEpoch,
+            maxTotalPointers = 2
+        ).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val state = fixtureContinuation()
+            val first = registry.register(project, state)
+            val second = registry.register(project, state)
+            val third = registry.register(project, state)
+            assertTrue(registry.resolve(project, first).isFailure)
+            assertTrue(registry.resolve(project, second).isSuccess)
+            assertTrue(registry.resolve(project, third).isSuccess)
+            assertEquals(2, registry.stats().entries)
+            assertEquals(2L, registry.stats().storedPointers)
+            assertEquals(1L, registry.stats().evictions[CacheEvictionReason.WEIGHT])
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testAggregateTextBudgetIncludesSnapshotsAsWellAsVisitedKeys() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "text-weighted-${++generated}" }, serverEpoch = serverEpoch,
+            maxTotalCharacters = 256
+        ).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val state = fixtureContinuation().copy(visited = setOf("x".repeat(128)))
+            val first = registry.register(project, state)
+            val second = registry.register(project, state)
+            assertTrue(registry.resolve(project, first).isFailure)
+            assertTrue(registry.resolve(project, second).isSuccess)
+            assertEquals(1, registry.stats().entries)
+            assertTrue(registry.stats().storedTextCharacters > registry.stats().storedKeyCharacters)
+            assertTrue(registry.stats().storedTextCharacters <= 256)
+            assertEquals(1L, registry.stats().evictions[CacheEvictionReason.WEIGHT])
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testWeightEvictionPrefersReplayHistoryOverAnotherActiveTraversal() {
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "active-frontier-${++generated}" }, serverEpoch = serverEpoch,
+            maxTotalPointers = 3
+        ).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val state = fixtureContinuation()
+            val independent = registry.register(project, state)
+            val first = registry.register(project, state)
+            val second = registry.register(project, registry.currentGeneration(), state, first).getOrThrow()
+            val third = registry.register(project, registry.currentGeneration(), state, second).getOrThrow()
+            assertTrue("old independent traversal is still its active frontier", registry.resolve(project, independent).isSuccess)
+            assertTrue("obsolete chain history is the eviction candidate", registry.resolve(project, first).isFailure)
+            assertTrue(registry.resolve(project, second).isSuccess)
+            assertTrue(registry.resolve(project, third).isSuccess)
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testRegisteredHistoryDoesNotAliasMutableInputCollections() {
+        val registry = HierarchyContinuationRegistry(serverEpoch = serverEpoch).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val state = fixtureContinuation()
+            val keys = mutableSetOf("original")
+            val pointers = mutableListOf(state.rootPointer)
+            val cursor = registry.register(project, state.copy(visited = keys, visitedPointers = pointers))
+            keys += "later"
+            pointers.clear()
+            val retained = registry.resolve(project, cursor).getOrThrow() as TypeContinuation
+            assertEquals(setOf("original"), retained.visited)
+            assertEquals(1, retained.visitedPointers.size)
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testMaintenanceAndProjectCloseReclaimStateWithoutClientLookup() {
+        var now = 1_000L
+        var generated = 0
+        val registry = HierarchyContinuationRegistry(
+            ttlMillis = 100, clock = { now }, idGenerator = { "cleanup-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val state = fixtureContinuation()
+            registry.register(project, state)
+            now += 100
+            assertEquals("read-only occupancy must not sweep", 1, registry.stats().entries)
+            registry.sweepExpired()
+            assertEquals(0, registry.stats().entries)
+            assertEquals(1L, registry.stats().evictions[CacheEvictionReason.TTL])
+            assertEquals(0L, registry.stats().storedPointers)
+            registry.register(project, state)
+            registry.removeProject(ProjectManager.getInstance().defaultProject)
+            assertEquals(1, registry.stats().entries)
+            registry.removeProject(project)
+            assertEquals(0, registry.stats().entries)
+            assertEquals(0L, registry.stats().storedTextCharacters)
+            assertEquals(1L, registry.stats().evictions[CacheEvictionReason.PROJECT_CLOSED])
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testRegistryRejectsContinuationWhoseFrontierExceedsSmartPointerCap() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "frontier-overflow" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val fixture = fixtureContinuation()
+        val continuation = fixture.copy(
+            frontier = List(HierarchyContinuationRegistry.MAX_POINTERS_PER_CONTINUATION) {
+                HierarchyContinuationRegistry.PendingTypeExpansion(
+                    pointer = fixture.rootPointer,
+                    direction = com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyDirection.SUBTYPE,
+                    offset = it
+                )
+            }
+        )
+
+        assertTrue(registry.register(project, registry.currentGeneration(), continuation).isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testRegistryRejectsTypeContinuationWhoseVisitedKeyCountExceedsBudget() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "visited-key-count-overflow" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val fixture = fixtureContinuation()
+        val continuation = fixture.copy(
+            visited = (0..HierarchyContinuationRegistry.MAX_VISITED_KEYS_PER_CONTINUATION)
+                .map { "type-key-$it" }
+                .toSet()
+        )
+
+        val result = registry.register(project, registry.currentGeneration(), continuation)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message.orEmpty().contains("stable visited-key budget"))
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testRegistryRejectsCallContinuationWhoseVisitedKeyCharactersExceedBudget() {
+        val registry = HierarchyContinuationRegistry(
+            idGenerator = { "visited-key-character-overflow" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val continuation = fixtureCallContinuation().copy(
+            visited = setOf("x".repeat(HierarchyContinuationRegistry.MAX_VISITED_KEY_CHARS_PER_CONTINUATION + 1))
+        )
+
+        val result = registry.register(project, registry.currentGeneration(), continuation)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message.orEmpty().contains("stable visited-key budget"))
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    private fun fixtureContinuation(): TypeContinuation {
+        writeProjectFile("hierarchy-registry-src/RegistryRoot.java", "class RegistryRoot {}")
+        val basePath = requireNotNull(project.basePath)
+        return ReadAction.compute<TypeContinuation, Throwable> {
+            val virtualFile = requireNotNull(
+                LocalFileSystem.getInstance().findFileByPath("$basePath/hierarchy-registry-src/RegistryRoot.java")
+            )
+            val psiFile = requireNotNull(PsiManager.getInstance(project).findFile(virtualFile)) as PsiJavaFile
+            val root = psiFile.classes.single()
+            TypeContinuation(
+                rootPointer = SmartPointerManager.getInstance(project).createSmartPsiElementPointer(root),
+                root = TypeElement(
+                    name = "RegistryRoot",
+                    file = "hierarchy-registry-src/RegistryRoot.java",
+                    kind = "CLASS",
+                    language = "Java"
+                ),
+                frontier = emptyList(),
+                visited = setOf("RegistryRoot"),
+                scope = BuiltInSearchScope.PROJECT_FILES,
+                excludeGenerated = false
+            )
+        }
+    }
+
+    private fun fixtureCallContinuation(): HierarchyContinuationRegistry.CallContinuation {
+        val typeFixture = fixtureContinuation()
+        return HierarchyContinuationRegistry.CallContinuation(
+            rootPointer = typeFixture.rootPointer,
+            root = CallElement(
+                name = "RegistryRoot.call()",
+                file = "hierarchy-registry-src/RegistryRoot.java",
+                line = 1,
+                column = 1,
+                language = "Java"
+            ),
+            frontier = emptyList(),
+            visited = setOf("RegistryRoot.call()"),
+            direction = "callees",
+            maxDepth = 1,
+            scope = BuiltInSearchScope.PROJECT_FILES,
+            excludeGenerated = false
+        )
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerEpochUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerEpochUnitTest.kt
@@ -1,0 +1,21 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import junit.framework.TestCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class McpServerEpochUnitTest : TestCase() {
+
+    fun testCapturedRequestEpochSurvivesThreadHopsAndDoesNotJoinResetSession() = runBlocking {
+        val serverEpoch = McpServerEpoch()
+        val captured = serverEpoch.capture()
+
+        withContext(Dispatchers.Default + serverEpoch.requestContext(captured)) {
+            serverEpoch.advanceAndReset { }
+
+            assertEquals(captured, serverEpoch.expectedForCurrentRequest())
+            assertFalse(serverEpoch.isCurrent(captured))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerServiceTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpServerServiceTest.kt
@@ -60,6 +60,19 @@ class McpServerServiceTest : BasePlatformTestCase() {
         assertNull("unit test initialization must not expose a server URL", service!!.getServerUrl())
     }
 
+    fun testStopAdvancesExactlyOneSharedRegistryEpoch() {
+        service = McpServerService(testScope)
+        val before = McpServerEpoch.shared.capture()
+
+        service!!.stopServer()
+
+        assertEquals(
+            "one stop must create one atomic boundary for every handle registry",
+            before + 1,
+            McpServerEpoch.shared.capture()
+        )
+    }
+
     /**
      * A failed bind must surface as an error result — not as a thrown engine-side
      * CancellationException that kills the calling coroutine with no serverError recorded.

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpToolDispatcherTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/McpToolDispatcherTest.kt
@@ -1,15 +1,34 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
 
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.mcp.McpServerFactory
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.mcp.McpToolDispatcher
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.isFailure
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.text
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.McpTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeElement
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 /**
  * Covers the seam between "a client asked for tool X" and the tool running: the enabled/disabled
@@ -78,5 +97,143 @@ class McpToolDispatcherTest : BasePlatformTestCase() {
             "${ToolNames.INDEX_STATUS} should be advertised when enabled",
             advertised.contains(ToolNames.INDEX_STATUS)
         )
+    }
+
+    fun testNestedSymbolIdIsUsedForProjectRoutingBeforeToolExecution() = runBlocking {
+        var generated = 0
+        val serverEpoch = McpServerEpoch()
+        val registry = SymbolIdRegistry(
+            idGenerator = { "nested-route-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val psiFile = myFixture.addFileToProject("src/NestedRoute.java", "class NestedRoute {}")
+        val symbolId = ReadAction.compute<String, Throwable> { registry.bind(project, psiFile) }
+        val routedDispatcher = McpToolDispatcher(
+            toolRegistry = toolRegistry,
+            recordHistory = { _, _ -> },
+            updateHistory = { _, _, _, _, _ -> },
+            symbolIdRegistryProvider = { registry },
+            serverEpochProvider = { serverEpoch }
+        )
+
+        val success = routedDispatcher.call(ToolNames.INDEX_STATUS, buildJsonObject {
+            putJsonObject("target") { put("symbolId", symbolId) }
+        })
+        assertFalse("valid nested handle should route to its owning project", success.isFailure)
+
+        val expired = routedDispatcher.call(ToolNames.INDEX_STATUS, buildJsonObject {
+            putJsonObject("target") { put("symbolId", "missing-handle") }
+        })
+        assertTrue("unknown nested handle must fail routing even with one project open", expired.isFailure)
+        assertTrue(expired.text.contains("SYMBOL_ID_EXPIRED"))
+    }
+
+    fun testPaginationCursorIgnoresTargetSelectorsForRouting() = runBlocking {
+        val serverEpoch = McpServerEpoch()
+        val registry = SymbolIdRegistry(idGenerator = { "unused" }, serverEpoch = serverEpoch)
+            .also { Disposer.register(testRootDisposable, it) }
+        val cursorDispatcher = McpToolDispatcher(
+            toolRegistry = toolRegistry,
+            recordHistory = { _, _ -> },
+            updateHistory = { _, _, _, _, _ -> },
+            symbolIdRegistryProvider = { registry },
+            serverEpochProvider = { serverEpoch }
+        )
+
+        val result = cursorDispatcher.call(ToolNames.INDEX_STATUS, buildJsonObject {
+            put("cursor", "next-page")
+            put("symbolId", "missing-handle")
+            putJsonObject("target") { put("symbolId", "also-missing") }
+        })
+
+        assertFalse("a valid cursor must bypass target-based routing", result.isFailure)
+    }
+
+    fun testOneServerEpochIsCapturedBeforePreExecutionChecksForEveryRegistry() = runBlocking {
+        val serverEpoch = McpServerEpoch()
+        val symbolRegistry = SymbolIdRegistry(
+            idGenerator = { "shared-epoch-symbol" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val paginationScope = CoroutineScope(Dispatchers.Default)
+        Disposer.register(testRootDisposable, Disposable { paginationScope.cancel() })
+        val paginationService = PaginationService(paginationScope, serverEpoch)
+            .also { Disposer.register(testRootDisposable, it) }
+        val hierarchyRegistry = HierarchyContinuationRegistry(
+            idGenerator = { "shared-epoch-hierarchy" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val psiFile = myFixture.addFileToProject("src/SharedEpoch.java", "class SharedEpoch {}")
+        val rootPointer = ReadAction.compute<SmartPsiElementPointer<PsiElement>, Throwable> {
+            SmartPointerManager.getInstance(project).createSmartPsiElementPointer<PsiElement>(psiFile)
+        }
+        val continuation = HierarchyContinuationRegistry.TypeContinuation(
+            rootPointer = rootPointer,
+            root = TypeElement(
+                name = "SharedEpoch",
+                file = "src/SharedEpoch.java",
+                kind = "CLASS",
+                language = "Java"
+            ),
+            frontier = emptyList(),
+            visited = setOf("SharedEpoch"),
+            scope = BuiltInSearchScope.PROJECT_FILES,
+            excludeGenerated = false
+        )
+        val toolName = "ide_test_shared_server_epoch"
+        val statePublishingTool = object : McpTool {
+            override val name: String = toolName
+            override val description: String = "Attempts to publish state in all server registries"
+            override val inputSchema: ToolSchema = ToolSchema()
+
+            override suspend fun execute(project: Project, arguments: JsonObject): CallToolResult {
+                ReadAction.compute<Result<String>, Throwable> {
+                    runCatching { symbolRegistry.bind(project, psiFile) }
+                }
+                runCatching {
+                    paginationService.createCursor(
+                        toolName = name,
+                        results = emptyList(),
+                        seenKeys = emptySet(),
+                        searchExtender = null,
+                        psiModCount = 0L,
+                        project = project
+                    )
+                }
+                hierarchyRegistry.register(
+                    project,
+                    hierarchyRegistry.currentGeneration(),
+                    continuation
+                )
+                return CallToolResult(content = listOf(TextContent("tool completed")))
+            }
+        }
+        var reset = false
+        val epochDispatcher = McpToolDispatcher(
+            toolRegistry = ToolRegistry().apply { register(statePublishingTool) },
+            edtUnresponsiveDurationMs = {
+                if (!reset) {
+                    reset = true
+                    serverEpoch.advanceAndReset {
+                        symbolRegistry.clearForSessionReset()
+                        paginationService.clearForSessionReset()
+                        hierarchyRegistry.clearForSessionReset()
+                    }
+                }
+                null
+            },
+            recordHistory = { _, _ -> },
+            updateHistory = { _, _, _, _, _ -> },
+            symbolIdRegistryProvider = { symbolRegistry },
+            serverEpochProvider = { serverEpoch }
+        )
+
+        val result = epochDispatcher.call(toolName, buildJsonObject { })
+
+        assertTrue("a request from the old generation must fail", result.isFailure)
+        assertTrue(result.text.contains("session changed"))
+        assertEquals(0, symbolRegistry.sizeForTest())
+        assertEquals(0, paginationService.sizeForTesting())
+        assertEquals(0, hierarchyRegistry.sizeForTest())
     }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/SymbolIdRegistryBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/SymbolIdRegistryBehaviorTest.kt
@@ -1,0 +1,242 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.server
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class SymbolIdRegistryBehaviorTest : McpPlatformTestCase() {
+
+    private val serverEpoch = McpServerEpoch()
+
+    fun testDefaultsAreOneHourAnd4096Entries() {
+        assertEquals(4_096, SymbolIdRegistry.DEFAULT_MAX_ENTRIES)
+        assertEquals(60 * 60 * 1_000L, SymbolIdRegistry.DEFAULT_TTL_MILLIS)
+    }
+
+    fun testAccessOrderLruEvictsLeastRecentlyUsedHandle() {
+        val elements = fixtureElements()
+        var generated = 0
+        val registry = SymbolIdRegistry(
+            maxEntries = 2,
+            ttlMillis = 10_000,
+            clock = { 1_000L },
+            idGenerator = { "test-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+
+        val first = bind(registry, elements[0])
+        val second = bind(registry, elements[1])
+        assertResolved(registry, first)
+        val third = bind(registry, elements[2])
+
+        assertExpired(registry, second)
+        assertResolved(registry, first)
+        assertResolved(registry, third)
+        assertEquals(2, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testSamePsiSymbolMayHaveMultipleUnequalSimultaneouslyValidHandles() {
+        val element = fixtureElements().first()
+        var generated = 0
+        val registry = SymbolIdRegistry(
+            idGenerator = { "same-symbol-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+
+        val first = bind(registry, element)
+        val second = bind(registry, element)
+
+        assertFalse("symbolId is a handle, not a canonical symbol identity", first == second)
+        assertResolved(registry, first)
+        assertResolved(registry, second)
+        Disposer.dispose(registry)
+    }
+
+    fun testTtlIsBasedOnLastAccessAndExpiresAtBoundary() {
+        val element = fixtureElements().first()
+        var now = 1_000L
+        val registry = SymbolIdRegistry(
+            maxEntries = 2,
+            ttlMillis = 100,
+            clock = { now },
+            idGenerator = { "ttl-id" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+
+        val id = bind(registry, element)
+        now = 1_099L
+        assertResolved(registry, id)
+        now = 1_198L
+        assertResolved(registry, id)
+        now = 1_298L
+        assertExpired(registry, id)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testWrongProjectInstanceDoesNotResolveOrDestroyOwnerHandle() {
+        val element = fixtureElements().first()
+        val registry = SymbolIdRegistry(idGenerator = { "project-id" }, serverEpoch = serverEpoch).also { Disposer.register(testRootDisposable, it) }
+        val id = bind(registry, element)
+        val otherProject = ProjectManager.getInstance().defaultProject
+
+        assertNotSame(project, otherProject)
+        val wrongProjectResult = ReadAction.compute<Result<PsiElement>, Throwable> {
+            registry.resolve(otherProject, id)
+        }
+        assertTrue(wrongProjectResult.isFailure)
+        assertTrue(wrongProjectResult.exceptionOrNull()?.message.orEmpty().contains("SYMBOL_ID_EXPIRED"))
+
+        assertResolved(registry, id)
+        Disposer.dispose(registry)
+    }
+
+    fun testWrongProjectLookupDoesNotPromoteForeignHandleInAccessOrder() {
+        val elements = fixtureElements()
+        var generated = 0
+        val registry = SymbolIdRegistry(
+            maxEntries = 2,
+            idGenerator = { "foreign-lru-${++generated}" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val first = bind(registry, elements[0])
+        val second = bind(registry, elements[1])
+
+        ReadAction.compute<Result<PsiElement>, Throwable> {
+            registry.resolve(ProjectManager.getInstance().defaultProject, first)
+        }
+        val third = bind(registry, elements[2])
+
+        assertExpired(registry, first)
+        assertResolved(registry, second)
+        assertResolved(registry, third)
+        Disposer.dispose(registry)
+    }
+
+    fun testResetRejectsBindCapturedByPreviousGeneration() {
+        val element = fixtureElements().first()
+        val registry = SymbolIdRegistry(idGenerator = { "stale-bind" }, serverEpoch = serverEpoch).also { Disposer.register(testRootDisposable, it) }
+        val generation = registry.currentGeneration()
+
+        registry.resetSession()
+        val result = ReadAction.compute<Result<String>, Throwable> {
+            registry.bind(project, generation, element)
+        }
+
+        assertTrue("an in-flight old-session request must not publish a handle", result.isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testPublicBindCannotResurrectHandleFromCapturedRequestGeneration() = runBlocking {
+        val element = fixtureElements().first()
+        val registry = SymbolIdRegistry(
+            idGenerator = { "stale-public-bind" },
+            serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        val oldRequestContext = registry.generationContext()
+
+        registry.resetSession()
+        val result = withContext(oldRequestContext) {
+            ReadAction.compute<Result<String>, Throwable> {
+                runCatching { registry.bind(project, element) }
+            }
+        }
+
+        assertTrue("public bind must honor the request generation captured by dispatcher", result.isFailure)
+        assertEquals(0, registry.sizeForTest())
+        Disposer.dispose(registry)
+    }
+
+    fun testMaintenanceReclaimsExpiredHandlesWithoutAClientLookup() {
+        val element = fixtureElements().first()
+        var now = 1_000L
+        var generated = 0
+        val registry = SymbolIdRegistry(
+            maxEntries = 2, ttlMillis = 100, clock = { now },
+            idGenerator = { "maintenance-${++generated}" }, serverEpoch = serverEpoch
+        ).also { Disposer.register(testRootDisposable, it) }
+        try {
+            repeat(3) { bind(registry, element) }
+            val occupied = registry.stats()
+            assertEquals(2, occupied.entries)
+            assertEquals(3L, occupied.insertions)
+            assertEquals(1L, occupied.evictions[CacheEvictionReason.LRU])
+            assertEquals("bind must not perform a full maintenance sweep", 0L, occupied.maintenanceScans)
+
+            now += 100
+            assertEquals("stats must not mutate the cache or refresh expiry", 2, registry.stats().entries)
+            registry.sweepExpired()
+            val swept = registry.stats()
+            assertEquals(0, swept.entries)
+            assertEquals(2L, swept.evictions[CacheEvictionReason.TTL])
+            assertEquals(1L, swept.maintenanceScans)
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    fun testProjectCloseCleanupDropsHandlesWithoutWaitingForTtl() {
+        val element = fixtureElements().first()
+        val registry = SymbolIdRegistry(serverEpoch = serverEpoch).also { Disposer.register(testRootDisposable, it) }
+        try {
+            val handle = bind(registry, element)
+            registry.removeProject(ProjectManager.getInstance().defaultProject)
+            assertResolved(registry, handle)
+            registry.removeProject(project)
+            assertEquals(0, registry.stats().entries)
+            assertEquals(1L, registry.stats().evictions[CacheEvictionReason.PROJECT_CLOSED])
+            assertExpired(registry, handle)
+        } finally {
+            Disposer.dispose(registry)
+        }
+    }
+
+    private fun fixtureElements(): List<PsiElement> {
+        writeProjectFile(
+            "symbol-registry-src/RegistryTargets.java",
+            """
+            class RegistryTargets {
+                int first;
+                int second;
+                int third;
+            }
+            """.trimIndent()
+        )
+        val basePath = requireNotNull(project.basePath)
+        return ReadAction.compute<List<PsiElement>, Throwable> {
+            val virtualFile = requireNotNull(
+                LocalFileSystem.getInstance().findFileByPath("$basePath/symbol-registry-src/RegistryTargets.java")
+            )
+            val psiFile = requireNotNull(PsiManager.getInstance(project).findFile(virtualFile)) as PsiJavaFile
+            psiFile.classes.single().fields.toList()
+        }
+    }
+
+    private fun bind(registry: SymbolIdRegistry, element: PsiElement): String =
+        ReadAction.compute<String, Throwable> { registry.bind(project, element) }
+
+    private fun assertResolved(registry: SymbolIdRegistry, symbolId: String) {
+        val result = ReadAction.compute<Result<PsiElement>, Throwable> {
+            registry.resolve(project, symbolId)
+        }
+        assertTrue("Expected $symbolId to resolve, got ${result.exceptionOrNull()?.message}", result.isSuccess)
+        assertTrue(result.getOrThrow().isValid)
+    }
+
+    private fun assertExpired(registry: SymbolIdRegistry, symbolId: String) {
+        val result = ReadAction.compute<Result<PsiElement>, Throwable> {
+            registry.resolve(project, symbolId)
+        }
+        assertTrue("Expected $symbolId to be expired", result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message.orEmpty().contains("SYMBOL_ID_EXPIRED"))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/McpProtocolConformanceTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/server/transport/McpProtocolConformanceTest.kt
@@ -4,6 +4,7 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.McpConstants
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.constants.ToolNames
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.mcp.McpServerFactory
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.mcp.McpToolDispatcher
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.isFailure
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.text
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.ToolRegistry
@@ -11,11 +12,15 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.modelcontextprotocol.kotlin.sdk.client.mcpStreamableHttp
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import java.net.BindException
 import java.net.ServerSocket
 
 /**
@@ -37,14 +42,7 @@ class McpProtocolConformanceTest : BasePlatformTestCase() {
         super.setUp()
         val registry = ToolRegistry().apply { registerBuiltInTools() }
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        port = freePort()
-        server = KtorMcpServer(
-            port = port,
-            serverFactory = McpServerFactory(registry, McpToolDispatcher(registry)),
-            legacySseTransports = LegacySseTransports(),
-            coroutineScope = scope
-        )
-        assertEquals(KtorMcpServer.StartResult.Success, server.start())
+        startServerOnAvailablePort(registry)
     }
 
     override fun tearDown() {
@@ -63,6 +61,10 @@ class McpProtocolConformanceTest : BasePlatformTestCase() {
         assertNotSame("serverInfo.version must not be the old hardcoded constant", "4.10.4", serverInfo.version)
 
         assertNotNull("Server must advertise the tools capability", client.serverCapabilities?.tools)
+        assertFalse(
+            "listChanged must stay false until every transport can deliver tool-list notifications",
+            client.serverCapabilities?.tools?.listChanged == true
+        )
     }
 
     fun testInstructionsCarryTheServerDescription() = withMcpClient { client ->
@@ -105,6 +107,47 @@ class McpProtocolConformanceTest : BasePlatformTestCase() {
         }
     }
 
+    fun testInitializeThenListToolsPublishesSemanticHandlesTargetsAndRefactoringPreview() {
+        val settings = McpSettings.getInstance()
+        val originalDisabled = settings.disabledTools
+        settings.disabledTools = originalDisabled - setOf(
+            ToolNames.SYMBOL_INFO,
+            ToolNames.CHANGE_SIGNATURE
+        )
+        try {
+            withMcpClient { client ->
+                val tools = client.listTools().tools.associateBy { it.name }
+                val semanticTools = setOf(
+                    ToolNames.FIND_REFERENCES,
+                    ToolNames.FIND_DEFINITION,
+                    ToolNames.TYPE_HIERARCHY,
+                    ToolNames.CALL_HIERARCHY,
+                    ToolNames.FIND_IMPLEMENTATIONS,
+                    ToolNames.FIND_SUPER_METHODS,
+                    ToolNames.SYMBOL_INFO
+                )
+                for (toolName in semanticTools) {
+                    val properties = schemaProperties(tools.getValue(toolName).inputSchema)
+                    assertTrue("$toolName must publish symbolId in fresh tools/list", "symbolId" in properties)
+                    assertTrue("$toolName must publish the additive nested target", "target" in properties)
+                }
+
+                for (toolName in setOf(
+                    ToolNames.REFACTOR_RENAME,
+                    ToolNames.REFACTOR_SAFE_DELETE,
+                    ToolNames.CHANGE_SIGNATURE
+                )) {
+                    val properties = schemaProperties(tools.getValue(toolName).inputSchema)
+                    assertTrue("$toolName must publish symbolId in fresh tools/list", "symbolId" in properties)
+                    assertTrue("$toolName must publish dryRun in fresh tools/list", "dryRun" in properties)
+                    assertTrue("$toolName must publish the additive nested target", "target" in properties)
+                }
+            }
+        } finally {
+            settings.disabledTools = originalDisabled
+        }
+    }
+
     fun testCallToolRoundTripsThroughTheProtocol() = withMcpClient { client ->
         val result = client.callTool(ToolNames.INDEX_STATUS, emptyMap())
 
@@ -144,6 +187,56 @@ class McpProtocolConformanceTest : BasePlatformTestCase() {
                 http.close()
             }
         }
+
+    private fun schemaProperties(schema: io.modelcontextprotocol.kotlin.sdk.types.ToolSchema) =
+        McpJson.encodeToJsonElement(schema).jsonObject["properties"]!!.jsonObject
+
+    /**
+     * Closing ServerSocket(0) before Ktor binds necessarily leaves a short TOCTOU window. Retry
+     * only genuine bind collisions so a busy ephemeral port cannot make the protocol gate flaky.
+     */
+    private fun startServerOnAvailablePort(registry: ToolRegistry) {
+        var lastBindFailure: Throwable? = null
+        repeat(10) {
+            port = freePort()
+            val candidate = KtorMcpServer(
+                port = port,
+                serverFactory = McpServerFactory(registry, McpToolDispatcher(registry)),
+                legacySseTransports = LegacySseTransports(),
+                coroutineScope = scope
+            )
+            val startResult = try {
+                candidate.start()
+            } catch (failure: Throwable) {
+                candidate.stop()
+                if (!failure.hasBindException()) throw failure
+                lastBindFailure = failure
+                return@repeat
+            }
+            when (startResult) {
+                KtorMcpServer.StartResult.Success -> {
+                    server = candidate
+                    return
+                }
+                is KtorMcpServer.StartResult.PortInUse -> {
+                    lastBindFailure = BindException("Port ${startResult.port} is already in use")
+                }
+                is KtorMcpServer.StartResult.Error -> {
+                    val cause = startResult.cause
+                    if (cause?.hasBindException() != true) {
+                        candidate.stop()
+                        fail("MCP protocol test server failed to start: ${startResult.message}")
+                    }
+                    lastBindFailure = cause
+                }
+            }
+            candidate.stop()
+        }
+        fail("Could not reserve an MCP protocol test port after 10 attempts: ${lastBindFailure?.message}")
+    }
+
+    private fun Throwable.hasBindException(): Boolean =
+        generateSequence(this) { it.cause }.take(16).any { it is BindException }
 
     private fun freePort(): Int = ServerSocket(0).use { it.localPort }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsTest.kt
@@ -481,6 +481,9 @@ class ToolsTest : McpPlatformTestCase() {
             20,
             payload.calls.size
         )
+        assertEquals(20, payload.returnedNodes)
+        assertTrue("Additional callers should remain available through pagination", payload.hasMore)
+        assertNotNull("A capped first page must provide a continuation cursor", payload.cursor)
         assertTrue(
             "Fixture should exercise the >20 direct test callers regression",
             callersByName.keys.any { it.startsWith("loadPluginConfigFromTest") }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/ToolsUnitTest.kt
@@ -15,7 +15,9 @@ import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindUsage
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.TypeHierarchyTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.CreateModuleTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ChangeSignatureTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.SafeDeleteTool
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.isExcludedPath
 import io.mockk.every
@@ -27,6 +29,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 class ToolsUnitTest : TestCase() {
     private fun assertHasScopeAndNoLegacyFilters(toolName: String, properties: kotlinx.serialization.json.JsonObject?) {
@@ -93,6 +96,23 @@ class ToolsUnitTest : TestCase() {
         }
     }
 
+    fun testRefactoringPreviewsStillParticipateInConfiguredPsiSync() {
+        val previewArguments = buildJsonObject {
+            put(ParamNames.DRY_RUN, true)
+        }
+
+        listOf(
+            RenameSymbolTool(),
+            SafeDeleteTool(),
+            ChangeSignatureTool()
+        ).forEach { tool ->
+            assertTrue(
+                "${tool.name} dry-run must honor configured VFS/PSI synchronization",
+                tool.needsPsiSync(previewArguments)
+            )
+        }
+    }
+
     // ── rename mode resolution ─────────────────────────────────────────────────
 
     fun testRenameSymbolToolResolvesFileModeWhenTargetTypeFileEvenWithZeroCoordinates() {
@@ -138,6 +158,25 @@ class ToolsUnitTest : TestCase() {
         )
 
         assertEquals("Symbol rename should reject malformed coordinates", "InvalidRenameMode", decision.javaClass.simpleName)
+    }
+
+    fun testRenameSymbolToolDoesNotReinterpretNestedPositionAsFileTarget() {
+        val normalized = UnifiedTargetArguments.normalize(
+            buildJsonObject {
+                put(ParamNames.TARGET_TYPE_CAMEL, kotlinx.serialization.json.JsonPrimitive("file"))
+                putJsonObject("target") {
+                    putJsonObject("position") {
+                        put("file", "src/Target.java")
+                        put("line", 4)
+                        put("column", 8)
+                    }
+                }
+            }
+        ).getOrThrow()
+
+        val decision = RenameSymbolTool.resolveRenameMode(normalized)
+
+        assertEquals("Nested position always denotes a symbol target", "InvalidRenameMode", decision.javaClass.simpleName)
     }
 
     private fun invokeRenameModeResolver(targetType: String?, line: Int?, column: Int?): Any {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/UnifiedTargetArgumentsUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/UnifiedTargetArgumentsUnitTest.kt
@@ -1,0 +1,152 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
+
+import junit.framework.TestCase
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+class UnifiedTargetArgumentsUnitTest : TestCase() {
+
+    fun testSymbolIdTargetNormalizesToLegacySelector() {
+        val normalized = UnifiedTargetArguments.normalize(buildJsonObject {
+            put("direction", "callers")
+            putJsonObject("target") { put("symbolId", " sym_saved ") }
+        }).getOrThrow()
+
+        assertEquals("sym_saved", normalized["symbolId"].toString().trim('"'))
+        assertEquals("callers", normalized["direction"].toString().trim('"'))
+        assertFalse(normalized.containsKey("target"))
+    }
+
+    fun testPositionTargetNormalizesToLegacyCoordinates() {
+        val normalized = UnifiedTargetArguments.normalize(buildJsonObject {
+            putJsonObject("target") {
+                putJsonObject("position") {
+                    put("file", "src/Foo.kt")
+                    put("line", 12)
+                    put("column", 9)
+                }
+            }
+        }).getOrThrow()
+
+        assertEquals("\"src/Foo.kt\"", normalized["file"].toString())
+        assertEquals("12", normalized["line"].toString())
+        assertEquals("9", normalized["column"].toString())
+        assertEquals("\"position\"", normalized[UnifiedTargetArguments.NORMALIZED_VARIANT].toString())
+    }
+
+    fun testQualifiedNameTargetNormalizesToLegacyLanguageAndSymbol() {
+        val normalized = UnifiedTargetArguments.normalize(buildJsonObject {
+            putJsonObject("target") {
+                put("qualifiedName", "com.example.Foo#bar")
+                put("language", "Kotlin")
+            }
+        }).getOrThrow()
+
+        assertEquals("\"com.example.Foo#bar\"", normalized["symbol"].toString())
+        assertEquals("\"Kotlin\"", normalized["language"].toString())
+    }
+
+    fun testTargetRequiresExactlyOneVariant() {
+        assertTargetError(buildJsonObject { putJsonObject("target") {} }, "exactly one")
+        assertTargetError(buildJsonObject {
+            putJsonObject("target") {
+                put("symbolId", "sym_one")
+                putJsonObject("position") {
+                    put("file", "src/Foo.kt")
+                    put("line", 1)
+                    put("column", 1)
+                }
+            }
+        }, "exactly one")
+    }
+
+    fun testTargetRejectsLegacySelectorMixing() {
+        assertTargetError(buildJsonObject {
+            put("file", "src/Legacy.kt")
+            putJsonObject("target") { put("symbolId", "sym_one") }
+        }, "mutually exclusive")
+
+        assertTargetError(buildJsonObject {
+            put("className", "legacy.Foo")
+            putJsonObject("target") { put("symbolId", "sym_one") }
+        }, "className")
+    }
+
+    fun testTargetRejectsMemberSpecificLegacySelectorMixing() {
+        listOf("class", "member", "parameterCount").forEach { selector ->
+            assertTargetError(buildJsonObject {
+                if (selector == "parameterCount") put(selector, 1) else put(selector, "legacy")
+                putJsonObject("target") { put("symbolId", "sym_one") }
+            }, "exactly one")
+        }
+    }
+
+    fun testNullTargetBehavesLikeOmittedOptionalArgument() {
+        val arguments = buildJsonObject {
+            put("target", JsonNull)
+            put("file", "src/Legacy.kt")
+            put("line", 3)
+            put("column", 2)
+        }
+
+        assertSame(arguments, UnifiedTargetArguments.normalize(arguments).getOrThrow())
+    }
+
+    fun testPositionRequiresCompletePositiveCoordinates() {
+        assertTargetError(buildJsonObject {
+            putJsonObject("target") {
+                putJsonObject("position") {
+                    put("file", "src/Foo.kt")
+                    put("line", 0)
+                }
+            }
+        }, "target.position.line")
+    }
+
+    fun testQualifiedNameRequiresLanguage() {
+        assertTargetError(buildJsonObject {
+            putJsonObject("target") { put("qualifiedName", "com.example.Foo") }
+        }, "target.language")
+    }
+
+    fun testNestedSymbolIdCanRouteProject() {
+        val symbolId = UnifiedTargetArguments.symbolIdForRouting(buildJsonObject {
+            putJsonObject("target") { put("symbolId", "sym_route") }
+        }).getOrThrow()
+
+        assertEquals("sym_route", symbolId)
+    }
+
+    fun testBlankLegacySymbolIdIsAbsentForRouting() {
+        val symbolId = UnifiedTargetArguments.symbolIdForRouting(buildJsonObject {
+            put("symbolId", "   ")
+        }).getOrThrow()
+
+        assertNull(symbolId)
+    }
+
+    fun testCursorContinuationDropsAllTargetSelectors() {
+        val arguments = buildJsonObject {
+            put("cursor", "next-page")
+            put("file", "src/Legacy.kt")
+            put("member", "legacy")
+            putJsonObject("target") { put("symbolId", "sym_one") }
+        }
+
+        val continued = UnifiedTargetArguments.withoutTargetSelectors(arguments)
+
+        assertEquals("\"next-page\"", continued["cursor"].toString())
+        assertFalse(continued.containsKey("target"))
+        assertFalse(continued.containsKey("file"))
+        assertFalse(continued.containsKey("member"))
+    }
+
+    private fun assertTargetError(arguments: JsonObject, expectedText: String) {
+        val error = UnifiedTargetArguments.normalize(arguments).exceptionOrNull()
+        assertNotNull(error)
+        assertTrue(error!!.message.orEmpty(), error.message.orEmpty().contains(expectedText))
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/UnifiedTargetToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/UnifiedTargetToolBehaviorTest.kt
@@ -1,0 +1,119 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DefinitionResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindDefinitionTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SymbolInfoTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.ChangeSignatureTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RefactoringPreviewResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.SafeDeleteTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import org.junit.Assume
+
+class UnifiedTargetToolBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        LanguageHandlerRegistry.registerHandlers()
+        SymbolIdRegistry.getInstance().resetSession()
+    }
+
+    override fun tearDown() {
+        try {
+            SymbolIdRegistry.getInstance().resetSession()
+            LanguageHandlerRegistry.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testNestedPositionFlowsThroughNormalizationIntoSemanticTool() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        val source = javaSource()
+        writeProjectFile("nested-position-src/unifiedtarget/Service.java", source)
+        val offset = source.indexOf("work")
+        val lineStart = source.lastIndexOf('\n', offset - 1) + 1
+
+        val result = FindDefinitionTool().execute(project, buildJsonObject {
+            putJsonObject("target") {
+                putJsonObject("position") {
+                    put("file", "nested-position-src/unifiedtarget/Service.java")
+                    put("line", source.substring(0, offset).count { it == '\n' } + 1)
+                    put("column", offset - lineStart + 1)
+                }
+            }
+        })
+
+        assertToolSucceeded("nested target.position should resolve", result)
+        assertEquals("work", json.decodeFromString<DefinitionResult>(toolText(result)).symbolName)
+    }
+
+    fun testNestedQualifiedNameWorksForSemanticLookupAndAllPreviewRefactorings() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("qualified-target-src")
+        val path = writeProjectFile("qualified-target-src/unifiedtarget/Service.java", javaSource())
+        val before = Files.readAllBytes(path)
+
+        val info = SymbolInfoTool().execute(project, buildJsonObject {
+            qualifiedMethodTarget()
+        })
+        assertToolSucceeded("nested target.qualifiedName should resolve in semantic tools", info)
+        assertTrue(toolText(info).contains("work"))
+
+        val rename = RenameSymbolTool().execute(project, buildJsonObject {
+            qualifiedMethodTarget()
+            put("newName", "compute")
+            put("dryRun", true)
+        })
+        assertApplicablePreview("rename", rename)
+
+        val safeDelete = SafeDeleteTool().execute(project, buildJsonObject {
+            qualifiedMethodTarget()
+            put("force", true)
+            put("dryRun", true)
+        })
+        assertApplicablePreview("safe delete", safeDelete)
+
+        val changeSignature = ChangeSignatureTool().execute(project, buildJsonObject {
+            qualifiedMethodTarget()
+            put("newName", "compute")
+            put("dryRun", true)
+        })
+        assertApplicablePreview("change signature", changeSignature)
+
+        assertTrue("nested-target previews changed the source file", before.contentEquals(Files.readAllBytes(path)))
+    }
+
+    private fun kotlinx.serialization.json.JsonObjectBuilder.qualifiedMethodTarget() {
+        putJsonObject("target") {
+            put("qualifiedName", "unifiedtarget.Service#work(int)")
+            put("language", "Java")
+        }
+    }
+
+    private fun assertApplicablePreview(label: String, result: io.modelcontextprotocol.kotlin.sdk.types.CallToolResult) {
+        assertToolSucceeded("$label preview should resolve nested target.qualifiedName", result)
+        val preview = json.decodeFromString<RefactoringPreviewResult>(toolText(result))
+        assertTrue("$label preview should be applicable: ${preview.warnings}", preview.canApply)
+        assertEquals("work", preview.target.name)
+    }
+
+    private fun javaSource() = """
+        package unifiedtarget;
+
+        public class Service {
+            public int work(int value) { return value; }
+        }
+    """.trimIndent()
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/intelligence/GetDiagnosticsToolBehaviorTest.kt
@@ -24,10 +24,15 @@ import com.intellij.psi.PsiManager
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.nio.file.Files
@@ -119,6 +124,8 @@ class GetDiagnosticsToolBehaviorTest : BasePlatformTestCase() {
             val diagnostics = decodeDiagnostics(result)
             assertTrue("Analysis should be marked timed out", diagnostics.analysisTimedOut == true)
             assertFalse("Timed out analysis should not be marked fresh", diagnostics.analysisFresh == true)
+            assertEquals(0, diagnostics.problemCount)
+            assertEquals("A timeout is not output truncation", false, diagnostics.problemsTruncated)
             assertNull("A timed-out analysis produced no result, so analysisMode must be null", diagnostics.analysisMode)
             assertTrue(
                 "Expected timeout explanation",
@@ -603,6 +610,275 @@ class GetDiagnosticsToolBehaviorTest : BasePlatformTestCase() {
         } finally {
             service.closedFileAnalysisOverride = originalRunner
         }
+    }
+
+    fun testMultiFileDiagnosticsAggregateProblemsAndReportPerFileAnalysis() = runBlocking {
+        createProjectFile("MultiA.java", "class MultiA {}")
+        createProjectFile("MultiB.java", "class MultiB {}")
+
+        val service = DiagnosticsAnalysisService.getInstance(project)
+        val originalRunner = service.closedFileAnalysisOverride
+
+        try {
+            service.closedFileAnalysisOverride = { request ->
+                listOf(
+                    CodeSmellInfo(
+                        request.document,
+                        "Synthetic problem in ${request.filePath}",
+                        TextRange(0, 1),
+                        HighlightSeverity.ERROR
+                    )
+                )
+            }
+
+            val result = GetDiagnosticsTool().execute(project, buildJsonObject {
+                put("files", buildJsonArray {
+                    add(JsonPrimitive("src/MultiA.java"))
+                    add(JsonPrimitive("src/MultiB.java"))
+                })
+            })
+
+            assertFalse("Multi-file diagnostics should succeed: ${renderResult(result)}", result.isFailure)
+            val diagnostics = decodeDiagnostics(result)
+            assertEquals(2, diagnostics.problemCount)
+            assertEquals(
+                listOf("src/MultiA.java", "src/MultiB.java"),
+                diagnostics.problems.orEmpty().map { it.file }
+            )
+            assertEquals(
+                listOf("src/MultiA.java", "src/MultiB.java"),
+                diagnostics.fileAnalyses.orEmpty().map { it.file }
+            )
+            diagnostics.fileAnalyses.orEmpty().forEach { analysis ->
+                assertEquals(DiagnosticsAnalysisService.MODE_CLOSED_BATCH, analysis.mode)
+                assertTrue(analysis.fresh)
+                assertFalse(analysis.timedOut)
+            }
+            assertNull("Legacy single-file mode must stay absent for multi-file calls", diagnostics.analysisMode)
+            assertNull("Intentions are position-based and must stay absent for multi-file calls", diagnostics.intentions)
+        } finally {
+            service.closedFileAnalysisOverride = originalRunner
+        }
+    }
+
+    fun testMultiFileDiagnosticsReportHiddenProblemsAfterAggregateLimit() = runBlocking {
+        val diagnostics = diagnoseSyntheticProblems(firstCount = 100, secondCount = 1)
+
+        assertEquals(100, diagnostics.problemCount)
+        assertEquals(true, diagnostics.problemsTruncated)
+        assertTrue(diagnostics.problems.orEmpty().all { it.file == "src/CapA.java" })
+        val analyses = requireNotNull(diagnostics.fileAnalyses)
+        assertEquals(100, analyses[0].problemCount)
+        assertFalse("Exactly 100 problems in A were all returned", analyses[0].problemsTruncated)
+        assertEquals(0, analyses[1].problemCount)
+        assertTrue("B's hidden problem must be explicit", analyses[1].problemsTruncated)
+        assertTrue("Output truncation must not change analysis freshness", analyses[1].fresh)
+        assertFalse(analyses[1].timedOut)
+        assertTrue("Provide an actionable single-file retry", analyses[1].message.orEmpty().contains("using 'file'"))
+    }
+
+    fun testMultiFileDiagnosticsDoNotReportTruncationForCleanFileAfterLimit() = runBlocking {
+        val diagnostics = diagnoseSyntheticProblems(firstCount = 100, secondCount = 0)
+
+        assertEquals(100, diagnostics.problemCount)
+        assertEquals(false, diagnostics.problemsTruncated)
+        val analyses = requireNotNull(diagnostics.fileAnalyses)
+        assertEquals(listOf(100, 0), analyses.map { it.problemCount })
+        assertTrue(analyses.all { it.fresh && !it.timedOut && !it.problemsTruncated })
+    }
+
+    fun testMultiFileDiagnosticsReportPartiallyReturnedFile() = runBlocking {
+        val diagnostics = diagnoseSyntheticProblems(firstCount = 99, secondCount = 2)
+
+        assertEquals(100, diagnostics.problemCount)
+        assertEquals(true, diagnostics.problemsTruncated)
+        val analyses = requireNotNull(diagnostics.fileAnalyses)
+        assertEquals(listOf(99, 1), analyses.map { it.problemCount })
+        assertFalse(analyses[0].problemsTruncated)
+        assertTrue(analyses[1].problemsTruncated)
+        assertEquals("src/CapB.java", diagnostics.problems.orEmpty().last().file)
+    }
+
+    fun testSingleFileDiagnosticsReportProblemLimitTruncation() = runBlocking {
+        val diagnostics = diagnoseSyntheticProblems(firstCount = 101)
+
+        assertEquals(100, diagnostics.problemCount)
+        assertEquals(true, diagnostics.problemsTruncated)
+        assertEquals(true, diagnostics.analysisFresh)
+        assertTrue(diagnostics.analysisMessage.orEmpty().contains("narrower startLine/endLine"))
+        assertNull(diagnostics.fileAnalyses)
+    }
+
+    fun testSingleFileDiagnosticsDoNotReportTruncationAtExactLimit() = runBlocking {
+        val diagnostics = diagnoseSyntheticProblems(firstCount = 100)
+
+        assertEquals(100, diagnostics.problemCount)
+        assertEquals(false, diagnostics.problemsTruncated)
+        assertEquals(true, diagnostics.analysisFresh)
+    }
+
+    private suspend fun diagnoseSyntheticProblems(firstCount: Int, secondCount: Int? = null): DiagnosticsResult {
+        createProjectFile("CapA.java", "class CapA {}")
+        if (secondCount != null) createProjectFile("CapB.java", "class CapB {}")
+        val service = DiagnosticsAnalysisService.getInstance(project)
+        val originalRunner = service.closedFileAnalysisOverride
+        try {
+            service.closedFileAnalysisOverride = { request ->
+                val count = if (request.filePath == "src/CapA.java") firstCount else requireNotNull(secondCount)
+                List(count) { index ->
+                    CodeSmellInfo(request.document, "Synthetic error $index", TextRange(0, 1), HighlightSeverity.ERROR)
+                }
+            }
+            val result = GetDiagnosticsTool().execute(project, buildJsonObject {
+                put("severity", "errors")
+                if (secondCount == null) {
+                    put("file", "src/CapA.java")
+                } else {
+                    put("files", buildJsonArray {
+                        add(JsonPrimitive("src/CapA.java"))
+                        add(JsonPrimitive("src/CapB.java"))
+                    })
+                }
+            })
+            assertFalse("Synthetic diagnostics should succeed: ${renderResult(result)}", result.isFailure)
+            return decodeDiagnostics(result)
+        } finally {
+            service.closedFileAnalysisOverride = originalRunner
+        }
+    }
+
+    fun testMultiFileDiagnosticsUseOneSharedTimeoutBudget() = runBlocking {
+        createProjectFile("BudgetA.java", "class BudgetA {}")
+        createProjectFile("BudgetB.java", "class BudgetB {}")
+
+        val service = DiagnosticsAnalysisService.getInstance(project)
+        val originalTimeout = service.analysisTimeoutMsOverride
+        val originalRunner = service.closedFileAnalysisOverride
+
+        try {
+            // Each file is individually faster than the configured timeout. Only a shared budget
+            // can make the second file time out.
+            service.analysisTimeoutMsOverride = 300L
+            service.closedFileAnalysisOverride = {
+                delay(200L)
+                emptyList()
+            }
+
+            val result = GetDiagnosticsTool().execute(project, buildJsonObject {
+                put("files", buildJsonArray {
+                    add(JsonPrimitive("src/BudgetA.java"))
+                    add(JsonPrimitive("src/BudgetB.java"))
+                })
+            })
+
+            assertFalse("Multi-file diagnostics should return timeout metadata: ${renderResult(result)}", result.isFailure)
+            val analyses = decodeDiagnostics(result).fileAnalyses.orEmpty()
+            assertEquals(2, analyses.size)
+            assertTrue("The first file should finish within the shared budget", analyses[0].fresh)
+            assertFalse(analyses[0].timedOut)
+            assertTrue("The second file must consume only the remaining shared budget", analyses[1].timedOut)
+            assertFalse(analyses[1].fresh)
+            assertEquals(0, analyses[1].problemCount)
+            assertFalse("Timeout metadata is independent of the output cap", analyses[1].problemsTruncated)
+        } finally {
+            service.analysisTimeoutMsOverride = originalTimeout
+            service.closedFileAnalysisOverride = originalRunner
+        }
+    }
+
+    fun testDiagnosticsTimeoutIncludesWaitingForAnalysisLock() = runBlocking {
+        createProjectFile("LockBudget.java", "class LockBudget {}")
+
+        val service = DiagnosticsAnalysisService.getInstance(project)
+        val originalTimeout = service.analysisTimeoutMsOverride
+        val originalRunner = service.closedFileAnalysisOverride
+        val lockAcquired = CompletableDeferred<Unit>()
+        val releaseLock = CompletableDeferred<Unit>()
+        val lockHolder = launch(Dispatchers.Default) {
+            DiagnosticsAnalysisCoordinator.getInstance().withMainPassLock {
+                lockAcquired.complete(Unit)
+                releaseLock.await()
+            }
+        }
+        lockAcquired.await()
+
+        try {
+            service.analysisTimeoutMsOverride = 100L
+            service.closedFileAnalysisOverride = {
+                fail("Analysis must not start while another call owns the main-pass lock")
+                emptyList()
+            }
+
+            val result = GetDiagnosticsTool().execute(project, buildJsonObject {
+                put("file", "src/LockBudget.java")
+            })
+
+            assertFalse("Lock timeout should be returned as metadata: ${renderResult(result)}", result.isFailure)
+            val diagnostics = decodeDiagnostics(result)
+            assertTrue("Waiting for the shared lock must consume the timeout budget", diagnostics.analysisTimedOut == true)
+            assertFalse(diagnostics.analysisFresh == true)
+        } finally {
+            service.analysisTimeoutMsOverride = originalTimeout
+            service.closedFileAnalysisOverride = originalRunner
+            releaseLock.complete(Unit)
+            lockHolder.join()
+        }
+    }
+
+    fun testMultiFileDiagnosticsRejectAmbiguousTargetsAndLocations() = runBlocking {
+        createProjectFile("Validation.java", "class Validation {}")
+
+        val bothTargets = GetDiagnosticsTool().execute(project, buildJsonObject {
+            put("file", "src/Validation.java")
+            put("files", buildJsonArray { add(JsonPrimitive("src/Validation.java")) })
+        })
+        assertTrue("file and files must be mutually exclusive", bothTargets.isFailure)
+        assertTrue(renderResult(bothTargets).contains("mutually exclusive"))
+
+        val multiFileLocation = GetDiagnosticsTool().execute(project, buildJsonObject {
+            put("files", buildJsonArray { add(JsonPrimitive("src/Validation.java")) })
+            put("line", 1)
+        })
+        assertTrue("Location parameters require the singular file target", multiFileLocation.isFailure)
+        assertTrue(renderResult(multiFileLocation).contains("single 'file'"))
+    }
+
+    fun testMultiFileDiagnosticsBoundAndNormalizeRequestedPaths() = runBlocking {
+        val tooMany = GetDiagnosticsTool().execute(project, buildJsonObject {
+            put("files", buildJsonArray {
+                repeat(101) { index -> add(JsonPrimitive("src/File$index.java")) }
+            })
+        })
+        assertTrue("An unbounded diagnostics request must be rejected", tooMany.isFailure)
+        assertTrue(renderResult(tooMany).contains("at most 100"))
+
+        createProjectFile("Normalized.java", "class Normalized {}")
+        val duplicateAliases = GetDiagnosticsTool().execute(project, buildJsonObject {
+            put("files", buildJsonArray {
+                add(JsonPrimitive("src/Normalized.java"))
+                add(JsonPrimitive("  src/./Normalized.java  "))
+                add(JsonPrimitive("src/dir/../Normalized.java"))
+            })
+        })
+        assertFalse("Lexical aliases should be analyzed once: ${renderResult(duplicateAliases)}", duplicateAliases.isFailure)
+        assertEquals(
+            listOf("src/Normalized.java"),
+            decodeDiagnostics(duplicateAliases).fileAnalyses.orEmpty().map { it.file }
+        )
+
+        val traversal = GetDiagnosticsTool().execute(project, buildJsonObject {
+            put("files", buildJsonArray { add(JsonPrimitive("../Normalized.java")) })
+        })
+        assertTrue("Traversal outside the project must be rejected", traversal.isFailure)
+        assertTrue(renderResult(traversal).contains("traversal"))
+
+        val absolute = GetDiagnosticsTool().execute(project, buildJsonObject {
+            put("files", buildJsonArray {
+                add(JsonPrimitive("${requireNotNull(project.basePath)}/src/Normalized.java"))
+            })
+        })
+        assertTrue("Absolute paths must be rejected from the multi-file contract", absolute.isFailure)
+        assertTrue(renderResult(absolute).contains("project-relative"))
     }
 
     fun testFiltersBuildDiagnosticsByRequestedSeverity() = runBlocking {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/AnonymousImplementationMetadataBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/AnonymousImplementationMetadataBehaviorTest.kt
@@ -1,0 +1,116 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ImplementationResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PsiUtils
+import com.intellij.openapi.application.ReadAction
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class AnonymousImplementationMetadataBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        SymbolIdRegistry.getInstance().resetSession()
+        LanguageHandlerRegistry.registerHandlers()
+    }
+
+    override fun tearDown() {
+        try {
+            SymbolIdRegistry.getInstance().resetSession()
+            LanguageHandlerRegistry.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testAnonymousImplementationHasUsefulLocationNameAndNoInventedQualifiedName() = runBlocking {
+        registerSourceRoot("anonymous-impl-src")
+        writeProjectFile(
+            "anonymous-impl-src/anonimpl/Task.java",
+            """
+            package anonimpl;
+
+            public interface Task {
+                void run();
+            }
+            """.trimIndent()
+        )
+        writeProjectFile(
+            "anonymous-impl-src/anonimpl/TaskFactory.java",
+            """
+            package anonimpl;
+
+            public final class TaskFactory {
+                public Task create() {
+                    return new Task() {
+                        @Override public void run() {}
+                    };
+                }
+            }
+            """.trimIndent()
+        )
+        writeProjectFile(
+            "anonymous-impl-src/anonimpl/NamedTask.java",
+            """
+            package anonimpl;
+
+            public final class NamedTask implements Task {
+                @Override public void run() {}
+            }
+            """.trimIndent()
+        )
+
+        val result = FindImplementationsTool().execute(project, buildJsonObject {
+            put("file", "anonymous-impl-src/anonimpl/Task.java")
+            put("line", 3)
+            put("column", 18)
+        })
+        assertToolSucceeded("find_implementations should include anonymous classes", result)
+
+        val implementations = json.decodeFromString<ImplementationResult>(toolText(result)).implementations
+        val anonymous = implementations.singleOrNull { it.name.startsWith("<anonymous implementation of Task at ") }
+        assertNotNull("Expected an anonymous Task implementation, got: ${implementations.map { it.name }}", anonymous)
+        assertEquals(
+            "<anonymous implementation of Task at TaskFactory.java:5>",
+            anonymous!!.name
+        )
+        assertNull(
+            "Anonymous implementations must expose qualifiedName = null on the wire",
+            anonymous.qualifiedName
+        )
+
+        val named = implementations.singleOrNull { it.qualifiedName == "anonimpl.NamedTask" }
+        assertNotNull("Named class implementations should expose their semantic qualified name", named)
+        assertEquals("anonimpl.NamedTask", named!!.name)
+
+        val symbolId = requireNotNull(anonymous.symbolId)
+        val qualifiedName = ReadAction.compute<String?, RuntimeException> {
+            val element = SymbolIdRegistry.getInstance().resolve(project, symbolId).getOrThrow()
+            PsiUtils.qualifiedName(element.navigationElement)
+        }
+        assertNull("Anonymous implementations must not get a fabricated qualified name", qualifiedName)
+
+        val methodResult = FindImplementationsTool().execute(project, buildJsonObject {
+            put("file", "anonymous-impl-src/anonimpl/Task.java")
+            put("line", 4)
+            put("column", 10)
+        })
+        assertToolSucceeded("find_implementations should include overriding methods", methodResult)
+
+        val methods = json.decodeFromString<ImplementationResult>(toolText(methodResult)).implementations
+        val namedMethod = methods.singleOrNull { it.name == "NamedTask.run" }
+        assertNotNull("Expected NamedTask.run implementation, got: ${methods.map { it.name }}", namedMethod)
+        assertNull(
+            "Method implementations have no reliable shared qualified-name contract",
+            namedMethod!!.qualifiedName
+        )
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureNodesBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/FileStructureNodesBehaviorTest.kt
@@ -1,0 +1,110 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FileStructureResult
+import com.intellij.openapi.application.ReadAction
+import com.intellij.psi.PsiMethod
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class FileStructureNodesBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        SymbolIdRegistry.getInstance().resetSession()
+        LanguageHandlerRegistry.registerHandlers()
+    }
+
+    override fun tearDown() {
+        try {
+            SymbolIdRegistry.getInstance().resetSession()
+            LanguageHandlerRegistry.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testFileStructureKeepsLegacyTextAndReturnsExactStructuredHandles() = runBlocking {
+        writeProjectFile(
+            "structure-src/OverloadedStructure.java",
+            """
+            public class OverloadedStructure {
+                public void choose(int value) {} public void choose(long value) {}
+            }
+            """.trimIndent()
+        )
+
+        val result = FileStructureTool().execute(project, buildJsonObject {
+            put("file", "structure-src/OverloadedStructure.java")
+        })
+        assertToolSucceeded("file_structure should return Java structure", result)
+
+        val payload = json.decodeFromString<FileStructureResult>(toolText(result))
+        assertTrue("Legacy formatted output must remain available", payload.structure.contains("OverloadedStructure"))
+
+        val classNode = payload.nodes.single()
+        assertEquals("OverloadedStructure", classNode.name)
+        assertEquals("CLASS", classNode.kind.name)
+        assertEquals(listOf("public"), classNode.modifiers)
+        assertEquals(1, classNode.line)
+        assertEquals(3, classNode.endLine)
+        assertNotNull("The class node should expose a symbol handle", classNode.symbolId)
+
+        val overloads = classNode.children.filter { it.name == "choose" }
+        assertEquals("Both same-line overloads must be represented", 2, overloads.size)
+        assertEquals("Both overloads intentionally share a source line", 1, overloads.map { it.line }.toSet().size)
+        assertEquals(listOf("public"), overloads.first().modifiers)
+        assertTrue(overloads.all { !it.signature.isNullOrBlank() })
+
+        val ids = overloads.map { requireNotNull(it.symbolId) }
+        assertEquals("Exact PSI declarations need distinct handles", 2, ids.toSet().size)
+
+        val parameterTypes = ReadAction.compute<Set<String>, RuntimeException> {
+            ids.map { symbolId ->
+                val method = SymbolIdRegistry.getInstance().resolve(project, symbolId).getOrThrow() as PsiMethod
+                method.parameterList.parameters.single().type.canonicalText
+            }.toSet()
+        }
+        assertEquals(setOf("int", "long"), parameterTypes)
+        assertFalse(payload.symbolIdsTruncated)
+        assertEquals(0, payload.symbolIdsOmitted)
+    }
+
+    fun testLargeOutlinePreservesEveryNodeWithoutReturningAlreadyEvictedHandles() = runBlocking {
+        val fieldCount = SymbolIdRegistry.DEFAULT_MAX_ENTRIES
+        writeProjectFile("structure-src/LargeStructure.java", buildString {
+            appendLine("class LargeStructure {")
+            repeat(fieldCount) { appendLine("  int field$it;") }
+            appendLine("}")
+        })
+
+        val result = FileStructureTool().execute(project, buildJsonObject {
+            put("file", "structure-src/LargeStructure.java")
+        })
+        assertToolSucceeded("large outlines should retain the complete structure", result)
+        val payload = json.decodeFromString<FileStructureResult>(toolText(result))
+        val root = payload.nodes.single()
+        assertEquals(fieldCount, root.children.size)
+        assertEquals("field${fieldCount - 1}", root.children.last().name)
+        assertTrue(payload.structure.contains("field${fieldCount - 1}"))
+        val allNodes = listOf(root) + root.children
+        val registry = SymbolIdRegistry.getInstance()
+        val handles = allNodes.mapNotNull { it.symbolId }
+        assertEquals(registry.responseHandleBudget, handles.size)
+        assertTrue(payload.symbolIdsTruncated)
+        assertEquals(allNodes.size - handles.size, payload.symbolIdsOmitted)
+        assertNotNull("preorder gives the root a usable handle", root.symbolId)
+        ReadAction.run<RuntimeException> {
+            for (handle in handles) {
+                assertTrue("every returned handle must still resolve", registry.resolve(project, handle).isSuccess)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/HierarchyIdentityAndHandlesBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/HierarchyIdentityAndHandlesBehaviorTest.kt
@@ -1,0 +1,333 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallHierarchyResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.replaceService
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assume
+
+class HierarchyIdentityAndHandlesBehaviorTest : McpPlatformTestCase() {
+    private val json = Json { ignoreUnknownKeys = true }
+    private var now = 100L
+
+    override fun setUp() {
+        super.setUp()
+        Assume.assumeTrue("Java plugin required for PSI fixtures", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        LanguageHandlerRegistry.registerHandlers()
+        HierarchyContinuationRegistry.getInstance().resetSession()
+        SymbolIdRegistry.getInstance().resetSession()
+    }
+
+    override fun tearDown() {
+        try {
+            HierarchyContinuationRegistry.getInstance().resetSession()
+            SymbolIdRegistry.getInstance().resetSession()
+            LanguageHandlerRegistry.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testCallPageRebindsHandlesAfterLruEvictionWithoutPsiChanges() = runBlocking {
+        checkCallHandleRetention(expireByTtl = false)
+    }
+
+    fun testCallPageRebindsHandlesAfterIdleTtlWithoutPsiChanges() = runBlocking {
+        checkCallHandleRetention(expireByTtl = true)
+    }
+
+    fun testTypePageRebindsHandlesAfterLruEvictionWithoutPsiChanges() = runBlocking {
+        checkTypeHandleRetention(expireByTtl = false)
+    }
+
+    fun testTypePageRebindsHandlesAfterIdleTtlWithoutPsiChanges() = runBlocking {
+        checkTypeHandleRetention(expireByTtl = true)
+    }
+
+    private suspend fun checkCallHandleRetention(expireByTtl: Boolean) {
+        val registry = installSmallSymbolRegistry()
+        writeProjectFile("src/handles/CallHandles.java", """
+            package handles;
+            class CallHandles {
+                void alpha() {}
+                void beta() {}
+                void gamma() {}
+                void root() { alpha(); beta(); gamma(); }
+            }
+        """.trimIndent())
+        val owner = findClass("handles.CallHandles")
+        val root = owner.findMethodsByName("root", false).single()
+        val tool = CallHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("language", "Java")
+            put("symbol", "handles.CallHandles#root()")
+            put("direction", "callees")
+            put("depth", 1)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("first call page", firstResult)
+        val first = json.decodeFromString<CallHierarchyResult>(toolText(firstResult))
+        assertEquals("look-ahead nodes must not allocate handles", 2, registry.sizeForTest())
+        val cursor = requireNotNull(first.cursor)
+
+        suspend fun page(): CallHierarchyResult {
+            val result = tool.execute(project, buildJsonObject {
+                put("cursor", cursor)
+                put("maxNodes", 1)
+            })
+            assertToolSucceeded("continued call page", result)
+            return json.decodeFromString(toolText(result))
+        }
+
+        val before = page()
+        val oldRootId = requireNotNull(before.element.symbolId)
+        val oldNodeId = requireNotNull(before.calls.single().symbolId)
+        val modifications = PsiModificationTracker.getInstance(project).modificationCount
+        evictHandles(registry, root, expireByTtl)
+        assertTrue("root handle should actually be expired", registry.resolve(project, oldRootId).isFailure)
+        assertTrue("page handle should actually be expired", registry.resolve(project, oldNodeId).isFailure)
+        assertEquals(modifications, PsiModificationTracker.getInstance(project).modificationCount)
+
+        val after = page()
+        val rootId = requireNotNull(after.element.symbolId)
+        val nodeId = requireNotNull(after.calls.single().symbolId)
+        assertFalse(oldRootId == rootId)
+        assertFalse(oldNodeId == nodeId)
+        assertSame(root, registry.resolve(project, rootId).getOrThrow())
+        assertSame(owner.findMethodsByName("beta", false).single(), registry.resolve(project, nodeId).getOrThrow())
+        assertEquals(before.calls.map { it.name }, after.calls.map { it.name })
+        assertEquals("retries must reuse their continuation snapshot", before.cursor, after.cursor)
+        val retry = page()
+        assertEquals(rootId, retry.element.symbolId)
+        assertEquals(nodeId, retry.calls.single().symbolId)
+    }
+
+    private suspend fun checkTypeHandleRetention(expireByTtl: Boolean) {
+        val registry = installSmallSymbolRegistry()
+        writeProjectFile("src/handles/TypeHandles.java", """
+            package handles;
+            class TypeRoot {}
+            class Alpha extends TypeRoot {}
+            class Beta extends TypeRoot {}
+            class Gamma extends TypeRoot {}
+        """.trimIndent())
+        val root = findClass("handles.TypeRoot")
+        val tool = TypeHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("className", "handles.TypeRoot")
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("first type page", firstResult)
+        val first = json.decodeFromString<TypeHierarchyResult>(toolText(firstResult))
+        assertEquals("look-ahead types must not allocate handles", 2, registry.sizeForTest())
+        val cursor = requireNotNull(first.cursor)
+
+        suspend fun page(): TypeHierarchyResult {
+            val result = tool.execute(project, buildJsonObject {
+                put("cursor", cursor)
+                put("maxNodes", 1)
+            })
+            assertToolSucceeded("continued type page", result)
+            return json.decodeFromString(toolText(result))
+        }
+
+        val before = page()
+        val oldRootId = requireNotNull(before.element.symbolId)
+        val oldNodeId = requireNotNull(before.traversal.single().element.symbolId)
+        val modifications = PsiModificationTracker.getInstance(project).modificationCount
+        evictHandles(registry, root, expireByTtl)
+        assertTrue(registry.resolve(project, oldRootId).isFailure)
+        assertTrue(registry.resolve(project, oldNodeId).isFailure)
+        assertEquals(modifications, PsiModificationTracker.getInstance(project).modificationCount)
+
+        val after = page()
+        val rootId = requireNotNull(after.element.symbolId)
+        val nodeId = requireNotNull(after.traversal.single().element.symbolId)
+        assertFalse(oldRootId == rootId)
+        assertFalse(oldNodeId == nodeId)
+        assertSame(root, registry.resolve(project, rootId).getOrThrow())
+        assertSame(findClass(before.traversal.single().element.name), registry.resolve(project, nodeId).getOrThrow())
+        assertEquals(before.traversal.map { it.element.name }, after.traversal.map { it.element.name })
+        assertEquals(before.cursor, after.cursor)
+        val retry = page()
+        assertEquals(rootId, retry.element.symbolId)
+        assertEquals(nodeId, retry.traversal.single().element.symbolId)
+    }
+
+    fun testAnonymousCallersOnTheSameLineRemainDistinctAcrossPagesAndEdits() = runBlocking {
+        val path = writeProjectFile("src/identity/AnonymousCalls.java", """
+            package identity;
+            interface Action { void run(); }
+            class AnonymousCalls {
+                void target() {}
+                Action first = new Action() { public void run() { target(); } }; Action second = new Action() { public void run() { target(); } };
+            }
+        """.trimIndent())
+        val owner = findClass("identity.AnonymousCalls")
+        val callers = PsiTreeUtil.findChildrenOfType(owner, PsiMethod::class.java)
+            .filter { it.name == "run" }.sortedBy { it.textOffset }
+        assertEquals(2, callers.size)
+        assertEquals("both owners intentionally lack a qualified name", listOf(null, null), callers.map { it.containingClass?.qualifiedName })
+
+        val tool = CallHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("language", "Java")
+            put("symbol", "identity.AnonymousCalls#target()")
+            put("direction", "callers")
+            put("depth", 1)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("first anonymous caller page", firstResult)
+        val first = json.decodeFromString<CallHierarchyResult>(toolText(firstResult))
+        assertEquals(1, first.calls.size)
+        val cursor = requireNotNull(first.cursor)
+        val firstId = requireNotNull(first.calls.single().symbolId)
+
+        val file = requireNotNull(LocalFileSystem.getInstance().findFileByPath(path.toString()))
+        val document = requireNotNull(FileDocumentManager.getInstance().getDocument(file))
+        WriteCommandAction.runWriteCommandAction(project) {
+            document.insertString(0, "\n\n")
+            PsiDocumentManager.getInstance(project).commitDocument(document)
+        }
+        val nextResult = tool.execute(project, buildJsonObject { put("cursor", cursor); put("maxNodes", 1) })
+        assertToolSucceeded("anonymous caller cursor after a line shift", nextResult)
+        val second = json.decodeFromString<CallHierarchyResult>(toolText(nextResult))
+        assertEquals(1, second.calls.size)
+        val firstPointer = SymbolIdRegistry.getInstance().resolve(project, firstId).getOrThrow()
+        val secondPointer = SymbolIdRegistry.getInstance().resolve(project, requireNotNull(second.calls.single().symbolId)).getOrThrow()
+        assertFalse("distinct anonymous declarations must not collapse", sameHierarchyDeclaration(firstPointer, secondPointer))
+        assertFalse(second.hasMore)
+    }
+
+    fun testSameNamedLocalTypesInDifferentMethodsRemainDistinct() = runBlocking {
+        writeProjectFile("src/identity/LocalTypes.java", """
+            package identity;
+            class Base {}
+            class LocalTypes {
+                void first() { class Local extends Base {} }
+                void second() { class Local extends Base {} }
+            }
+        """.trimIndent())
+        val localTypes = PsiTreeUtil.findChildrenOfType(findClass("identity.LocalTypes"), PsiClass::class.java)
+            .filter { it.name == "Local" }
+        assertEquals(2, localTypes.size)
+        val resolved = mutableListOf<PsiElement>()
+        var cursor: String? = null
+        var remaining = 10
+        do {
+            assertTrue("local type cursor must terminate", remaining-- > 0)
+            val result = TypeHierarchyTool().execute(project, buildJsonObject {
+                put("maxNodes", 1)
+                if (cursor == null) put("className", "identity.Base") else put("cursor", cursor!!)
+            })
+            assertToolSucceeded("local type hierarchy page", result)
+            val page = json.decodeFromString<TypeHierarchyResult>(toolText(result))
+            resolved += page.traversal.map {
+                SymbolIdRegistry.getInstance().resolve(project, requireNotNull(it.element.symbolId)).getOrThrow()
+            }
+            cursor = page.cursor
+        } while (cursor != null)
+        assertEquals("both local declarations must be emitted once", 2, resolved.size)
+        assertTrue(localTypes.all { expected -> resolved.count { sameHierarchyDeclaration(it, expected) } == 1 })
+    }
+
+    fun testExpansionFrontierReplayRetainsMembersAndSuccessorAfterEviction() = runBlocking {
+        writeProjectFile("src/replay/ExpansionCalls.java", """
+            package replay;
+            class ExpansionCalls {
+                void leafOne() {}
+                void leafTwo() {}
+                void alpha() {}
+                void beta() {}
+                void gamma() { leafOne(); leafTwo(); }
+                void root() { alpha(); beta(); gamma(); }
+            }
+        """.trimIndent())
+        val tool = CallHierarchyTool()
+        val initialResult = tool.execute(project, buildJsonObject {
+            put("language", "Java")
+            put("symbol", "replay.ExpansionCalls#root()")
+            put("direction", "callees")
+            put("depth", 2)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("initial expansion hierarchy", initialResult)
+        val initial = json.decodeFromString<CallHierarchyResult>(toolText(initialResult))
+        var parent = requireNotNull(initial.cursor)
+        val prefix = initial.calls.map { it.name }.toMutableList()
+        var pagesUntilExpansion = 10
+        while (true) {
+            val continuation = HierarchyContinuationRegistry.getInstance().resolve(project, parent).getOrThrow()
+                as HierarchyContinuationRegistry.CallContinuation
+            if (continuation.frontier.all { it is HierarchyContinuationRegistry.PendingCallExpansion }) break
+            assertTrue("fixture must reach the budget-limited expansion frontier", pagesUntilExpansion-- > 0)
+            val result = tool.execute(project, buildJsonObject { put("cursor", parent); put("maxNodes", 1) })
+            assertToolSucceeded("advance to expansion frontier", result)
+            val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+            prefix += page.calls.map { it.name }
+            parent = requireNotNull(page.cursor)
+        }
+        assertEquals(listOf("ExpansionCalls.alpha()", "ExpansionCalls.beta()", "ExpansionCalls.gamma()"), prefix)
+        suspend fun replay(): CallHierarchyResult {
+            val result = tool.execute(project, buildJsonObject { put("cursor", parent); put("maxNodes", 1) })
+            assertToolSucceeded("replayed expansion page", result)
+            return json.decodeFromString(toolText(result))
+        }
+        val first = replay()
+        val registry = SymbolIdRegistry.getInstance()
+        listOfNotNull(first.element.symbolId, first.calls.single().symbolId).forEach(registry::invalidate)
+        val second = replay()
+        assertEquals(first.calls.map { it.name }, second.calls.map { it.name })
+        assertEquals(first.cursor, second.cursor)
+        assertNotNull(registry.resolve(project, requireNotNull(second.calls.single().symbolId)).getOrThrow())
+        val allNames = prefix.toMutableList().apply { addAll(second.calls.map { it.name }) }
+        var cursor = second.cursor
+        var remaining = 10
+        while (cursor != null) {
+            assertTrue("continuation after replay must terminate", remaining-- > 0)
+            val result = tool.execute(project, buildJsonObject { put("cursor", cursor!!); put("maxNodes", 1) })
+            assertToolSucceeded("continuation after expansion replay", result)
+            val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+            allNames += page.calls.map { it.name }
+            cursor = page.cursor
+        }
+        assertEquals(listOf("ExpansionCalls.alpha()", "ExpansionCalls.beta()", "ExpansionCalls.gamma()", "ExpansionCalls.leafOne()", "ExpansionCalls.leafTwo()"), allNames)
+    }
+
+    private fun installSmallSymbolRegistry(): SymbolIdRegistry {
+        val registry = SymbolIdRegistry(maxEntries = 4, ttlMillis = 1_000L, clock = { now })
+        ApplicationManager.getApplication().replaceService(SymbolIdRegistry::class.java, registry, testRootDisposable)
+        Disposer.register(testRootDisposable, registry)
+        return registry
+    }
+
+    private fun evictHandles(registry: SymbolIdRegistry, target: PsiElement, expireByTtl: Boolean) {
+        if (expireByTtl) now += 1_000L else repeat(4) { registry.bind(project, target) }
+    }
+
+    private fun findClass(qualifiedName: String): PsiClass = requireNotNull(
+        JavaPsiFacade.getInstance(project).findClass(qualifiedName, GlobalSearchScope.projectScope(project))
+    )
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/HierarchyPaginationBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/HierarchyPaginationBehaviorTest.kt
@@ -1,0 +1,926 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.BuiltInSearchScope
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.CallElementData
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.CallHierarchyData
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.CallHierarchyHandler
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.HierarchyPageRequest
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeElementData
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyData
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyDirection
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.TypeHierarchyHandler
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.applyHierarchyPage
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.HierarchyContinuationRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.CallHierarchyResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.util.PluginDetectors
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assume
+
+class HierarchyPaginationBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        LanguageHandlerRegistry.registerHandlers()
+        HierarchyContinuationRegistry.getInstance().resetSession()
+        SymbolIdRegistry.getInstance().resetSession()
+    }
+
+    override fun tearDown() {
+        try {
+            HierarchyContinuationRegistry.getInstance().resetSession()
+            SymbolIdRegistry.getInstance().resetSession()
+            LanguageHandlerRegistry.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testTypeHierarchyPagesUseDeterministicBreadthFirstTraversalWithoutLoss() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        writeProjectFile(
+            "src/pages/Types.java",
+            """
+                package pages;
+
+                class Root {}
+                class Alpha extends Root {}
+                class Beta extends Root {}
+                class AlphaLeaf extends Alpha {}
+                class BetaLeaf extends Beta {}
+            """.trimIndent()
+        )
+
+        val pages = mutableListOf<TypeHierarchyResult>()
+        val tool = TypeHierarchyTool()
+        var cursor: String? = null
+        var remainingPages = 20
+        do {
+            assertTrue("type hierarchy cursor chain must terminate", remainingPages-- > 0)
+            val result = tool.execute(project, buildJsonObject {
+                put("maxNodes", 1)
+                if (cursor == null) put("className", "pages.Root") else put("cursor", cursor!!)
+            })
+            assertToolSucceeded("type hierarchy page should succeed", result)
+            val page = json.decodeFromString<TypeHierarchyResult>(toolText(result))
+            assertTrue("maxNodes must be enforced while traversing", page.returnedNodes <= 1)
+            assertEquals(page.returnedNodes, page.supertypes.size + page.subtypes.size)
+            assertEquals(page.hasMore, page.cursor != null)
+            assertEquals(page.hasMore, page.truncated)
+            pages += page
+            cursor = page.cursor
+        } while (cursor != null)
+
+        val names = pages.flatMap { page -> page.traversal }.map { it.element.name }
+        assertEquals(
+            "the order-preserving view must contain exactly the legacy nodes",
+            pages.sumOf { it.supertypes.size + it.subtypes.size },
+            pages.sumOf { it.traversal.size }
+        )
+        assertEquals(
+            "Each BFS level must be stable before its children",
+            listOf("pages.Alpha", "pages.Beta", "pages.AlphaLeaf", "pages.BetaLeaf"),
+            names
+        )
+        assertEquals("No node may be duplicated across pages", names.size, names.toSet().size)
+        assertTrue("Every non-empty hierarchy must fit in a finite number of pages", pages.size <= 10)
+    }
+
+    fun testCallHierarchyPagesUseDeterministicBreadthFirstTraversalWithoutLoss() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val source = """
+            package pages;
+
+            class Calls {
+                void leftLeaf() {}
+                void rightLeaf() {}
+                void left() { leftLeaf(); }
+                void right() { rightLeaf(); }
+                void root() { left(); right(); }
+            }
+        """.trimIndent()
+        writeProjectFile("src/pages/Calls.java", source)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val pages = mutableListOf<CallHierarchyResult>()
+        val tool = CallHierarchyTool()
+        var cursor: String? = null
+        var remainingPages = 20
+        do {
+            assertTrue("call hierarchy cursor chain must terminate", remainingPages-- > 0)
+            val result = tool.execute(project, buildJsonObject {
+                put("maxNodes", 1)
+                if (cursor == null) {
+                    put("file", "src/pages/Calls.java")
+                    put("line", line)
+                    put("column", column)
+                    put("direction", "callees")
+                    put("depth", 2)
+                } else {
+                    put("cursor", cursor!!)
+                }
+            })
+            assertToolSucceeded("call hierarchy page should succeed", result)
+            val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+            assertTrue("maxNodes must be enforced while traversing", page.returnedNodes <= 1)
+            assertEquals(page.returnedNodes, page.calls.size)
+            assertEquals(page.hasMore, page.cursor != null)
+            assertEquals(page.hasMore, page.truncated)
+            pages += page
+            cursor = page.cursor
+        } while (cursor != null)
+
+        val names = pages.flatMap { it.calls }.map { it.name.substringBefore('(').substringAfterLast('.') }
+        assertEquals(
+            "Direct callees must precede second-level callees in deterministic order",
+            listOf("left", "right", "leftLeaf", "rightLeaf"),
+            names
+        )
+        assertEquals("No call node may be duplicated across pages", names.size, names.toSet().size)
+        assertTrue("Every non-empty hierarchy must fit in a finite number of pages", pages.size <= 6)
+    }
+
+    fun testTypeLeafDoesNotAdvertiseAnEmptyTerminalCursor() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        writeProjectFile(
+            "src/pages/TerminalType.java",
+            "package pages; class TerminalRoot {} class TerminalChild extends TerminalRoot {}"
+        )
+
+        val result = TypeHierarchyTool().execute(project, buildJsonObject {
+            put("className", "pages.TerminalRoot")
+            put("maxNodes", 1)
+        })
+
+        assertToolSucceeded("terminal type hierarchy should succeed", result)
+        val page = json.decodeFromString<TypeHierarchyResult>(toolText(result))
+        assertEquals(listOf("pages.TerminalChild"), page.traversal.map { it.element.name })
+        assertFalse("a leaf must not create a cursor whose next page is empty", page.hasMore)
+        assertNull(page.cursor)
+    }
+
+    fun testCallLeafDoesNotAdvertiseAnEmptyTerminalCursor() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val source = """
+            package pages;
+            class TerminalCalls {
+                void leaf() {}
+                void root() { leaf(); }
+            }
+        """.trimIndent()
+        writeProjectFile("src/pages/TerminalCalls.java", source)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val result = CallHierarchyTool().execute(project, buildJsonObject {
+            put("file", "src/pages/TerminalCalls.java")
+            put("line", line)
+            put("column", column)
+            put("direction", "callees")
+            // Depth two schedules the leaf expansion, which used to manufacture an empty page.
+            put("depth", 2)
+            put("maxNodes", 1)
+        })
+
+        assertToolSucceeded("terminal call hierarchy should succeed", result)
+        val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+        assertEquals(1, page.returnedNodes)
+        assertTrue(page.calls.single().name.contains("TerminalCalls.leaf"))
+        assertFalse("a leaf must not create a cursor whose next page is empty", page.hasMore)
+        assertNull(page.cursor)
+    }
+
+    fun testCallHierarchyKeepsOverloadsDistinctAcrossPages() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val source = """
+            package pages;
+            class Overloads {
+                void hit(int value) {}
+                void hit(String value) {}
+                void root() { hit(1); hit("value"); }
+            }
+        """.trimIndent()
+        writeProjectFile("src/pages/Overloads.java", source)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val tool = CallHierarchyTool()
+        val names = mutableListOf<String>()
+        var cursor: String? = null
+        do {
+            val result = tool.execute(project, buildJsonObject {
+                put("maxNodes", 1)
+                if (cursor == null) {
+                    put("file", "src/pages/Overloads.java")
+                    put("line", line)
+                    put("column", column)
+                    put("direction", "callees")
+                    put("depth", 1)
+                } else put("cursor", cursor!!)
+            })
+            assertToolSucceeded("overload hierarchy page should succeed", result)
+            val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+            names += page.calls.map { it.name }
+            cursor = page.cursor
+        } while (cursor != null)
+
+        assertEquals(listOf("Overloads.hit(int)", "Overloads.hit(String)"), names)
+    }
+
+    fun testTypeCursorRootUsesResolvedDeclarationInsteadOfReferenceLeaf() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        writeProjectFile("src/pages/ReferenceRoot.java", "package pages; class ReferenceRoot {}")
+        val referenceSource = "package pages; class ReferenceFirst extends ReferenceRoot {}"
+        val referencePath = writeProjectFile("src/pages/ReferenceFirst.java", referenceSource)
+        writeProjectFile(
+            "src/pages/ReferenceSecond.java",
+            "package pages; class ReferenceSecond extends ReferenceRoot {}"
+        )
+        val markerOffset = referenceSource.lastIndexOf("ReferenceRoot")
+        val line = referenceSource.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = referenceSource.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val tool = TypeHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("file", "src/pages/ReferenceFirst.java")
+            put("line", line)
+            put("column", column)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("type hierarchy should resolve a type reference", firstResult)
+        val first = json.decodeFromString<TypeHierarchyResult>(toolText(firstResult))
+        assertEquals("pages.ReferenceRoot", first.element.name)
+        val cursor = requireNotNull(first.cursor)
+
+        Files.delete(referencePath)
+        LocalFileSystem.getInstance().refreshAndFindFileByPath(requireNotNull(project.basePath))
+            ?.refresh(false, true)
+
+        val secondResult = tool.execute(project, buildJsonObject {
+            put("cursor", cursor)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded(
+            "deleting the reference leaf must not invalidate the resolved hierarchy root",
+            secondResult
+        )
+        val second = json.decodeFromString<TypeHierarchyResult>(toolText(secondResult))
+        assertEquals(listOf("pages.ReferenceSecond"), second.traversal.map { it.element.name })
+    }
+
+    fun testCallCursorRootUsesResolvedDeclarationInsteadOfCallSiteLeaf() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        writeProjectFile(
+            "src/pages/ReferenceTarget.java",
+            "package pages; class ReferenceTarget { static void hit() {} }"
+        )
+        val callerSource =
+            "package pages; class ReferenceCallerA { void call() { ReferenceTarget.hit(); } }"
+        val callerPath = writeProjectFile("src/pages/ReferenceCallerA.java", callerSource)
+        writeProjectFile(
+            "src/pages/ReferenceCallerB.java",
+            "package pages; class ReferenceCallerB { void call() { ReferenceTarget.hit(); } }"
+        )
+        val markerOffset = callerSource.indexOf("hit")
+        val line = callerSource.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = callerSource.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val tool = CallHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("file", "src/pages/ReferenceCallerA.java")
+            put("line", line)
+            put("column", column)
+            put("direction", "callers")
+            put("depth", 1)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("call hierarchy should resolve a call-site reference", firstResult)
+        val first = json.decodeFromString<CallHierarchyResult>(toolText(firstResult))
+        assertTrue(first.element.name.contains("ReferenceTarget.hit"))
+        val cursor = requireNotNull(first.cursor)
+
+        Files.delete(callerPath)
+        LocalFileSystem.getInstance().refreshAndFindFileByPath(requireNotNull(project.basePath))
+            ?.refresh(false, true)
+
+        val secondResult = tool.execute(project, buildJsonObject {
+            put("cursor", cursor)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded(
+            "deleting the call-site leaf must not invalidate the resolved hierarchy root",
+            secondResult
+        )
+        val second = json.decodeFromString<CallHierarchyResult>(toolText(secondResult))
+        assertTrue(second.calls.single().name.contains("ReferenceCallerB.call"))
+    }
+
+    fun testWideTypeLevelContinuesPastHistoricalHandlerCap() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val subtypeCount = 105
+        writeProjectFile(
+            "src/pages/WideTypes.java",
+            buildString {
+                appendLine("package pages;")
+                appendLine("class WideRoot {}")
+                repeat(subtypeCount) { index ->
+                    appendLine("class WideChild%03d extends WideRoot {}".format(index))
+                }
+            }
+        )
+
+        suspend fun collectFreshTraversal(): List<String> {
+            val names = mutableListOf<String>()
+            val tool = TypeHierarchyTool()
+            var cursor: String? = null
+            var remainingPages = 12
+            do {
+                assertTrue("wide hierarchy cursor chain must terminate", remainingPages-- > 0)
+                val result = tool.execute(project, buildJsonObject {
+                    put("maxNodes", 40)
+                    if (cursor == null) put("className", "pages.WideRoot") else put("cursor", cursor!!)
+                })
+                assertToolSucceeded("wide hierarchy page should succeed", result)
+                val page = json.decodeFromString<TypeHierarchyResult>(toolText(result))
+                assertTrue("maxNodes must bound every wide-level page", page.returnedNodes <= 40)
+                assertEquals(page.returnedNodes, page.traversal.size)
+                assertEquals(page.returnedNodes, page.supertypes.size + page.subtypes.size)
+                assertEquals(page.hasMore, page.cursor != null)
+                assertEquals(page.hasMore, page.truncated)
+                names += page.traversal.map { it.element.name }
+                cursor = page.cursor
+            } while (cursor != null)
+            return names
+        }
+
+        val firstTraversal = collectFreshTraversal()
+        val secondTraversal = collectFreshTraversal()
+        val expectedNames = (0 until subtypeCount).map { "pages.WideChild%03d".format(it) }.toSet()
+
+        assertEquals(subtypeCount, firstTraversal.size)
+        assertEquals("No node may be duplicated across wide-level pages", subtypeCount, firstTraversal.toSet().size)
+        assertEquals("No wide-level node may be lost", expectedNames, firstTraversal.toSet())
+        assertEquals(
+            "unchanged fresh traversals must preserve the same bounded discovery order",
+            firstTraversal,
+            secondTraversal
+        )
+    }
+
+    fun testWideCallLevelContinuesPastHistoricalHandlerCap() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val calleeCount = 25
+        val source = buildString {
+            appendLine("package pages;")
+            appendLine("class WideCalls {")
+            repeat(calleeCount) { index -> appendLine("  void call%02d() {}".format(index)) }
+            append("  void root() {")
+            repeat(calleeCount) { index -> append(" call%02d();".format(index)) }
+            appendLine(" }")
+            appendLine("}")
+        }
+        writeProjectFile("src/pages/WideCalls.java", source)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val names = mutableListOf<String>()
+        val tool = CallHierarchyTool()
+        var cursor: String? = null
+        var remainingPages = 10
+        do {
+            assertTrue("wide call cursor chain must terminate", remainingPages-- > 0)
+            val result = tool.execute(project, buildJsonObject {
+                put("maxNodes", 7)
+                if (cursor == null) {
+                    put("file", "src/pages/WideCalls.java")
+                    put("line", line)
+                    put("column", column)
+                    put("direction", "callees")
+                    put("depth", 1)
+                } else put("cursor", cursor!!)
+            })
+            assertToolSucceeded("wide call page should succeed", result)
+            val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+            names += page.calls.map { it.name.substringBefore('(').substringAfterLast('.') }
+            cursor = page.cursor
+        } while (cursor != null)
+
+        assertEquals(calleeCount, names.size)
+        assertEquals((0 until calleeCount).map { "call%02d".format(it) }, names)
+    }
+
+    fun testTypeHierarchyBoundsTerminalProbesAndBindsEachGrowingPrefixNodeOnce() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val childCount = 8
+        writeProjectFile(
+            "src/pages/ProbeTypes.java",
+            buildString {
+                appendLine("package pages;")
+                appendLine("class ProbeRoot {}")
+                repeat(childCount) { index ->
+                    appendLine("class ProbeType%02d extends ProbeRoot {}".format(index))
+                }
+            }
+        )
+        val facade = JavaPsiFacade.getInstance(project)
+        val scope = GlobalSearchScope.projectScope(project)
+        val root = requireNotNull(facade.findClass("pages.ProbeRoot", scope))
+        val children = (0 until childCount).map { index ->
+            requireNotNull(facade.findClass("pages.ProbeType%02d".format(index), scope))
+        }
+        val handler = CountingTypeHierarchyHandler(root, children)
+        LanguageHandlerRegistry.registerTypeHierarchyHandler(handler)
+
+        val names = mutableListOf<String>()
+        var cursor: String? = null
+        var sawProbeOnlyPage = false
+        var remainingPages = 24
+        do {
+            assertTrue("bounded type probe cursor chain must terminate", remainingPages-- > 0)
+            val callsBefore = handler.invocations
+            val result = TypeHierarchyTool().execute(project, buildJsonObject {
+                put("maxNodes", 1)
+                if (cursor == null) put("className", "pages.ProbeRoot") else put("cursor", cursor!!)
+            })
+            val callsThisPage = handler.invocations - callsBefore
+
+            assertToolSucceeded("bounded type hierarchy page should succeed", result)
+            assertTrue(
+                "maxNodes=1 permits at most one normal expansion plus one terminal look-ahead " +
+                    "probe, got $callsThisPage",
+                callsThisPage <= 2
+            )
+            val page = json.decodeFromString<TypeHierarchyResult>(toolText(result))
+            assertTrue(page.returnedNodes <= 1)
+            assertEquals(page.returnedNodes, page.traversal.size)
+            assertEquals(page.hasMore, page.cursor != null)
+            if (page.returnedNodes == 0) sawProbeOnlyPage = true
+            names += page.traversal.map { it.element.name }
+            cursor = page.cursor
+        } while (cursor != null)
+
+        assertTrue("a bounded terminal frontier should continue through a probe-only page", sawProbeOnlyPage)
+        assertEquals((0 until childCount).map { "pages.ProbeType%02d".format(it) }, names)
+        assertEquals(
+            "growing-prefix re-reads must not allocate handles for already visited types",
+            childCount + 1,
+            SymbolIdRegistry.getInstance().sizeForTest()
+        )
+    }
+
+    fun testCallHierarchyBoundsTerminalProbesAndBindsEachGrowingPrefixNodeOnce() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val calleeCount = 8
+        val source = buildString {
+            appendLine("package pages;")
+            appendLine("class ProbeCalls {")
+            repeat(calleeCount) { index -> appendLine("  void leaf%02d() {}".format(index)) }
+            append("  void root() {")
+            repeat(calleeCount) { index -> append(" leaf%02d();".format(index)) }
+            appendLine(" }")
+            appendLine("}")
+        }
+        writeProjectFile("src/pages/ProbeCalls.java", source)
+        val fixtureClass = requireNotNull(
+            JavaPsiFacade.getInstance(project)
+                .findClass("pages.ProbeCalls", GlobalSearchScope.projectScope(project))
+        )
+        val root = fixtureClass.findMethodsByName("root", false).single()
+        val callees = (0 until calleeCount).map { index ->
+            fixtureClass.findMethodsByName("leaf%02d".format(index), false).single()
+        }
+        val handler = CountingCallHierarchyHandler(root, callees)
+        LanguageHandlerRegistry.registerCallHierarchyHandler(handler)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val names = mutableListOf<String>()
+        var cursor: String? = null
+        var sawProbeOnlyPage = false
+        var remainingPages = 24
+        do {
+            assertTrue("bounded call probe cursor chain must terminate", remainingPages-- > 0)
+            val callsBefore = handler.invocations
+            val result = CallHierarchyTool().execute(project, buildJsonObject {
+                put("maxNodes", 1)
+                if (cursor == null) {
+                    put("file", "src/pages/ProbeCalls.java")
+                    put("line", line)
+                    put("column", column)
+                    put("direction", "callees")
+                    put("depth", 2)
+                } else put("cursor", cursor!!)
+            })
+            val callsThisPage = handler.invocations - callsBefore
+
+            assertToolSucceeded("bounded call hierarchy page should succeed", result)
+            assertTrue(
+                "maxNodes=1 permits at most one normal expansion plus one terminal look-ahead " +
+                    "probe, got $callsThisPage",
+                callsThisPage <= 2
+            )
+            val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+            assertTrue(page.returnedNodes <= 1)
+            assertEquals(page.returnedNodes, page.calls.size)
+            assertEquals(page.hasMore, page.cursor != null)
+            if (page.returnedNodes == 0) sawProbeOnlyPage = true
+            names += page.calls.map { it.name }
+            cursor = page.cursor
+        } while (cursor != null)
+
+        assertTrue("a bounded terminal frontier should continue through a probe-only page", sawProbeOnlyPage)
+        assertEquals((0 until calleeCount).map { "ProbeCalls.leaf%02d()".format(it) }, names)
+        assertEquals(
+            "growing-prefix re-reads must not allocate handles for already visited calls",
+            calleeCount + 1,
+            SymbolIdRegistry.getInstance().sizeForTest()
+        )
+    }
+
+    fun testTypeHierarchyAllowsOnlyOneTerminalLookaheadAfterDiscoveryBudget() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val childCount = 4
+        writeProjectFile(
+            "src/pages/CyclicProbeTypes.java",
+            buildString {
+                appendLine("package pages;")
+                appendLine("class CyclicProbeRoot {}")
+                repeat(childCount) { index ->
+                    appendLine("class CyclicProbeType%02d extends CyclicProbeRoot {}".format(index))
+                }
+            }
+        )
+        val facade = JavaPsiFacade.getInstance(project)
+        val scope = GlobalSearchScope.projectScope(project)
+        val root = requireNotNull(facade.findClass("pages.CyclicProbeRoot", scope))
+        val children = (0 until childCount).map { index ->
+            requireNotNull(facade.findClass("pages.CyclicProbeType%02d".format(index), scope))
+        }
+        val handler = CountingTypeHierarchyHandler(
+            root,
+            children,
+            repeatVisitedChildrenForLeaves = true
+        )
+        LanguageHandlerRegistry.registerTypeHierarchyHandler(handler)
+
+        val result = TypeHierarchyTool().execute(project, buildJsonObject {
+            put("className", "pages.CyclicProbeRoot")
+            put("maxNodes", childCount)
+        })
+
+        assertToolSucceeded("cyclic type hierarchy page should succeed", result)
+        val page = json.decodeFromString<TypeHierarchyResult>(toolText(result))
+        assertEquals(childCount, page.returnedNodes)
+        assertTrue("unresolved terminal probes must remain resumable", page.hasMore)
+        assertEquals(
+            "one initial lookup, one bounded root expansion, and one terminal look-ahead are allowed",
+            3,
+            handler.invocations
+        )
+    }
+
+    fun testCallHierarchyAllowsOnlyOneTerminalLookaheadAfterDiscoveryBudget() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val calleeCount = 4
+        val source = buildString {
+            appendLine("package pages;")
+            appendLine("class CyclicProbeCalls {")
+            repeat(calleeCount) { index -> appendLine("  void leaf%02d() {}".format(index)) }
+            append("  void root() {")
+            repeat(calleeCount) { index -> append(" leaf%02d();".format(index)) }
+            appendLine(" }")
+            appendLine("}")
+        }
+        writeProjectFile("src/pages/CyclicProbeCalls.java", source)
+        val fixtureClass = requireNotNull(
+            JavaPsiFacade.getInstance(project)
+                .findClass("pages.CyclicProbeCalls", GlobalSearchScope.projectScope(project))
+        )
+        val root = fixtureClass.findMethodsByName("root", false).single()
+        val callees = (0 until calleeCount).map { index ->
+            fixtureClass.findMethodsByName("leaf%02d".format(index), false).single()
+        }
+        val handler = CountingCallHierarchyHandler(
+            root,
+            callees,
+            repeatVisitedCalleesForLeaves = true
+        )
+        LanguageHandlerRegistry.registerCallHierarchyHandler(handler)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val result = CallHierarchyTool().execute(project, buildJsonObject {
+            put("file", "src/pages/CyclicProbeCalls.java")
+            put("line", line)
+            put("column", column)
+            put("direction", "callees")
+            put("depth", 2)
+            put("maxNodes", calleeCount)
+        })
+
+        assertToolSucceeded("cyclic call hierarchy page should succeed", result)
+        val page = json.decodeFromString<CallHierarchyResult>(toolText(result))
+        assertEquals(calleeCount, page.returnedNodes)
+        assertTrue("unresolved terminal probes must remain resumable", page.hasMore)
+        assertEquals(
+            "one initial lookup, one ordinary leaf expansion, and one terminal look-ahead are allowed",
+            3,
+            handler.invocations
+        )
+    }
+
+    fun testTypeCursorRefreshesLiveDeclarationMetadataAndPreservesHandles() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val path = writeProjectFile(
+            "src/pages/LiveTypes.java",
+            """
+                package pages;
+                class LiveRoot {}
+                class Alpha extends LiveRoot {}
+                class Beta extends LiveRoot {}
+                class Gamma extends LiveRoot {}
+            """.trimIndent()
+        )
+
+        val tool = TypeHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("className", "pages.LiveRoot")
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("first live hierarchy page should succeed", firstResult)
+        val first = json.decodeFromString<TypeHierarchyResult>(toolText(firstResult))
+        val rootSymbolId = requireNotNull(first.element.symbolId)
+        val cursor = requireNotNull(first.cursor)
+
+        val beta = requireNotNull(
+            JavaPsiFacade.getInstance(project).findClass("pages.Beta", GlobalSearchScope.projectScope(project))
+        )
+        val virtualFile = requireNotNull(LocalFileSystem.getInstance().refreshAndFindFileByPath(path.toString()))
+        val document = requireNotNull(FileDocumentManager.getInstance().getDocument(virtualFile))
+        WriteCommandAction.runWriteCommandAction(project) {
+            beta.setName("RenamedBeta")
+            PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(document)
+            document.insertString(0, "\n")
+            PsiDocumentManager.getInstance(project).commitDocument(document)
+        }
+
+        val secondResult = tool.execute(project, buildJsonObject {
+            put("cursor", cursor)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("cursor should survive declaration edits", secondResult)
+        val second = json.decodeFromString<TypeHierarchyResult>(toolText(secondResult))
+
+        assertEquals("root handle must retain identity across a line shift", rootSymbolId, second.element.symbolId)
+        assertEquals(listOf("pages.RenamedBeta"), second.traversal.map { it.element.name })
+        assertNotNull("refreshed declaration should expose a live handle", second.traversal.single().element.symbolId)
+    }
+
+    fun testCallCursorRefreshesLiveDeclarationMetadataAndPreservesHandles() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        val source = """
+            package pages;
+
+            class LiveCalls {
+                void alpha() {}
+                void beta() {}
+                void root() { alpha(); beta(); }
+            }
+        """.trimIndent()
+        val path = writeProjectFile("src/pages/LiveCalls.java", source)
+        val markerOffset = source.indexOf("root()")
+        val line = source.substring(0, markerOffset).count { it == '\n' } + 1
+        val lineStart = source.lastIndexOf('\n', markerOffset - 1) + 1
+        val column = markerOffset - lineStart + 1
+
+        val tool = CallHierarchyTool()
+        val firstResult = tool.execute(project, buildJsonObject {
+            put("file", "src/pages/LiveCalls.java")
+            put("line", line)
+            put("column", column)
+            put("direction", "callees")
+            put("depth", 1)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("first live call page should succeed", firstResult)
+        val first = json.decodeFromString<CallHierarchyResult>(toolText(firstResult))
+        val rootSymbolId = requireNotNull(first.element.symbolId)
+        val cursor = requireNotNull(first.cursor)
+
+        val liveClass = requireNotNull(
+            JavaPsiFacade.getInstance(project).findClass("pages.LiveCalls", GlobalSearchScope.projectScope(project))
+        )
+        val beta = liveClass.findMethodsByName("beta", false).single()
+        val virtualFile = requireNotNull(LocalFileSystem.getInstance().refreshAndFindFileByPath(path.toString()))
+        val document = requireNotNull(FileDocumentManager.getInstance().getDocument(virtualFile))
+        WriteCommandAction.runWriteCommandAction(project) {
+            beta.setName("renamedBeta")
+            PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(document)
+            document.insertString(0, "\n")
+            PsiDocumentManager.getInstance(project).commitDocument(document)
+        }
+        val expectedLine = document.getLineNumber(beta.textOffset) + 1
+
+        val secondResult = tool.execute(project, buildJsonObject {
+            put("cursor", cursor)
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("call cursor should survive declaration edits", secondResult)
+        val second = json.decodeFromString<CallHierarchyResult>(toolText(secondResult))
+
+        assertEquals("root handle must retain identity across a line shift", rootSymbolId, second.element.symbolId)
+        assertTrue(second.calls.single().name.contains("renamedBeta"))
+        assertEquals(expectedLine, second.calls.single().line)
+        assertNotNull(second.calls.single().symbolId)
+    }
+
+    fun testContinuationFailsClearlyWhenRootPointerWasDeleted() = runBlocking {
+        Assume.assumeTrue("Java plugin required for this fixture", PluginDetectors.java.isAvailable)
+        registerSourceRoot("src")
+        writeProjectFile("src/pages/DeletedRoot.java", "package pages; class DeletedRoot {}")
+        writeProjectFile("src/pages/DeletedChild.java", "package pages; class DeletedChild extends DeletedRoot {}")
+        writeProjectFile("src/pages/DeletedLeaf.java", "package pages; class DeletedLeaf extends DeletedChild {}")
+
+        val tool = TypeHierarchyTool()
+        val first = tool.execute(project, buildJsonObject {
+            put("className", "pages.DeletedRoot")
+            put("maxNodes", 1)
+        })
+        assertToolSucceeded("first hierarchy page should create a continuation", first)
+        val cursor = requireNotNull(json.decodeFromString<TypeHierarchyResult>(toolText(first)).cursor)
+
+        val rootPath = Path.of(requireNotNull(project.basePath), "src/pages/DeletedRoot.java")
+        Files.delete(rootPath)
+        LocalFileSystem.getInstance().refreshAndFindFileByPath(requireNotNull(project.basePath))
+            ?.refresh(false, true)
+
+        val next = tool.execute(project, buildJsonObject {
+            put("cursor", cursor)
+            put("maxNodes", 1)
+        })
+
+        assertToolFailed("continuation rooted at a deleted PSI element must fail", next)
+        assertTrue(
+            "failure should tell the client to restart the query: ${toolText(next)}",
+            toolText(next).contains("deleted") || toolText(next).contains("invalid")
+        )
+    }
+
+    private class CountingTypeHierarchyHandler(
+        private val root: PsiClass,
+        private val children: List<PsiClass>,
+        private val repeatVisitedChildrenForLeaves: Boolean = false
+    ) : TypeHierarchyHandler {
+        override val languageId: String = "JAVA"
+        var invocations: Int = 0
+            private set
+
+        override fun canHandle(element: PsiElement): Boolean = asClass(element) != null
+
+        override fun isAvailable(): Boolean = true
+
+        override fun getTypeHierarchy(
+            element: PsiElement,
+            project: Project,
+            scope: BuiltInSearchScope,
+            excludeGenerated: Boolean,
+            directOnly: Boolean,
+            direction: TypeHierarchyDirection?,
+            page: HierarchyPageRequest?
+        ): TypeHierarchyData? {
+            invocations++
+            val type = asClass(element) ?: return null
+            val isRoot = type === root || type.manager.areElementsEquivalent(type, root)
+            val directChildren = if (
+                direction == TypeHierarchyDirection.SUBTYPE &&
+                (isRoot || repeatVisitedChildrenForLeaves)
+            ) {
+                children.map(::toData)
+            } else {
+                emptyList()
+            }
+            val (pageChildren, nextOffset) = directChildren.applyHierarchyPage(page)
+            return TypeHierarchyData(
+                element = toData(type),
+                supertypes = emptyList(),
+                subtypes = pageChildren,
+                nextOffset = nextOffset
+            )
+        }
+
+        private fun asClass(element: PsiElement): PsiClass? =
+            element as? PsiClass ?: PsiTreeUtil.getParentOfType(element, PsiClass::class.java, false)
+
+        private fun toData(type: PsiClass): TypeElementData = TypeElementData(
+            name = type.qualifiedName ?: type.name.orEmpty(),
+            qualifiedName = type.qualifiedName,
+            file = type.containingFile?.virtualFile?.path,
+            line = 1,
+            kind = if (type.isInterface) "INTERFACE" else "CLASS",
+            language = "Java",
+            pointerTarget = type
+        )
+    }
+
+    private class CountingCallHierarchyHandler(
+        private val root: PsiMethod,
+        private val callees: List<PsiMethod>,
+        private val repeatVisitedCalleesForLeaves: Boolean = false
+    ) : CallHierarchyHandler {
+        override val languageId: String = "JAVA"
+        var invocations: Int = 0
+            private set
+
+        override fun canHandle(element: PsiElement): Boolean = asMethod(element) != null
+
+        override fun isAvailable(): Boolean = true
+
+        override fun getCallHierarchy(
+            element: PsiElement,
+            project: Project,
+            direction: String,
+            depth: Int,
+            scope: BuiltInSearchScope,
+            excludeGenerated: Boolean,
+            page: HierarchyPageRequest?
+        ): CallHierarchyData? {
+            invocations++
+            val method = asMethod(element) ?: return null
+            val isRoot = method === root || method.manager.areElementsEquivalent(method, root)
+            val directCallees = if (isRoot || repeatVisitedCalleesForLeaves) {
+                callees.map(::toData)
+            } else {
+                emptyList()
+            }
+            val (pageCallees, nextOffset) = directCallees.applyHierarchyPage(page)
+            return CallHierarchyData(
+                element = toData(method),
+                calls = pageCallees,
+                nextOffset = nextOffset
+            )
+        }
+
+        private fun asMethod(element: PsiElement): PsiMethod? =
+            element as? PsiMethod ?: PsiTreeUtil.getParentOfType(element, PsiMethod::class.java, false)
+
+        private fun toData(method: PsiMethod): CallElementData = CallElementData(
+            name = "${method.containingClass?.name}.${method.name}()",
+            file = method.containingFile.virtualFile?.path ?: method.containingFile.name,
+            line = 1,
+            column = 1,
+            language = "Java",
+            pointerTarget = method
+        )
+    }
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SymbolIdBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/SymbolIdBehaviorTest.kt
@@ -1,0 +1,307 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.handlers.LanguageHandlerRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.McpServerService
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DefinitionResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindSymbolResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.FindUsagesResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SymbolInfoResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.TypeHierarchyResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project.SyncFilesTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring.RenameSymbolTool
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class SymbolIdBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        SymbolIdRegistry.getInstance().resetSession()
+        LanguageHandlerRegistry.registerHandlers()
+    }
+
+    override fun tearDown() {
+        try {
+            SymbolIdRegistry.getInstance().resetSession()
+            LanguageHandlerRegistry.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testFindSymbolReturnsDistinctIdsForOverloadsAndSymbolInfoUsesExactOverload() = runBlocking {
+        registerSourceRoot("overload-symbol-src")
+        writeProjectFile(
+            "overload-symbol-src/Overloaded.java",
+            """
+            class Overloaded {
+                int choose(int value) { return value; }
+                long choose(long value) { return value; }
+            }
+            """.trimIndent()
+        )
+
+        val search = FindSymbolTool().execute(project, buildJsonObject {
+            put("query", "choose")
+            put("pageSize", 50)
+        })
+        assertToolSucceeded("find_symbol should find both overloads", search)
+        val matches = decode<FindSymbolResult>(search).symbols
+            .filter { it.file.endsWith("Overloaded.java") && it.name == "choose" }
+        assertEquals("Both overloads must be returned", 2, matches.size)
+        assertEquals("Overloads need separate opaque handles", 2, matches.map { it.symbolId }.toSet().size)
+        assertTrue(matches.all { it.symbolId.startsWith("sym_") })
+
+        val parameterTypes = matches.map { match ->
+            val infoResult = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", match.symbolId) })
+            assertToolSucceeded("symbol_info should resolve ${match.symbolId}", infoResult)
+            val info = decode<SymbolInfoResult>(infoResult)
+            assertEquals("A semantic round-trip should preserve the handle", match.symbolId, info.symbolId)
+            requireNotNull(info.parameters).single().type
+        }.toSet()
+
+        assertEquals(setOf("int", "long"), parameterTypes)
+    }
+
+    fun testPaginatedSearchBindsOnlyReturnedSymbolsAndRebindsAnEvictedPageHandle() = runBlocking {
+        registerSourceRoot("paged-symbol-src")
+        writeProjectFile(
+            "paged-symbol-src/PagedHandles.java",
+            """
+            class PagedHandles {
+                void uniquelyPagedHandle(int value) {}
+                void uniquelyPagedHandle(long value) {}
+                void uniquelyPagedHandle(double value) {}
+            }
+            """.trimIndent()
+        )
+        val registry = SymbolIdRegistry.getInstance()
+
+        val firstResult = FindSymbolTool().execute(project, buildJsonObject {
+            put("query", "uniquelyPagedHandle")
+            put("pageSize", 1)
+        })
+        assertToolSucceeded("First symbol page should succeed", firstResult)
+        val firstPage = decode<FindSymbolResult>(firstResult)
+        assertEquals(1, firstPage.symbols.size)
+        assertEquals(
+            "Over-collected but undisclosed results must not consume symbol handles",
+            1,
+            registry.sizeForTest()
+        )
+        val secondCursor = requireNotNull(firstPage.nextCursor)
+
+        val secondResult = FindSymbolTool().execute(project, buildJsonObject {
+            put("cursor", secondCursor)
+        })
+        assertToolSucceeded("Second symbol page should succeed", secondResult)
+        val secondPage = decode<FindSymbolResult>(secondResult)
+        val originalSecondId = secondPage.symbols.single().symbolId
+        assertTrue(originalSecondId.startsWith("sym_"))
+
+        registry.invalidate(originalSecondId)
+        val retriedResult = FindSymbolTool().execute(project, buildJsonObject {
+            put("cursor", secondCursor)
+        })
+        assertToolSucceeded("Retrying the page should rebind an evicted handle", retriedResult)
+        val reboundId = decode<FindSymbolResult>(retriedResult).symbols.single().symbolId
+        assertFalse("A missing cached handle must be replaced", originalSecondId == reboundId)
+
+        val infoResult = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", reboundId) })
+        assertToolSucceeded("The replacement handle must be immediately resolvable", infoResult)
+    }
+
+    fun testLocalSymbolSurvivesExternalLineShiftAndDrivesUsagesAndRename() = runBlocking {
+        registerSourceRoot("local-symbol-src")
+        val original = """
+            class LocalSymbolTarget {
+                void run() {
+                    int count = 1;
+                    int copy = count;
+                }
+            }
+        """.trimIndent()
+        val path = writeProjectFile("local-symbol-src/LocalSymbolTarget.java", original)
+
+        val definition = definitionAt("local-symbol-src/LocalSymbolTarget.java", original, "count;")
+        assertEquals("count", definition.symbolName)
+        assertTrue(definition.symbolId.startsWith("sym_"))
+
+        Files.writeString(path, "// external header\n\n$original")
+        val sync = SyncFilesTool().execute(project, buildJsonObject {})
+        assertToolSucceeded("External rewrite should synchronize", sync)
+
+        val usagesResult = FindUsagesTool().execute(project, buildJsonObject {
+            put("symbolId", definition.symbolId)
+        })
+        assertToolSucceeded("find_references should resolve the shifted local by ID", usagesResult)
+        val usages = decode<FindUsagesResult>(usagesResult)
+        assertEquals(1, usages.usages.size)
+        assertEquals(definition.symbolId, usages.resolvedSymbol?.symbolId)
+        assertEquals("count", usages.resolvedSymbol?.name)
+        assertEquals("Smart pointer must follow the two inserted lines", 5, usages.resolvedSymbol?.line)
+
+        val renameResult = RenameSymbolTool().execute(project, buildJsonObject {
+            put("symbolId", definition.symbolId)
+            put("newName", "total")
+        })
+        assertToolSucceeded("Local rename by ID should succeed", renameResult)
+        val rename = decode<RefactoringResult>(renameResult)
+        assertEquals("The live ID should be rebound after rename", definition.symbolId, rename.updatedSymbol?.symbolId)
+        assertEquals("total", rename.updatedSymbol?.name)
+        assertEquals(5, rename.updatedSymbol?.line)
+        assertFileContains("local-symbol-src/LocalSymbolTarget.java", "int total = 1;")
+        assertFileContains("local-symbol-src/LocalSymbolTarget.java", "int copy = total;")
+        assertFileDoesNotContain("local-symbol-src/LocalSymbolTarget.java", "count")
+
+        val infoResult = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", definition.symbolId) })
+        assertToolSucceeded("The same ID should resolve after rename", infoResult)
+        val info = decode<SymbolInfoResult>(infoResult)
+        assertEquals(definition.symbolId, info.symbolId)
+        assertEquals("total", info.name)
+    }
+
+    fun testRemovingDeclarationExpiresIdInsteadOfRetargetingNearbyMethod() = runBlocking {
+        registerSourceRoot("removed-symbol-src")
+        val original = """
+            class RemovedSymbolTarget {
+                void removed() {}
+                void survivor() {}
+            }
+        """.trimIndent()
+        val path = writeProjectFile("removed-symbol-src/RemovedSymbolTarget.java", original)
+        val definition = definitionAt("removed-symbol-src/RemovedSymbolTarget.java", original, "removed")
+
+        Files.writeString(
+            path,
+            """
+            class RemovedSymbolTarget {
+                void survivor() {}
+            }
+            """.trimIndent()
+        )
+        assertToolSucceeded("Deletion should synchronize", SyncFilesTool().execute(project, buildJsonObject {}))
+
+        val result = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", definition.symbolId) })
+        assertToolFailed("Deleted declaration ID must not snap to survivor", result)
+        assertTrue(toolText(result).contains("SYMBOL_ID_EXPIRED"))
+        assertFalse(toolText(result).contains("survivor"))
+    }
+
+    fun testDeletingFileExternallyExpiresItsSymbolIdsAfterSync() = runBlocking {
+        val source = "class DeletedFileTarget { void target() {} }"
+        val path = writeProjectFile("deleted-symbol-src/DeletedFileTarget.java", source)
+        val definition = definitionAt("deleted-symbol-src/DeletedFileTarget.java", source, "target()")
+
+        Files.delete(path)
+        assertToolSucceeded("External file deletion should synchronize", SyncFilesTool().execute(project, buildJsonObject {}))
+
+        val result = FindDefinitionTool().execute(project, buildJsonObject { put("symbolId", definition.symbolId) })
+        assertToolFailed("A handle into a deleted file must expire", result)
+        assertTrue(toolText(result).contains("SYMBOL_ID_EXPIRED"))
+    }
+
+    fun testTypeHierarchyAcceptsIdAndReturnsResolvableIds() = runBlocking {
+        registerSourceRoot("hierarchy-symbol-src")
+        val baseSource = """
+            package hierarchyid;
+            public class BaseType {}
+        """.trimIndent()
+        writeProjectFile("hierarchy-symbol-src/hierarchyid/BaseType.java", baseSource)
+        writeProjectFile(
+            "hierarchy-symbol-src/hierarchyid/DerivedType.java",
+            """
+            package hierarchyid;
+            public class DerivedType extends BaseType {}
+            """.trimIndent()
+        )
+        val base = definitionAt("hierarchy-symbol-src/hierarchyid/BaseType.java", baseSource, "BaseType")
+
+        val hierarchyResult = TypeHierarchyTool().execute(project, buildJsonObject {
+            put("symbolId", base.symbolId)
+        })
+        assertToolSucceeded("type_hierarchy should accept symbolId", hierarchyResult)
+        val hierarchy = decode<TypeHierarchyResult>(hierarchyResult)
+        assertEquals(base.symbolId, hierarchy.element.symbolId)
+        val derived = hierarchy.subtypes.single { it.name.endsWith("DerivedType") }
+        assertNotNull("Hierarchy nodes backed by PSI must expose IDs", derived.symbolId)
+
+        val derivedDefinition = FindDefinitionTool().execute(project, buildJsonObject {
+            put("symbolId", derived.symbolId!!)
+        })
+        assertToolSucceeded("A hierarchy node ID should be reusable", derivedDefinition)
+        val resolved = decode<DefinitionResult>(derivedDefinition)
+        assertEquals(derived.symbolId, resolved.symbolId)
+        assertEquals("DerivedType", resolved.symbolName)
+    }
+
+    fun testMcpServerStopInvalidatesCurrentSessionIds() = runBlocking {
+        val source = "class RestartTarget { void target() {} }"
+        writeProjectFile("restart-symbol-src/RestartTarget.java", source)
+        val definition = definitionAt("restart-symbol-src/RestartTarget.java", source, "target")
+
+        McpServerService.getInstance().stopServer()
+
+        val result = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", definition.symbolId) })
+        assertToolFailed("MCP server restart boundary must expire old IDs", result)
+        assertTrue(toolText(result).contains("SYMBOL_ID_EXPIRED"))
+    }
+
+    fun testMcpServerStopInvalidatesOrdinaryPaginationCursors() = runBlocking {
+        registerSourceRoot("restart-cursor-src")
+        writeProjectFile(
+            "restart-cursor-src/RestartCursor.java",
+            """
+            class RestartCursor {
+                void uniqueRestartCursor(int value) {}
+                void uniqueRestartCursor(long value) {}
+            }
+            """.trimIndent()
+        )
+        val searchResult = FindSymbolTool().execute(project, buildJsonObject {
+            put("query", "uniqueRestartCursor")
+            put("pageSize", 1)
+        })
+        assertToolSucceeded("Search should produce a continuation", searchResult)
+        val cursor = requireNotNull(decode<FindSymbolResult>(searchResult).nextCursor)
+
+        McpServerService.getInstance().stopServer()
+
+        val continued = FindSymbolTool().execute(project, buildJsonObject { put("cursor", cursor) })
+        assertToolFailed("A pagination cursor must not survive the MCP session boundary", continued)
+        assertTrue(toolText(continued).contains("Cursor not found"))
+    }
+
+    private suspend fun definitionAt(file: String, source: String, marker: String): DefinitionResult {
+        val arguments = positionArguments(file, source, marker)
+        val result = FindDefinitionTool().execute(project, arguments)
+        assertToolSucceeded("find_definition at $file / $marker", result)
+        return decode(result)
+    }
+
+    private fun positionArguments(file: String, source: String, marker: String): JsonObject {
+        val offset = source.indexOf(marker)
+        require(offset >= 0) { "Marker '$marker' is absent from fixture" }
+        val lineStart = source.lastIndexOf('\n', offset - 1) + 1
+        val line = source.substring(0, offset).count { it == '\n' } + 1
+        val column = offset - lineStart + 1
+        return buildJsonObject {
+            put("file", file)
+            put("line", line)
+            put("column", column)
+        }
+    }
+
+    private inline fun <reified T> decode(result: CallToolResult): T =
+        json.decodeFromString(toolText(result))
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/navigation/TypeHierarchyToolBehaviorTest.kt
@@ -81,12 +81,11 @@ class TypeHierarchyToolBehaviorTest : McpPlatformTestCase() {
             parentEntries.size
         )
 
-        // The surviving entry must be the informative one — carrying Parent's own transitive
-        // supertype chain, not the interfaces-loop duplicate whose nested supertypes are null.
-        val nested = parentEntries.single().supertypes?.map { it.name }.orEmpty()
+        // Pagination flattens the deterministic BFS page, so Parent's ancestor is a peer entry
+        // rather than an eagerly materialized nested tree.
         assertTrue(
-            "The single Parent entry must carry its own supertype hier.GrandParent; got $nested",
-            nested.contains("hier.GrandParent")
+            "The hierarchy page must carry Parent's supertype hier.GrandParent; got $supertypeNames",
+            supertypeNames.contains("hier.GrandParent")
         )
     }
 

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/SyncFilesToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/project/SyncFilesToolBehaviorTest.kt
@@ -3,6 +3,8 @@ package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.project
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SyncFilesResult
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.PsiTestUtil
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -73,6 +75,9 @@ class SyncFilesToolBehaviorTest : McpPlatformTestCase() {
         assertToolSucceeded("sync_files should succeed", result)
         val payload = decode(toolText(result))
         assertEquals(listOf("synced/A.java", "synced/B.java"), payload.syncedPaths)
+        assertEquals(listOf("synced/A.java", "synced/B.java"), payload.requestedPaths)
+        assertEquals(listOf("synced/A.java", "synced/B.java"), payload.refreshedRoots)
+        assertTrue(payload.deletedPaths.isEmpty())
         assertFalse("An explicit path list is not a whole-project sync", payload.syncedAll)
         assertEquals("Synchronized 2 path(s).", payload.message)
     }
@@ -84,30 +89,41 @@ class SyncFilesToolBehaviorTest : McpPlatformTestCase() {
         val payload = decode(toolText(result))
         assertTrue("Omitting paths must sync the whole project", payload.syncedAll)
         assertEquals(listOf(project.basePath), payload.syncedPaths)
+        assertTrue(payload.requestedPaths.isEmpty())
+        assertEquals(listOf(project.basePath), payload.refreshedRoots)
+        assertTrue(payload.deletedPaths.isEmpty())
         assertEquals("Synchronized entire project.", payload.message)
     }
 
     /**
-     * A path that cannot be resolved must be reported, not silently dropped — otherwise an agent
-     * sees success and concludes the file is now indexed.
+     * A deleted path is refreshed through its nearest existing parent. This invalidates the stale
+     * VFS entry while keeping the requested and actually-refreshed paths unambiguous in the result.
      */
-    fun testSyncNamesUnresolvablePathsInsteadOfSilentlyIgnoringThem() = runBlocking {
-        writeProjectFile("synced/Present.java", "public class Present {}\n")
+    fun testSyncRefreshesDeletedPathThroughNearestExistingParent() = runBlocking {
+        val deletedFile = writeProjectFile("synced/deleted/Old.java", "public class Old {}\n")
+        val absolutePath = deletedFile.toString()
+        val staleVirtualFile = requireNotNull(LocalFileSystem.getInstance().findFileByPath(absolutePath))
+        val stalePsiFile = requireNotNull(PsiManager.getInstance(project).findFile(staleVirtualFile))
+        Files.delete(deletedFile)
 
         val result = SyncFilesTool().execute(project, buildJsonObject {
             put("paths", buildJsonArray {
-                add(JsonPrimitive("synced/Present.java"))
-                add(JsonPrimitive("synced/Missing.java"))
+                add(JsonPrimitive("synced/deleted/Old.java"))
             })
         })
 
-        assertToolSucceeded("Partial resolution is still a success", result)
+        assertToolSucceeded("A deleted target should be synchronized via its parent", result)
         val payload = decode(toolText(result))
-        assertEquals(listOf("synced/Present.java"), payload.syncedPaths)
+        assertEquals(listOf("synced/deleted/Old.java"), payload.syncedPaths)
+        assertEquals(listOf("synced/deleted/Old.java"), payload.requestedPaths)
+        assertEquals(listOf("synced/deleted"), payload.refreshedRoots)
+        assertEquals(listOf("synced/deleted/Old.java"), payload.deletedPaths)
         assertEquals(
-            "Synchronized 1 of 2 requested path(s). Not found: synced/Missing.java.",
+            "Synchronized 1 path(s), including 1 deleted path(s) via existing parent directories.",
             payload.message
         )
+        assertNull("The deleted file must be evicted from the VFS", LocalFileSystem.getInstance().findFileByPath(absolutePath))
+        assertFalse("The deleted file's PSI must be invalidated", stalePsiFile.isValid)
     }
 
     fun testSyncWithEmptyPathListFallsBackToWholeProject() = runBlocking {
@@ -118,5 +134,60 @@ class SyncFilesToolBehaviorTest : McpPlatformTestCase() {
         assertToolSucceeded("An empty path list should not error", result)
         val payload = decode(toolText(result))
         assertTrue("An empty list is treated as 'sync everything'", payload.syncedAll)
+    }
+
+    fun testSyncRejectsTraversalAndAbsolutePaths() = runBlocking {
+        val traversal = SyncFilesTool().execute(project, buildJsonObject {
+            put("paths", buildJsonArray { add(JsonPrimitive("synced/../Outside.java")) })
+        })
+        assertToolFailed("Path traversal must be rejected", traversal)
+        assertTrue(toolText(traversal).contains("traversal"))
+
+        val absolute = SyncFilesTool().execute(project, buildJsonObject {
+            put("paths", buildJsonArray { add(JsonPrimitive("${project.basePath}/Outside.java")) })
+        })
+        assertToolFailed("Absolute paths must be rejected", absolute)
+        assertTrue(toolText(absolute).contains("relative"))
+    }
+
+    fun testSyncRejectsSymbolicLinkEscape() = runBlocking {
+        val outsideDirectory = Files.createTempDirectory("ide-sync-files-outside")
+        val link = java.nio.file.Path.of(requireNotNull(project.basePath), "outside-link")
+        Files.createSymbolicLink(link, outsideDirectory)
+
+        try {
+            val result = SyncFilesTool().execute(project, buildJsonObject {
+                put("paths", buildJsonArray { add(JsonPrimitive("outside-link/Deleted.java")) })
+            })
+
+            assertToolFailed("A symlink must not escape the selected project root", result)
+            assertTrue(toolText(result).contains("symbolic link"))
+        } finally {
+            Files.deleteIfExists(link)
+            Files.deleteIfExists(outsideDirectory)
+        }
+    }
+
+    fun testSyncResolvesPathsAgainstSelectedWorkspaceContentRoot() = runBlocking {
+        // A same-named file under the workspace base makes a base-first implementation lie: the
+        // selected sub-project target is absent and must be reported as deleted.
+        writeProjectFile("Shared.java", "public class Shared {}\n")
+        val workspaceRootPath = java.nio.file.Path.of(requireNotNull(project.basePath), "workspace-module")
+        Files.createDirectories(workspaceRootPath)
+        val workspaceRoot = requireNotNull(
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(workspaceRootPath.toString())
+        )
+        PsiTestUtil.addContentRoot(module, workspaceRoot)
+
+        val result = SyncFilesTool().execute(project, buildJsonObject {
+            put("project_path", workspaceRootPath.toString())
+            put("paths", buildJsonArray { add(JsonPrimitive("Shared.java")) })
+        })
+
+        assertToolSucceeded("Workspace sync should use the selected content root", result)
+        val payload = decode(toolText(result))
+        assertEquals(listOf("Shared.java"), payload.requestedPaths)
+        assertEquals(listOf("Shared.java"), payload.deletedPaths)
+        assertEquals(listOf(workspaceRootPath.toRealPath().toString()), payload.refreshedRoots)
     }
 }

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringDryRunBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RefactoringDryRunBehaviorTest.kt
@@ -1,0 +1,893 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.settings.McpSettings
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Ref
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import com.intellij.refactoring.changeSignature.ChangeInfo
+import com.intellij.refactoring.changeSignature.ChangeSignatureUsageProcessor
+import com.intellij.refactoring.rename.ResolveSnapshotProvider
+import com.intellij.refactoring.rename.naming.AutomaticRenamer
+import com.intellij.refactoring.rename.naming.AutomaticRenamerFactory
+import com.intellij.usageView.UsageInfo
+import com.intellij.util.containers.MultiMap
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.lang.reflect.InvocationTargetException
+import java.nio.file.Files
+import java.nio.file.Path
+
+class RefactoringDryRunBehaviorTest : McpPlatformTestCase() {
+
+    // MCP requests arrive on Ktor worker threads. Running these previews on the test EDT would
+    // keep it blocked in runBlocking while RenameProcessor coordinates platform progress with
+    // the EDT, creating a fixture-only deadlock that production does not have.
+    override fun runInDispatchThread(): Boolean = false
+
+    fun testRenameDryRunDiscoversCrossFileUsageAndPreservesFilesByteForByte() = runBlocking {
+        registerSourceRoot("dry-rename-src")
+        val declaration = writeProjectFile(
+            "dry-rename-src/preview/RenameTarget.java",
+            """
+            package preview;
+            class RenameTarget {
+                String calculate(String input) { return input; }
+            }
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-rename-src/preview/RenameCaller.java",
+            """
+            package preview;
+            class RenameCaller {
+                String call(RenameTarget target) { return target.calculate("value"); }
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration, caller)
+        val tool = RenameSymbolTool().also {
+            it.processorRunHook = { error("RenameProcessor.run() must not be called by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-rename-src/preview/RenameTarget.java")
+            put("line", 3)
+            put("column", 12)
+            put("newName", "compute")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = true)
+        assertTrue(preview.getValue("usageCount").jsonPrimitive.int >= 1)
+        assertEquals(0, preview.getValue("conflictCount").jsonPrimitive.int)
+        val affected = preview.getValue("affectedFiles").jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(affected.contains("dry-rename-src/preview/RenameTarget.java"))
+        assertTrue(affected.contains("dry-rename-src/preview/RenameCaller.java"))
+        assertBytesUnchanged(before)
+        assertProjectFileExists("dry-rename-src/preview/RenameTarget.java")
+        assertProjectFileAbsent("dry-rename-src/preview/compute.java")
+    }
+
+    fun testFileRenameDryRunPreservesFileAndReferences() = runBlocking {
+        registerSourceRoot("dry-file-rename-src")
+        val declaration = writeProjectFile(
+            "dry-file-rename-src/preview/PreviewTarget.java",
+            """
+            package preview;
+            public class PreviewTarget {}
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-file-rename-src/preview/PreviewCaller.java",
+            """
+            package preview;
+            class PreviewCaller { PreviewTarget target; }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration, caller)
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "dry-file-rename-src/preview/PreviewTarget.java")
+            put("targetType", "file")
+            put("newName", "RenamedTarget.java")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = true)
+        assertEquals("file", preview.getValue("plannedChange").jsonObject.getValue("targetType").jsonPrimitive.content)
+        assertProjectFileExists("dry-file-rename-src/preview/PreviewTarget.java")
+        assertProjectFileAbsent("dry-file-rename-src/preview/RenamedTarget.java")
+        assertBytesUnchanged(before)
+    }
+
+    fun testFileRenameDryRunFailsClosedForExistingSiblingWithoutChangingFiles() = runBlocking {
+        val source = writeProjectFile("dry-file-rename-collision/Original.txt", "original\n")
+        val existingSibling = writeProjectFile("dry-file-rename-collision/Target.txt", "existing\n")
+        val before = snapshotBytes(source, existingSibling)
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "dry-file-rename-collision/Original.txt")
+            put("targetType", "file")
+            put("newName", "Target.txt")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertTrue(preview.getValue("conflictCount").jsonPrimitive.int >= 1)
+        assertPreviewWarningContains(preview, "already exists in its containing directory")
+        assertProjectFileExists("dry-file-rename-collision/Original.txt")
+        assertProjectFileExists("dry-file-rename-collision/Target.txt")
+        assertBytesUnchanged(before)
+    }
+
+    fun testSafeDeleteDryRunChecksUsagesAndPreservesFilesByteForByte() = runBlocking {
+        registerSourceRoot("dry-delete-src")
+        val declaration = writeProjectFile(
+            "dry-delete-src/preview/DeleteTarget.java",
+            """
+            package preview;
+            class DeleteTarget {
+                String doomed() { return "value"; }
+            }
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-delete-src/preview/DeleteCaller.java",
+            """
+            package preview;
+            class DeleteCaller {
+                String call(DeleteTarget target) { return target.doomed(); }
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration, caller)
+        val tool = SafeDeleteTool().also {
+            it.beforeDeletionHook = { error("Deletion write phase must not be reached by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-delete-src/preview/DeleteTarget.java")
+            put("line", 3)
+            put("column", 12)
+            put("force", true)
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = true)
+        assertTrue(preview.getValue("usageCount").jsonPrimitive.int >= 1)
+        assertTrue(preview.getValue("conflictCount").jsonPrimitive.int >= 1)
+        assertBytesUnchanged(before)
+        assertProjectFileVfsContains("dry-delete-src/preview/DeleteTarget.java", "String doomed()")
+    }
+
+    fun testFileSafeDeleteDryRunPreservesTargetFile() = runBlocking {
+        registerSourceRoot("dry-file-delete-src")
+        val target = writeProjectFile(
+            "dry-file-delete-src/preview/UnusedPreview.java",
+            """
+            package preview;
+            public class UnusedPreview {}
+            """.trimIndent()
+        )
+        val before = snapshotBytes(target)
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "dry-file-delete-src/preview/UnusedPreview.java")
+            put("target_type", "file")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = true)
+        assertEquals("file", preview.getValue("plannedChange").jsonObject.getValue("targetType").jsonPrimitive.content)
+        assertProjectFileExists("dry-file-delete-src/preview/UnusedPreview.java")
+        assertBytesUnchanged(before)
+    }
+
+    fun testFileSafeDeleteDryRunWithoutDeclarationsFailsClosed() = runBlocking {
+        registerSourceRoot("dry-file-delete-unknown-src")
+        val target = writeProjectFile(
+            "dry-file-delete-unknown-src/preview/opaque.data",
+            "opaque non-code payload"
+        )
+        val before = snapshotBytes(target)
+
+        val result = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", "dry-file-delete-unknown-src/preview/opaque.data")
+            put("target_type", "file")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "complete usage discovery cannot be proven")
+        assertEquals(0, preview.getValue("usageCount").jsonPrimitive.int)
+        assertEquals(0, preview.getValue("conflictCount").jsonPrimitive.int)
+        assertProjectFileExists("dry-file-delete-unknown-src/preview/opaque.data")
+        assertBytesUnchanged(before)
+    }
+
+    fun testRenameDryRunReportsConflictsWithoutOpeningApplyPath() = runBlocking {
+        val file = writeProjectFile(
+            "dry-rename-conflict/RenameConflict.java",
+            """
+            class RenameConflict {
+                void existing() {}
+                void candidate() {}
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(file)
+        val tool = RenameSymbolTool().also {
+            it.processorRunHook = { error("RenameProcessor.run() must not be called by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-rename-conflict/RenameConflict.java")
+            put("line", 3)
+            put("column", 10)
+            put("newName", "existing")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertTrue(preview.getValue("conflictCount").jsonPrimitive.int >= 1)
+        assertBytesUnchanged(before)
+    }
+
+    fun testRenameDryRunFailsClosedWhenAutomaticRenamerHasCandidates() = runBlocking {
+        val path = writeProjectFile(
+            "dry-rename-related/RelatedRename.java",
+            """
+            class RelatedRename {
+                void target() {}
+                void related() {}
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(path)
+        val relatedMethod = ReadAction.compute<com.intellij.psi.PsiMethod, RuntimeException> {
+            val virtualFile = requireNotNull(LocalFileSystem.getInstance().findFileByPath(path.toString()))
+            val psiFile = requireNotNull(PsiManager.getInstance(project).findFile(virtualFile)) as PsiJavaFile
+            psiFile.classes.single().findMethodsByName("related", false).single()
+        }
+        val factory = object : AutomaticRenamerFactory {
+            override fun isApplicable(element: com.intellij.psi.PsiElement): Boolean =
+                (element as? com.intellij.psi.PsiMethod)?.name == "target"
+
+            // The tool deliberately registers only user-selectable factories. A non-null option
+            // therefore proves the preview sees a factory supplied through its normal setup,
+            // rather than relying on RenameProcessor's separate built-in-factory fallback.
+            override fun getOptionName(): String = "Synthetic related rename"
+            override fun isEnabled(): Boolean = true
+            override fun setEnabled(enabled: Boolean) = Unit
+
+            override fun createRenamer(
+                element: com.intellij.psi.PsiElement,
+                newName: String,
+                usages: Collection<UsageInfo>
+            ): AutomaticRenamer = object : AutomaticRenamer() {
+                init {
+                    myElements.add(relatedMethod)
+                    suggestAllNames("related", "renamedRelated")
+                }
+
+                override fun getDialogTitle(): String = "Synthetic related rename"
+                override fun getDialogDescription(): String = "Synthetic related rename"
+                override fun entityName(): String = "method"
+            }
+        }
+        AutomaticRenamerFactory.EP_NAME.point.registerExtension(factory, testRootDisposable)
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "dry-rename-related/RelatedRename.java")
+            put("line", 2)
+            put("column", 10)
+            put("newName", "renamedTarget")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "found related symbols")
+        assertBytesUnchanged(before)
+    }
+
+    fun testChangeSignatureDryRunDiscoversCallerAndPreservesFilesByteForByte() = runBlocking {
+        registerSourceRoot("dry-signature-src")
+        val declaration = writeProjectFile(
+            "dry-signature-src/preview/SignatureTarget.java",
+            """
+            package preview;
+            class SignatureTarget {
+                String format(String input) { return input; }
+            }
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-signature-src/preview/SignatureCaller.java",
+            """
+            package preview;
+            class SignatureCaller {
+                String call(SignatureTarget target) { return target.format("value"); }
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration, caller)
+        val tool = ChangeSignatureTool().also {
+            it.processorRunHook = { error("ChangeSignatureProcessor.run() must not be called by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-signature-src/preview/SignatureTarget.java")
+            put("line", 3)
+            put("column", 12)
+            put("newParameters", buildJsonArray {
+                add(buildJsonObject {
+                    put("oldIndex", 0)
+                    put("name", "input")
+                    put("type", "String")
+                })
+                add(buildJsonObject {
+                    put("oldIndex", -1)
+                    put("name", "uppercase")
+                    put("type", "boolean")
+                    put("defaultValue", "false")
+                })
+            })
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = true)
+        assertTrue(preview.getValue("usageCount").jsonPrimitive.int >= 1)
+        val affected = preview.getValue("affectedFiles").jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(affected.contains("dry-signature-src/preview/SignatureTarget.java"))
+        assertTrue(affected.contains("dry-signature-src/preview/SignatureCaller.java"))
+        assertBytesUnchanged(before)
+        assertProjectFileVfsDoesNotContain("dry-signature-src/preview/SignatureTarget.java", "uppercase")
+        assertProjectFileVfsDoesNotContain("dry-signature-src/preview/SignatureCaller.java", "false")
+    }
+
+    fun testChangeSignatureDryRunMetadataUsesUsagesFilteredByConflictExtension() = runBlocking {
+        registerSourceRoot("dry-signature-extension-src")
+        val declaration = writeProjectFile(
+            "dry-signature-extension-src/preview/ExtensionTarget.java",
+            """
+            package preview;
+            class ExtensionTarget { String format(String input) { return input; } }
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-signature-extension-src/preview/ExtensionCaller.java",
+            """
+            package preview;
+            class ExtensionCaller {
+                String call(ExtensionTarget target) { return target.format("value"); }
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration, caller)
+        val filteringProcessor = object : ChangeSignatureUsageProcessor {
+            override fun findUsages(changeInfo: ChangeInfo): Array<UsageInfo> = emptyArray()
+
+            override fun findConflicts(
+                changeInfo: ChangeInfo,
+                usages: Ref<Array<UsageInfo>>
+            ): MultiMap<PsiElement, String> {
+                usages.set(emptyArray())
+                return MultiMap.empty<PsiElement, String>()
+            }
+
+            override fun processUsage(
+                changeInfo: ChangeInfo,
+                usageInfo: UsageInfo,
+                beforeMethodChange: Boolean,
+                usages: Array<UsageInfo>
+            ): Boolean = true
+
+            override fun processPrimaryMethod(changeInfo: ChangeInfo): Boolean = true
+
+            override fun shouldPreviewUsages(
+                changeInfo: ChangeInfo,
+                usages: Array<UsageInfo>
+            ): Boolean = false
+
+            override fun setupDefaultValues(
+                changeInfo: ChangeInfo,
+                usages: Ref<Array<UsageInfo>>,
+                project: Project
+            ): Boolean = true
+
+            override fun registerConflictResolvers(
+                conflictResolvers: MutableList<in ResolveSnapshotProvider.ResolveSnapshot>,
+                resolveSnapshotProvider: ResolveSnapshotProvider,
+                usages: Array<UsageInfo>,
+                changeInfo: ChangeInfo
+            ) = Unit
+        }
+        ChangeSignatureUsageProcessor.EP_NAME.point.registerExtension(
+            filteringProcessor,
+            testRootDisposable
+        )
+
+        val result = ChangeSignatureTool().execute(project, buildJsonObject {
+            put("file", "dry-signature-extension-src/preview/ExtensionTarget.java")
+            put("line", 2)
+            put("column", 32)
+            put("newName", "render")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = true)
+        assertEquals(0, preview.getValue("usageCount").jsonPrimitive.int)
+        val affected = preview.getValue("affectedFiles").jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(affected.contains("dry-signature-extension-src/preview/ExtensionTarget.java"))
+        assertFalse(affected.contains("dry-signature-extension-src/preview/ExtensionCaller.java"))
+        assertBytesUnchanged(before)
+    }
+
+    fun testChangeSignaturePreviewAndApplyPreserveExistingThrowsForVisibilityChange() = runBlocking {
+        registerSourceRoot("dry-signature-throws-src")
+        val declaration = writeProjectFile(
+            "dry-signature-throws-src/preview/ThrowsTarget.java",
+            """
+            package preview;
+            import java.io.IOException;
+            class ThrowsTarget {
+                String work(String value) throws IOException { return value; }
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration)
+        val tool = ChangeSignatureTool()
+
+        val previewResult = tool.execute(project, buildJsonObject {
+            put("file", "dry-signature-throws-src/preview/ThrowsTarget.java")
+            put("line", 4)
+            put("column", 12)
+            put("newVisibility", "public")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(previewResult, expectedCanApply = true)
+        val plannedChange = preview.getValue("plannedChange").jsonObject
+        assertEquals("changeSignature", plannedChange.getValue("operation").jsonPrimitive.content)
+        assertEquals(
+            "package-private",
+            plannedChange.getValue("before").jsonObject.getValue("visibility").jsonPrimitive.content
+        )
+        assertEquals(
+            "public",
+            plannedChange.getValue("requested").jsonObject.getValue("newVisibility").jsonPrimitive.content
+        )
+        assertBytesUnchanged(before)
+        assertProjectFileVfsContains(
+            "dry-signature-throws-src/preview/ThrowsTarget.java",
+            "throws IOException"
+        )
+
+        val applyResult = tool.execute(project, buildJsonObject {
+            put("file", "dry-signature-throws-src/preview/ThrowsTarget.java")
+            put("line", 4)
+            put("column", 12)
+            put("newVisibility", "public")
+        })
+
+        assertToolSucceeded("Change Signature apply should preserve existing throws", applyResult)
+        assertProjectFileVfsContains(
+            "dry-signature-throws-src/preview/ThrowsTarget.java",
+            "public String work(String value) throws IOException"
+        )
+    }
+
+    fun testChangeSignatureDryRunWithNewParameterWithoutDefaultFailsClosed() = runBlocking {
+        registerSourceRoot("dry-signature-default-src")
+        val declaration = writeProjectFile(
+            "dry-signature-default-src/preview/DefaultTarget.java",
+            """
+            package preview;
+            class DefaultTarget { void format(String input) {} }
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-signature-default-src/preview/DefaultCaller.java",
+            """
+            package preview;
+            class DefaultCaller { void call(DefaultTarget target) { target.format("value"); } }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(declaration, caller)
+
+        val result = ChangeSignatureTool().execute(project, buildJsonObject {
+            put("file", "dry-signature-default-src/preview/DefaultTarget.java")
+            put("line", 2)
+            put("column", 35)
+            put("newParameters", buildJsonArray {
+                add(buildJsonObject {
+                    put("oldIndex", 0)
+                    put("name", "input")
+                    put("type", "String")
+                })
+                add(buildJsonObject {
+                    put("oldIndex", -1)
+                    put("name", "required")
+                    put("type", "boolean")
+                })
+            })
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "no explicit non-blank defaultValue")
+        assertBytesUnchanged(before)
+    }
+
+    fun testChangeSignatureDryRunWithCovariantOverriderFailsClosed() = runBlocking {
+        registerSourceRoot("dry-signature-overrider-src")
+        val source = writeProjectFile(
+            "dry-signature-overrider-src/preview/SignatureInheritance.java",
+            """
+            package preview;
+            class BaseSignature {
+                CharSequence value() { return "base"; }
+            }
+            class ChildSignature extends BaseSignature {
+                @Override String value() { return "child"; }
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(source)
+
+        val result = ChangeSignatureTool().execute(project, buildJsonObject {
+            put("file", "dry-signature-overrider-src/preview/SignatureInheritance.java")
+            put("line", 3)
+            put("column", 18)
+            put("newReturnType", "Object")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "covariant-overrider choice")
+        assertBytesUnchanged(before)
+    }
+
+    fun testDryRunDoesNotSaveAnUnrelatedDirtyDocument() = runBlocking {
+        registerSourceRoot("dry-dirty-src")
+        val target = writeProjectFile(
+            "dry-dirty-src/preview/DirtyTarget.java",
+            """
+            package preview;
+            class DirtyTarget { void work() {} }
+            """.trimIndent()
+        )
+        val unrelated = writeProjectFile(
+            "dry-dirty-src/preview/Unrelated.java",
+            """
+            package preview;
+            class Unrelated {}
+            """.trimIndent()
+        )
+        val targetBefore = snapshotBytes(target)
+        val originalDiskText = Files.readString(unrelated)
+        val virtualFile = requireNotNull(
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(unrelated.toString())
+        )
+        val document = ReadAction.compute<com.intellij.openapi.editor.Document, RuntimeException> {
+            requireNotNull(FileDocumentManager.getInstance().getDocument(virtualFile))
+        }
+        val dirtyText = "$originalDiskText\n// unsaved editor text"
+        val settings = McpSettings.getInstance()
+        val originalSyncSetting = settings.syncExternalChanges
+
+        try {
+            settings.syncExternalChanges = true
+            WriteAction.runAndWait<Throwable> { document.setText(dirtyText) }
+            assertTrue("Precondition: unrelated document must be dirty", FileDocumentManager.getInstance().isFileModified(virtualFile))
+
+            val result = RenameSymbolTool().execute(project, buildJsonObject {
+                put("file", "dry-dirty-src/preview/DirtyTarget.java")
+                put("line", 2)
+                put("column", 26)
+                put("newName", "renamedWork")
+                put("dryRun", true)
+            })
+
+            assertPreview(result, expectedCanApply = true)
+            assertEquals("Dry-run must retain unrelated in-memory text", dirtyText, document.text)
+            assertTrue("Dry-run must not save unrelated documents", FileDocumentManager.getInstance().isFileModified(virtualFile))
+            assertEquals("Dry-run must not write unrelated document to disk", originalDiskText, Files.readString(unrelated))
+            assertBytesUnchanged(targetBefore)
+        } finally {
+            settings.syncExternalChanges = originalSyncSetting
+            WriteAction.runAndWait<Throwable> { document.setText(originalDiskText) }
+            ApplicationManager.getApplication().invokeAndWait {
+                FileDocumentManager.getInstance().saveDocument(document)
+            }
+        }
+    }
+
+    fun testRenameDryRunRefreshesExternalUsageWhenAutoSyncEnabled() = runBlocking {
+        registerSourceRoot("dry-external-sync-src")
+        val target = writeProjectFile(
+            "dry-external-sync-src/preview/ExternalSyncTarget.java",
+            """
+            package preview;
+            class ExternalSyncTarget { void work() {} }
+            """.trimIndent()
+        )
+        val caller = writeProjectFile(
+            "dry-external-sync-src/preview/ExternalSyncCaller.java",
+            """
+            package preview;
+            class ExternalSyncCaller { void call() {} }
+            """.trimIndent()
+        )
+        val targetBefore = snapshotBytes(target)
+        val settings = McpSettings.getInstance()
+        val originalSyncSetting = settings.syncExternalChanges
+        val tool = RenameSymbolTool().also {
+            it.processorRunHook = { error("RenameProcessor.run() must not be called by dry-run") }
+        }
+        fun arguments() = buildJsonObject {
+            put("file", "dry-external-sync-src/preview/ExternalSyncTarget.java")
+            put("line", 2)
+            put("column", 37)
+            put("newName", "run")
+            put("dryRun", true)
+        }
+
+        try {
+            settings.syncExternalChanges = false
+            val baseline = assertPreview(tool.execute(project, arguments()), expectedCanApply = true)
+            assertEquals(0, baseline.getValue("usageCount").jsonPrimitive.int)
+
+            Files.writeString(
+                caller,
+                """
+                package preview;
+                class ExternalSyncCaller {
+                    void call() { new ExternalSyncTarget().work(); }
+                }
+                """.trimIndent()
+            )
+            val externallyWrittenBytes = Files.readAllBytes(caller)
+            settings.syncExternalChanges = true
+
+            val refreshed = assertPreview(tool.execute(project, arguments()), expectedCanApply = true)
+            assertTrue(refreshed.getValue("usageCount").jsonPrimitive.int >= 1)
+            assertTrue(
+                refreshed.getValue("affectedFiles").jsonArray
+                    .map { it.jsonPrimitive.content }
+                    .contains("dry-external-sync-src/preview/ExternalSyncCaller.java")
+            )
+            assertTrue(
+                "Dry-run must not rewrite the externally changed caller",
+                externallyWrittenBytes.contentEquals(Files.readAllBytes(caller))
+            )
+            assertBytesUnchanged(targetBefore)
+        } finally {
+            settings.syncExternalChanges = originalSyncSetting
+        }
+    }
+
+    fun testDryRunFailsClosedWhenUsageDiscoveryBreaks() = runBlocking {
+        val file = writeProjectFile(
+            "dry-fail-closed/FailureTarget.java",
+            """
+            class FailureTarget {
+                void work() {}
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(file)
+        val tool = RenameSymbolTool().also {
+            it.previewUsageSearchHook = { error("simulated index failure") }
+            it.processorRunHook = { error("RenameProcessor.run() must not be called by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-fail-closed/FailureTarget.java")
+            put("line", 2)
+            put("column", 10)
+            put("newName", "renamedWork")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        val warnings = preview.getValue("warnings").jsonArray.joinToString { it.jsonPrimitive.content }
+        assertTrue(warnings.contains("simulated index failure"))
+        assertBytesUnchanged(before)
+    }
+
+    fun testRenameBaseRethrowsProcessCancellationFromReflectiveDeepSuperLookup() = runBlocking {
+        val file = writeProjectFile(
+            "rename-base-cancel/Child.java",
+            """
+            class Base { void work() {} }
+            class Child extends Base { @Override void work() {} }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(file)
+        val tool = RenameSymbolTool().also {
+            it.deepestSuperMethodResolutionHook = {
+                throw InvocationTargetException(ProcessCanceledException())
+            }
+        }
+
+        val thrown = runCatching {
+            tool.execute(project, buildJsonObject {
+                put("file", "rename-base-cancel/Child.java")
+                put("line", 2)
+                put("column", 44)
+                put("newName", "renamedWork")
+                put("dryRun", true)
+            })
+        }.exceptionOrNull()
+
+        assertTrue("rename_base must propagate cancellation, got: $thrown", thrown is ProcessCanceledException)
+        assertBytesUnchanged(before)
+    }
+
+    fun testSafeDeleteDryRunFailsClosedWhenUsageDiscoveryBreaks() = runBlocking {
+        val file = writeProjectFile(
+            "dry-delete-fail-closed/DeleteFailureTarget.java",
+            """
+            class DeleteFailureTarget {
+                void doomed() {}
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(file)
+        val tool = SafeDeleteTool().also {
+            it.usageSearchHook = { error("simulated delete search failure") }
+            it.beforeDeletionHook = { error("Deletion write phase must not be reached by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-delete-fail-closed/DeleteFailureTarget.java")
+            put("line", 2)
+            put("column", 10)
+            put("force", true)
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "simulated delete search failure")
+        assertBytesUnchanged(before)
+    }
+
+    fun testFileSafeDeleteDryRunFailsClosedWhenUsageDiscoveryBreaks() = runBlocking {
+        registerSourceRoot("dry-file-delete-fail-src")
+        val target = writeProjectFile(
+            "dry-file-delete-fail-src/preview/FailedFileDelete.java",
+            """
+            package preview;
+            class FailedFileDelete {}
+            """.trimIndent()
+        )
+        val before = snapshotBytes(target)
+        val tool = SafeDeleteTool().also {
+            it.usageSearchHook = { error("simulated file delete search failure") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-file-delete-fail-src/preview/FailedFileDelete.java")
+            put("target_type", "file")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "simulated file delete search failure")
+        assertProjectFileExists("dry-file-delete-fail-src/preview/FailedFileDelete.java")
+        assertBytesUnchanged(before)
+    }
+
+    fun testChangeSignatureDryRunFailsClosedWhenUsageDiscoveryBreaks() = runBlocking {
+        val file = writeProjectFile(
+            "dry-signature-fail-closed/SignatureFailureTarget.java",
+            """
+            class SignatureFailureTarget {
+                void work() {}
+            }
+            """.trimIndent()
+        )
+        val before = snapshotBytes(file)
+        val tool = ChangeSignatureTool().also {
+            it.previewUsageSearchHook = { error("simulated signature search failure") }
+            it.processorRunHook = { error("ChangeSignatureProcessor.run() must not be called by dry-run") }
+        }
+
+        val result = tool.execute(project, buildJsonObject {
+            put("file", "dry-signature-fail-closed/SignatureFailureTarget.java")
+            put("line", 2)
+            put("column", 10)
+            put("newName", "renamedWork")
+            put("dryRun", true)
+        })
+
+        val preview = assertPreview(result, expectedCanApply = false)
+        assertPreviewWarningContains(preview, "simulated signature search failure")
+        assertBytesUnchanged(before)
+    }
+
+    private fun assertPreview(result: CallToolResult, expectedCanApply: Boolean): JsonObject {
+        assertToolSucceeded("Dry-run should return a preview payload", result)
+        val payload = Json.parseToJsonElement(toolText(result)).jsonObject
+        assertTrue(payload.getValue("dryRun").jsonPrimitive.boolean)
+        assertEquals(payload.toString(), expectedCanApply, payload.getValue("canApply").jsonPrimitive.boolean)
+        assertTrue(payload.containsKey("target"))
+        assertTrue(payload.containsKey("plannedChange"))
+        assertTrue(payload.containsKey("affectedFiles"))
+        assertTrue(payload.containsKey("usageCount"))
+        assertTrue(payload.containsKey("conflictCount"))
+        assertTrue(payload.containsKey("warnings"))
+        assertTrue(payload.containsKey("elapsedMs"))
+        return payload
+    }
+
+    private fun assertPreviewWarningContains(preview: JsonObject, expected: String) {
+        val warnings = preview.getValue("warnings").jsonArray.joinToString { it.jsonPrimitive.content }
+        assertTrue("Expected preview warning containing '$expected', got: $warnings", warnings.contains(expected))
+    }
+
+    private data class FileSnapshot(
+        val diskBytes: ByteArray,
+        val documentText: String
+    )
+
+    private fun snapshotBytes(vararg paths: Path): Map<Path, FileSnapshot> =
+        paths.associateWith { path ->
+            FileSnapshot(
+                diskBytes = Files.readAllBytes(path),
+                documentText = readProjectFileVfsUnderReadAction(path)
+            )
+        }
+
+    private fun assertBytesUnchanged(before: Map<Path, FileSnapshot>) {
+        for ((path, expected) in before) {
+            assertTrue(
+                "Dry-run changed bytes in $path",
+                expected.diskBytes.contentEquals(Files.readAllBytes(path))
+            )
+            assertEquals(
+                "Dry-run changed in-memory Document/VFS text in $path",
+                expected.documentText,
+                readProjectFileVfsUnderReadAction(path)
+            )
+        }
+    }
+
+    private fun readProjectFileVfsUnderReadAction(path: Path): String =
+        ReadAction.compute<String, RuntimeException> {
+            readProjectFileVfs(relativeProjectPath(path))
+        }
+
+    private fun assertProjectFileVfsContains(relativePath: String, expected: String) {
+        val text = ReadAction.compute<String, RuntimeException> { readProjectFileVfs(relativePath) }
+        assertTrue("Expected $relativePath to contain '$expected'", text.contains(expected))
+    }
+
+    private fun assertProjectFileVfsDoesNotContain(relativePath: String, unexpected: String) {
+        val text = ReadAction.compute<String, RuntimeException> { readProjectFileVfs(relativePath) }
+        assertFalse("Expected $relativePath not to contain '$unexpected'", text.contains(unexpected))
+    }
+
+    private fun relativeProjectPath(path: Path): String =
+        Path.of(requireNotNull(project.basePath)).relativize(path).toString()
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/RenameSymbolToolBehaviorTest.kt
@@ -1,11 +1,16 @@
 package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
 
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
 import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.intellij.openapi.application.ReadAction
 import com.intellij.psi.PsiElement
 import com.intellij.util.containers.MultiMap
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 class RenameSymbolToolBehaviorTest : McpPlatformTestCase() {
@@ -33,6 +38,7 @@ class RenameSymbolToolBehaviorTest : McpPlatformTestCase() {
     // ── Java: symbol rename ──
 
     fun testJavaRenameMethodUpdatesCallSitesWithinFile() = runBlocking {
+        registerSourceRoot("src")
         writeProjectFile(
             "src/UserService.java", """
             public class UserService {
@@ -59,7 +65,52 @@ class RenameSymbolToolBehaviorTest : McpPlatformTestCase() {
         assertFileContains("src/UserService.java", "return getFullName();")
     }
 
+    fun testRenameBaseDryRunDescribesAndBindsTheBaseMethod() = runBlocking {
+        registerSourceRoot("rename-base-preview-src")
+        writeProjectFile(
+            "rename-base-preview-src/previewbase/Base.java", """
+            package previewbase;
+
+            class Base {
+                void execute() {}
+            }
+            """.trimIndent()
+        )
+        writeProjectFile(
+            "rename-base-preview-src/previewbase/Child.java", """
+            package previewbase;
+
+            class Child extends Base {
+                @Override void execute() {}
+            }
+            """.trimIndent()
+        )
+
+        val result = RenameSymbolTool().execute(project, buildJsonObject {
+            put("file", "rename-base-preview-src/previewbase/Child.java")
+            put("targetType", "symbol")
+            put("line", 4)
+            put("column", 20)
+            put("newName", "run")
+            put("overrideStrategy", "rename_base")
+            put("dryRun", true)
+        })
+
+        assertToolSucceeded("rename_base preview should return a target", result)
+        val target = Json.parseToJsonElement(toolText(result)).jsonObject.getValue("target").jsonObject
+        assertEquals("execute", target.getValue("name").jsonPrimitive.content)
+        assertEquals("rename-base-preview-src/previewbase/Base.java", target.getValue("file").jsonPrimitive.content)
+
+        val resolved = ReadAction.compute<PsiElement, Throwable> {
+            SymbolIdRegistry.getInstance().resolve(project, target.getValue("symbolId").jsonPrimitive.content).getOrThrow()
+        }
+        assertEquals("Base.java", resolved.containingFile.name)
+        assertFileContains("rename-base-preview-src/previewbase/Base.java", "void execute()")
+        assertFileContains("rename-base-preview-src/previewbase/Child.java", "void execute()")
+    }
+
     fun testJavaRenameFieldUpdatesReferencesWithinFile() = runBlocking {
+        registerSourceRoot("src")
         writeProjectFile(
             "src/FieldRenameTarget.java", """
             public class FieldRenameTarget {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SafeDeleteToolBehaviorTest.kt
@@ -34,6 +34,8 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
 
     private fun decodeRefactoring(text: String): RefactoringResult = json.decodeFromString(text)
 
+    private fun decodePreview(text: String): RefactoringPreviewResult = json.decodeFromString(text)
+
     private fun decodeSymbolBlocked(text: String): SafeDeleteBlockedResult = json.decodeFromString(text)
 
     private fun decodeFileBlocked(text: String): SafeDeleteFileBlockedResult = json.decodeFromString(text)
@@ -234,6 +236,110 @@ class SafeDeleteToolBehaviorTest : McpPlatformTestCase() {
 
         assertFileContains("sd-blocked-src/blocked/PaymentGateway.java", "public String charge()")
         assertFileContains("sd-blocked-src/blocked/CheckoutService.java", "return gateway.charge();")
+    }
+
+    fun testBaseMethodWithOverrideIsBlockedWithoutOrdinaryReferences() = runBlocking {
+        registerSourceRoot("sd-override-src")
+        val basePath = "sd-override-src/overrides/BaseWorker.java"
+        val implementationPath = "sd-override-src/overrides/Worker.java"
+        val baseBefore = """
+            package overrides;
+
+            public abstract class BaseWorker {
+                public abstract void run();
+            }
+        """.trimIndent()
+        val implementationBefore = """
+            package overrides;
+
+            public final class Worker extends BaseWorker {
+                @Override
+                public void run() {}
+            }
+        """.trimIndent()
+        writeProjectFile(basePath, baseBefore)
+        writeProjectFile(implementationPath, implementationBefore)
+
+        val previewResult = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", basePath)
+            put("line", 4)
+            put("column", 26)
+            put("dryRun", true)
+        })
+
+        assertToolSucceeded("An unsafe preview is a structured result", previewResult)
+        val preview = decodePreview(toolText(previewResult))
+        assertFalse("An overriding implementation must block deleting its base declaration", preview.canApply)
+        assertTrue("The semantic override must count as a usage", preview.usageCount >= 1)
+        assertEquals(preview.usageCount, preview.conflictCount)
+        assertEquals(baseBefore, readProjectFileVfs(basePath))
+        assertEquals(implementationBefore, readProjectFileVfs(implementationPath))
+
+        val applyResult = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", basePath)
+            put("line", 4)
+            put("column", 26)
+        })
+        assertToolSucceeded("A blocked safe delete is a structured result", applyResult)
+        val blocked = decodeSymbolBlocked(toolText(applyResult))
+        assertFalse(blocked.canDelete)
+        assertTrue(blocked.blockingUsages.any { it.file == implementationPath })
+        assertEquals(baseBefore, readProjectFileVfs(basePath))
+        assertEquals(implementationBefore, readProjectFileVfs(implementationPath))
+    }
+
+    fun testParameterDeleteIsBlockedByCallSiteArgument() = runBlocking {
+        registerSourceRoot("sd-parameter-src")
+        val declarationPath = "sd-parameter-src/parameters/Calculator.java"
+        val callerPath = "sd-parameter-src/parameters/CalculatorUser.java"
+        val declarationBefore = """
+            package parameters;
+
+            public final class Calculator {
+                public int add(int left, int right) {
+                    return left + right;
+                }
+            }
+        """.trimIndent()
+        val callerBefore = """
+            package parameters;
+
+            public final class CalculatorUser {
+                public int total() {
+                    return new Calculator().add(1, 2);
+                }
+            }
+        """.trimIndent()
+        writeProjectFile(declarationPath, declarationBefore)
+        writeProjectFile(callerPath, callerBefore)
+
+        val previewResult = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", declarationPath)
+            put("line", 4)
+            put("column", 35)
+            put("dryRun", true)
+        })
+
+        assertToolSucceeded("An unsafe parameter preview is a structured result", previewResult)
+        val preview = decodePreview(toolText(previewResult))
+        assertFalse("A call-site argument must block literal parameter deletion", preview.canApply)
+        assertTrue("The call-site argument must count as a usage", preview.usageCount >= 1)
+        assertEquals(declarationBefore, readProjectFileVfs(declarationPath))
+        assertEquals(callerBefore, readProjectFileVfs(callerPath))
+
+        val applyResult = SafeDeleteTool().execute(project, buildJsonObject {
+            put("file", declarationPath)
+            put("line", 4)
+            put("column", 35)
+        })
+        assertToolSucceeded("A blocked parameter delete is a structured result", applyResult)
+        val blocked = decodeSymbolBlocked(toolText(applyResult))
+        assertFalse(blocked.canDelete)
+        assertTrue("Expected the caller among ${blocked.blockingUsages}", blocked.blockingUsages.any {
+            it.file == callerPath
+        })
+        assertEquals(declarationBefore, readProjectFileVfs(declarationPath))
+        assertEquals(callerBefore, readProjectFileVfs(callerPath))
     }
 
     fun testReferencedJavaFileIsRefusedAndTheReferencingFileIsReported() = runBlocking {

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SymbolIdRefactoringBehaviorTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/tools/refactoring/SymbolIdRefactoringBehaviorTest.kt
@@ -1,0 +1,364 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.refactoring
+
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.server.SymbolIdRegistry
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.testutil.McpPlatformTestCase
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.DefinitionResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.RefactoringResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.ResolvedSymbolInfo
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.models.SymbolInfoResult
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.FindDefinitionTool
+import com.github.hechtcarmel.jetbrainsindexmcpplugin.tools.navigation.SymbolInfoTool
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+class SymbolIdRefactoringBehaviorTest : McpPlatformTestCase() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun setUp() {
+        super.setUp()
+        SymbolIdRegistry.getInstance().resetSession()
+    }
+
+    override fun tearDown() {
+        try {
+            SymbolIdRegistry.getInstance().resetSession()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testChangeSignatureByIdReturnsReboundMetadataAndUpdatesCaller() = runBlocking {
+        registerSourceRoot("signature-id-src")
+        val declaration = """
+            package signatureid;
+            class Service {
+                int calculate(int input) { return input; }
+            }
+        """.trimIndent()
+        writeProjectFile("signature-id-src/signatureid/Service.java", declaration)
+        writeProjectFile(
+            "signature-id-src/signatureid/Caller.java",
+            """
+            package signatureid;
+            class Caller {
+                int call(Service service) { return service.calculate(1); }
+            }
+            """.trimIndent()
+        )
+        val definition = definitionAt("signature-id-src/signatureid/Service.java", declaration, "calculate")
+
+        val result = ChangeSignatureTool().execute(project, buildJsonObject {
+            put("symbolId", definition.symbolId)
+            put("newName", "compute")
+        })
+        assertToolSucceeded("change_signature should accept symbolId", result)
+        val payload = json.parseToJsonElement(toolText(result)).jsonObject
+        val updated = json.decodeFromJsonElement<ResolvedSymbolInfo>(payload.getValue("updatedSymbol"))
+        assertEquals(definition.symbolId, updated.symbolId)
+        assertEquals("compute", updated.name)
+        assertRenamedInFile("signature-id-src/signatureid/Service.java", "calculate", "compute")
+        assertRenamedInFile("signature-id-src/signatureid/Caller.java", "calculate", "compute")
+    }
+
+    fun testEditAndReplaceMemberByIdKeepHandleOnTheEditedDeclaration() = runBlocking {
+        val source = """
+            class EditableById {
+                int value() { return 1; }
+            }
+        """.trimIndent()
+        writeProjectFile("member-id-src/EditableById.java", source)
+        val definition = definitionAt("member-id-src/EditableById.java", source, "value")
+
+        val editResult = EditMemberTool().execute(project, buildJsonObject {
+            put("symbolId", definition.symbolId)
+            put("content", "long renamedValue() { return 2L; }")
+            put("reformat", false)
+        })
+        assertToolSucceeded("edit_member should accept symbolId", editResult)
+        val edit = decode<MemberEditResult>(editResult)
+        assertEquals(definition.symbolId, edit.updatedSymbol?.symbolId)
+        assertEquals("renamedValue", edit.updatedSymbol?.name)
+        assertFileContains("member-id-src/EditableById.java", "long renamedValue() { return 2L; }")
+        assertFileDoesNotContain("member-id-src/EditableById.java", "int value()")
+
+        val replaceResult = ReplaceMemberTool().execute(project, buildJsonObject {
+            put("symbolId", definition.symbolId)
+            put("content", "return 3L;")
+            put("reformat", false)
+        })
+        assertToolSucceeded("replace_member should reuse the rebound symbolId", replaceResult)
+        val replace = decode<MemberEditResult>(replaceResult)
+        assertEquals(definition.symbolId, replace.updatedSymbol?.symbolId)
+        assertEquals("renamedValue", replace.updatedSymbol?.name)
+        assertFileContains("member-id-src/EditableById.java", "return 3L;")
+        assertFileDoesNotContain("member-id-src/EditableById.java", "return 2L;")
+
+        val lookup = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", definition.symbolId) })
+        assertToolSucceeded("Edited member ID should remain usable", lookup)
+        assertTrue(toolText(lookup).contains("renamedValue"))
+    }
+
+    fun testNestedPositionEditsTheExactMemberWithoutLegacyMemberSelector() = runBlocking {
+        val source = """
+            class PositionTarget {
+                int first() { return 1; }
+                int second() { return 2; }
+            }
+        """.trimIndent()
+        val file = "member-position-src/PositionTarget.java"
+        writeProjectFile(file, source)
+
+        val editResult = EditMemberTool().execute(project, nestedPositionArguments(file, source, "second()" ) {
+            put("content", "long renamedSecond() { return 20L; }")
+            put("reformat", false)
+        })
+        assertToolSucceeded("edit_member nested position should identify second exactly", editResult)
+        assertFileContains(file, "int first() { return 1; }")
+        assertFileContains(file, "long renamedSecond() { return 20L; }")
+
+        val edited = readProjectFileVfs(file)
+        val replaceResult = ReplaceMemberTool().execute(project, nestedPositionArguments(file, edited, "renamedSecond()") {
+            put("content", "return 30L;")
+            put("reformat", false)
+        })
+        assertToolSucceeded("replace_member nested position should identify renamed member exactly", replaceResult)
+        assertFileContains(file, "int first() { return 1; }")
+        assertFileContains(file, "return 30L;")
+    }
+
+    fun testInvalidFullReplacementsLeaveSourceAndOriginalMethodHandleUnchanged() = runBlocking {
+        val source = """
+            class RejectInvalidReplacement {
+                int original() { return 1; }
+                int survivor() { return 2; }
+            }
+        """.trimIndent()
+        val file = "member-invalid-src/RejectInvalidReplacement.java"
+        writeProjectFile(file, source)
+        val original = definitionAt(file, source, "original()")
+        val invalidReplacements = listOf(
+            "/* removed */",
+            "// removed",
+            "int first() { return 3; } int second() { return 4; }",
+            "class Nested {}",
+            "RejectInvalidReplacement() {}",
+            "int incomplete( { return 3; }",
+            "int renamed() { return 3; } /* unterminated"
+        )
+
+        for (replacement in invalidReplacements) {
+            val result = EditMemberTool().execute(project, buildJsonObject {
+                put("symbolId", original.symbolId)
+                put("content", replacement)
+                put("reformat", false)
+            })
+            assertToolFailed("Invalid replacement must be rejected before editing: $replacement", result)
+            assertTrue(toolText(result).contains("exactly one complete method declaration"))
+            assertEquals("A rejected edit must preserve every byte: $replacement", source, readProjectFileVfs(file))
+
+            val lookup = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", original.symbolId) })
+            assertToolSucceeded("Rejected edit must retain the original method handle: $replacement", lookup)
+            val symbol = decode<SymbolInfoResult>(lookup)
+            assertEquals(original.symbolId, symbol.symbolId)
+            assertEquals("original", symbol.name)
+        }
+    }
+
+    fun testCommentedAnnotatedReplacementKeepsExactHandleThroughFormattingAndNestedDeclarations() = runBlocking {
+        val source = """
+            class AnnotatedReplacement {
+                int original() { return 1; }
+                int survivor() { return 2; }
+            }
+        """.trimIndent()
+        val file = "member-comments-src/AnnotatedReplacement.java"
+        writeProjectFile(file, source)
+        val original = definitionAt(file, source, "original()")
+        val replacement = """
+            /* before the declaration */
+            /** Updated implementation. */
+            @Deprecated
+            long renamed(int input) {
+                class Local { long nested() { return 3L; } }
+                return new Local().nested() + input;
+            }
+            /* after the declaration */
+        """.trimIndent()
+
+        val result = EditMemberTool().execute(project, buildJsonObject {
+            put("symbolId", original.symbolId)
+            put("content", replacement)
+            put("reformat", true)
+        })
+        assertToolSucceeded("Comments and nested declarations must not hide the exact replacement", result)
+        val edit = decode<MemberEditResult>(result)
+        assertEquals(original.symbolId, edit.updatedSymbol?.symbolId)
+        assertEquals("renamed", edit.updatedSymbol?.name)
+        assertFileContains(file, "before the declaration")
+        assertFileContains(file, "Updated implementation.")
+        assertFileContains(file, "@Deprecated")
+        assertFileContains(file, "class Local")
+        assertFileContains(file, "after the declaration")
+        assertFileContains(file, "int survivor()")
+        assertFileDoesNotContain(file, "int original()")
+
+        val replaceResult = ReplaceMemberTool().execute(project, buildJsonObject {
+            put("symbolId", original.symbolId)
+            put("content", "return 40L;")
+            put("reformat", false)
+        })
+        assertToolSucceeded("The rebound handle must edit the outer replacement method", replaceResult)
+        assertFileContains(file, "long renamed(int input)")
+        assertFileContains(file, "return 40L;")
+        assertFileContains(file, "int survivor()")
+        assertFileDoesNotContain(file, "class Local")
+    }
+
+    fun testFullClassReplacementKeepsClassHandleAcrossInterfaceConversion() = runBlocking {
+        val source = """
+            class OriginalClass {
+                int value() { return 1; }
+            }
+            class UnchangedSibling {}
+        """.trimIndent()
+        val file = "member-class-id-src/OriginalClass.java"
+        writeProjectFile(file, source)
+        val original = definitionAt(file, source, "OriginalClass")
+
+        val result = EditMemberTool().execute(project, buildJsonObject {
+            put("symbolId", original.symbolId)
+            put("content", "/** Replacement type. */ interface RenamedType<T> { T value(); class Nested {} }")
+            put("reformat", false)
+        })
+        assertToolSucceeded("A class declaration may be replaced by an interface with nested members", result)
+        val edit = decode<MemberEditResult>(result)
+        assertEquals(original.symbolId, edit.updatedSymbol?.symbolId)
+        assertEquals("RenamedType", edit.updatedSymbol?.name)
+        assertFileContains(file, "interface RenamedType<T>")
+        assertFileContains(file, "class Nested")
+        assertFileContains(file, "class UnchangedSibling {}")
+        assertFileDoesNotContain(file, "class OriginalClass")
+
+        val lookup = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", original.symbolId) })
+        assertToolSucceeded("Converted class handle must identify the replacement interface", lookup)
+        assertEquals("RenamedType", decode<SymbolInfoResult>(lookup).name)
+    }
+
+    fun testFullFieldReplacementKeepsHandleOnRenamedField() = runBlocking {
+        val source = """
+            class FieldReplacement {
+                int original = 1;
+                int survivor = 2;
+            }
+        """.trimIndent()
+        val file = "member-field-id-src/FieldReplacement.java"
+        writeProjectFile(file, source)
+        val original = definitionAt(file, source, "original")
+
+        for (replacement in listOf("long first = 3L, second = 4L;", "long first = 3L; long second = 4L;")) {
+            val rejected = EditMemberTool().execute(project, buildJsonObject {
+                put("symbolId", original.symbolId)
+                put("content", replacement)
+                put("reformat", false)
+            })
+            assertToolFailed("A single field ID must not be rebound to several replacement fields", rejected)
+            assertEquals(source, readProjectFileVfs(file))
+        }
+
+        val result = EditMemberTool().execute(project, buildJsonObject {
+            put("symbolId", original.symbolId)
+            put("content", "/** Replaced field. */ @Deprecated long renamed = 3L; /* preserved */")
+            put("reformat", false)
+        })
+        assertToolSucceeded("A field replacement should preserve exact identity", result)
+        val edit = decode<MemberEditResult>(result)
+        assertEquals(original.symbolId, edit.updatedSymbol?.symbolId)
+        assertEquals("renamed", edit.updatedSymbol?.name)
+
+        val replaceResult = ReplaceMemberTool().execute(project, buildJsonObject {
+            put("symbolId", original.symbolId)
+            put("content", "4L")
+            put("reformat", false)
+        })
+        assertToolSucceeded("The field handle must select its replacement initializer", replaceResult)
+        assertFileContains(file, "long renamed = 4L;")
+        assertFileContains(file, "int survivor = 2;")
+        assertFileContains(file, "/* preserved */")
+        assertFileDoesNotContain(file, "int original")
+    }
+
+    fun testSafeDeleteByIdReturnsInvalidatedIdAndFurtherLookupsExpire() = runBlocking {
+        registerSourceRoot("safe-delete-id-src")
+        val source = """
+            class SafeDeleteById {
+                void doomed() {}
+                void survivor() {}
+            }
+        """.trimIndent()
+        writeProjectFile("safe-delete-id-src/SafeDeleteById.java", source)
+        val definition = definitionAt("safe-delete-id-src/SafeDeleteById.java", source, "doomed")
+
+        val deleteResult = SafeDeleteTool().execute(project, buildJsonObject {
+            put("symbolId", definition.symbolId)
+            put("force", true)
+        })
+        assertToolSucceeded("safe_delete should accept symbolId", deleteResult)
+        val deleted = decode<RefactoringResult>(deleteResult)
+        assertEquals(definition.symbolId, deleted.invalidatedSymbolId)
+        assertFileDoesNotContain("safe-delete-id-src/SafeDeleteById.java", "doomed")
+        assertFileContains("safe-delete-id-src/SafeDeleteById.java", "survivor")
+
+        val lookup = SymbolInfoTool().execute(project, buildJsonObject { put("symbolId", definition.symbolId) })
+        assertToolFailed("Safe-deleted symbol ID must be invalidated", lookup)
+        assertTrue(toolText(lookup).contains("SYMBOL_ID_EXPIRED"))
+    }
+
+    private suspend fun definitionAt(file: String, source: String, marker: String): DefinitionResult {
+        val result = FindDefinitionTool().execute(project, positionArguments(file, source, marker))
+        assertToolSucceeded("find_definition at $file / $marker", result)
+        return decode(result)
+    }
+
+    private fun positionArguments(file: String, source: String, marker: String): JsonObject {
+        val offset = source.indexOf(marker)
+        require(offset >= 0) { "Marker '$marker' is absent from fixture" }
+        val lineStart = source.lastIndexOf('\n', offset - 1) + 1
+        return buildJsonObject {
+            put("file", file)
+            put("line", source.substring(0, offset).count { it == '\n' } + 1)
+            put("column", offset - lineStart + 1)
+        }
+    }
+
+    private fun nestedPositionArguments(
+        file: String,
+        source: String,
+        marker: String,
+        extras: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit
+    ): JsonObject {
+        val offset = source.indexOf(marker)
+        require(offset >= 0) { "Marker '$marker' is absent from fixture" }
+        val lineStart = source.lastIndexOf('\n', offset - 1) + 1
+        return buildJsonObject {
+            putJsonObject("target") {
+                putJsonObject("position") {
+                    put("file", file)
+                    put("line", source.substring(0, offset).count { it == '\n' } + 1)
+                    put("column", offset - lineStart + 1)
+                }
+            }
+            extras()
+        }
+    }
+
+    private inline fun <reified T> decode(result: CallToolResult): T =
+        json.decodeFromString(toolText(result))
+}

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/IdeStructureViewExtractorUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/IdeStructureViewExtractorUnitTest.kt
@@ -92,6 +92,19 @@ class IdeStructureViewExtractorUnitTest : TestCase() {
         assertTrue(nodes.isEmpty())
     }
 
+    fun testConvertTreeElementsCarriesTheExactPsiTargetIntoTheNode() {
+        val physicalMethod = mockk<PsiElement>(relaxed = true)
+        val method = FakeTreeElement("save()", physicalMethod)
+
+        val nodes = IdeStructureViewExtractor.convertTreeElements(
+            elements = arrayOf(method),
+            classifier = SyntheticPsiClassifier,
+            lineResolver = { 17 }
+        )
+
+        assertSame(physicalMethod, nodes.single().pointerTarget)
+    }
+
     private object TestClassifier : IdeStructureViewExtractor.Classifier {
         override fun describe(
             value: Any?,

--- a/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/KotlinClassMetadataUnitTest.kt
+++ b/src/test/kotlin/com/github/hechtcarmel/jetbrainsindexmcpplugin/util/KotlinClassMetadataUnitTest.kt
@@ -1,0 +1,77 @@
+package com.github.hechtcarmel.jetbrainsindexmcpplugin.util
+
+import junit.framework.TestCase
+
+/** Headless coverage for Kotlin PSI metadata accessed through reflection. */
+class KotlinClassMetadataUnitTest : TestCase() {
+
+    fun testReflectiveKotlinClassKindUsesSemanticFlags() {
+        assertEquals("CLASS", classify(ReflectiveKtClassFake()))
+        assertEquals("INTERFACE", classify(ReflectiveKtClassFake(isInterface = true)))
+        assertEquals("ENUM", classify(ReflectiveKtClassFake(isEnum = true)))
+        assertEquals("ANNOTATION", classify(ReflectiveKtClassFake(isAnnotation = true)))
+        assertEquals(
+            "Annotation must win if a PSI implementation also presents as an interface",
+            "ANNOTATION",
+            classify(ReflectiveKtClassFake(isInterface = true, isAnnotation = true))
+        )
+        assertEquals("OBJECT", classify(ReflectiveKtObjectDeclarationFake()))
+    }
+
+    fun testReflectiveKotlinClassKindRejectsUnrelatedObjects() {
+        assertNull(
+            PsiUtils.reflectiveKotlinClassKind(
+                element = Any(),
+                ktClassType = ReflectiveKtClassFake::class.java,
+                ktObjectDeclarationType = ReflectiveKtObjectDeclarationFake::class.java
+            )
+        )
+    }
+
+    fun testReflectiveQualifiedNameUsesKotlinGetFqName() {
+        val declaration = ReflectiveKtNamedDeclarationFake(
+            ReflectiveFqNameFake("com.example.payments.PaymentService")
+        )
+
+        assertEquals(
+            "com.example.payments.PaymentService",
+            PsiUtils.reflectiveQualifiedName(declaration)
+        )
+    }
+
+    fun testReflectiveQualifiedNameTreatsMissingOrBlankKotlinFqNameAsAbsent() {
+        assertNull(PsiUtils.reflectiveQualifiedName(ReflectiveKtNamedDeclarationFake(null)))
+        assertNull(
+            PsiUtils.reflectiveQualifiedName(
+                ReflectiveKtNamedDeclarationFake(ReflectiveFqNameFake(""))
+            )
+        )
+    }
+
+    private fun classify(element: Any): String? =
+        PsiUtils.reflectiveKotlinClassKind(
+            element = element,
+            ktClassType = ReflectiveKtClassFake::class.java,
+            ktObjectDeclarationType = ReflectiveKtObjectDeclarationFake::class.java
+        )
+}
+
+internal open class ReflectiveKtClassFake(
+    private val isInterface: Boolean = false,
+    private val isEnum: Boolean = false,
+    private val isAnnotation: Boolean = false
+) {
+    fun isInterface(): Boolean = isInterface
+    fun isEnum(): Boolean = isEnum
+    fun isAnnotation(): Boolean = isAnnotation
+}
+
+internal class ReflectiveKtObjectDeclarationFake
+
+internal class ReflectiveKtNamedDeclarationFake(private val fqName: Any?) {
+    fun getFqName(): Any? = fqName
+}
+
+internal class ReflectiveFqNameFake(private val value: String) {
+    override fun toString(): String = value
+}

--- a/src/test/resources/contract/result-shapes.txt
+++ b/src/test/resources/contract/result-shapes.txt
@@ -1,6 +1,6 @@
 # MCP tool response shapes — golden snapshot
 # Regenerate: ./gradlew test -Ptier=unit --tests "*ResultShapeContractUnitTest" -Dcontract.update=true
-# shapes: 69
+# shapes: 73
 
 ## ActiveFileInfo
   column: number?
@@ -41,10 +41,16 @@
   language: string? (optional)
   line: number
   name: string
+  symbolId: string? (optional)
 
 ## CallHierarchyResult
   calls: array
+  cursor: string? (optional)
+  elapsedMs: number (optional)
   element: object
+  hasMore: boolean (optional)
+  returnedNodes: number (optional)
+  truncated: boolean (optional)
 
 ## ChangeSignatureTool.ChangeSignatureResult
   affectedFiles: array (optional)
@@ -52,6 +58,7 @@
   file: string
   message: string
   success: boolean
+  updatedSymbol: object? (optional)
 
 ## ConversionStatus (enum)
   CONVERTED -> "CONVERTED"
@@ -75,6 +82,7 @@
   file: string
   line: number
   preview: string
+  symbolId: string
   symbolName: string
 
 ## DiagnosticsResult
@@ -87,10 +95,12 @@
   buildErrorsTruncated: boolean? (optional)
   buildTimestamp: number? (optional)
   buildWarningCount: number? (optional)
+  fileAnalyses: array? (optional)
   intentionCount: number? (optional)
   intentions: array? (optional)
   problemCount: number? (optional)
   problems: array? (optional)
+  problemsTruncated: boolean? (optional)
   testResults: array? (optional)
   testResultsTruncated: boolean? (optional)
   testSummary: object? (optional)
@@ -108,6 +118,15 @@
   reason: string? (optional)
   state: string
 
+## FileDiagnosticsAnalysis
+  file: string
+  fresh: boolean
+  message: string? (optional)
+  mode: string? (optional)
+  problemCount: number (optional)
+  problemsTruncated: boolean (optional)
+  timedOut: boolean
+
 ## FileMatch
   directory: string
   name: string
@@ -116,7 +135,10 @@
 ## FileStructureResult
   file: string
   language: string
+  nodes: array (optional)
   structure: string
+  symbolIdsOmitted: number (optional)
+  symbolIdsTruncated: boolean (optional)
 
 ## FindClassResult
   classes: array
@@ -174,6 +196,8 @@
   language: string? (optional)
   line: number
   name: string
+  qualifiedName: string? (optional)
+  symbolId: string? (optional)
 
 ## ImplementationResult
   hasMore: boolean (optional)
@@ -223,6 +247,7 @@
   message: string
   startLine: number? (optional)
   success: boolean
+  updatedSymbol: object? (optional)
 
 ## MemberErrorResult
   candidates: array? (optional)
@@ -238,6 +263,7 @@
   line: number
   name: string
   signature: string
+  symbolId: string? (optional)
 
 ## NoSymbolFoundResult
   error: string
@@ -308,12 +334,25 @@
   lineCount: number
   startLine: number?
 
+## RefactoringPreviewResult
+  affectedFiles: array
+  canApply: boolean
+  conflictCount: number
+  dryRun: boolean (optional)
+  elapsedMs: number
+  plannedChange: object
+  target: object
+  usageCount: number
+  warnings: array
+
 ## RefactoringResult
   affectedFiles: array
   changesCount: number
+  invalidatedSymbolId: string? (optional)
   message: string
   success: boolean
   unretargetedImporters: array? (optional)
+  updatedSymbol: object? (optional)
   warnings: array? (optional)
 
 ## ReplaceTextInFileTool.ReplaceTextResult
@@ -322,6 +361,17 @@
   message: string
   replacements: number
   success: boolean
+
+## ResolvedSymbolInfo
+  column: number? (optional)
+  container: string?
+  file: string?
+  kind: string?
+  language: string? (optional)
+  line: number?
+  name: string?
+  qualifiedName: string? (optional)
+  symbolId: string
 
 ## RunTestsInProgressResult
   configName: string
@@ -349,6 +399,7 @@
   elementName: string
   elementType: string
   message: string
+  symbolId: string? (optional)
   usageCount: number
 
 ## SafeDeleteFileBlockedResult
@@ -414,6 +465,7 @@
   modifiers: array
   name: string
   signature: string?
+  symbolId: string? (optional)
 
 ## SuperMethodInfo
   column: number?
@@ -426,6 +478,7 @@
   line: number?
   name: string
   signature: string
+  symbolId: string? (optional)
 
 ## SuperMethodsResult
   hierarchy: array
@@ -454,6 +507,7 @@
   returnType: string? (optional)
   signature: string
   signatureSource: string
+  symbolId: string
   thrownTypes: array? (optional)
   typeParameters: array? (optional)
   visibility: string? (optional)
@@ -467,6 +521,7 @@
   line: number
   name: string
   qualifiedName: string?
+  symbolId: string
 
 ## SymbolParameterInfo
   name: string?
@@ -480,7 +535,10 @@
   type: string
 
 ## SyncFilesResult
+  deletedPaths: array (optional)
   message: string
+  refreshedRoots: array (optional)
+  requestedPaths: array (optional)
   syncedAll: boolean
   syncedPaths: array
 
@@ -535,11 +593,22 @@
   language: string? (optional)
   name: string
   supertypes: array? (optional)
+  symbolId: string? (optional)
 
 ## TypeHierarchyResult
+  cursor: string? (optional)
+  elapsedMs: number (optional)
   element: object
+  hasMore: boolean (optional)
+  returnedNodes: number (optional)
   subtypes: array
   supertypes: array
+  traversal: array (optional)
+  truncated: boolean (optional)
+
+## TypeHierarchyTraversalNode
+  direction: string
+  element: object
 
 ## UsageInfo
   column: number

--- a/src/test/resources/contract/tool-manifest.json
+++ b/src/test/resources/contract/tool-manifest.json
@@ -68,13 +68,14 @@ description:
   
   Rust note: "callers" direction works well; "callees" direction may have limited results due to Rust plugin PSI resolution constraints.
   
-  Returns: recursive tree with method signatures, file locations (line/column), and nested call relationships.
+  Returns deterministic breadth-first pages with method signatures, file locations, symbolId handles, and pagination metadata. Live progress is not available on stateless HTTP; continue with cursor.
   
   Target (mutually exclusive):
+  - symbolId: opaque handle returned by a previous semantic call
   - file + line + column: position-based lookup
   - language + symbol: fully qualified symbol reference (supported languages: Java, Kotlin, JavaScript, TypeScript)
   
-  Parameters: direction (required): "callers" or "callees". depth (optional, default: 3, max: 5). scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files).
+  Parameters: direction (required for a fresh query): "callers" or "callees". depth (optional, default: 3, max: 5), maxNodes (optional, default: 20 on a fresh query and 100 with cursor, max: 500), cursor (continuation page), scope (optional).
   
   Example: {"file": "src/Service.java", "line": 42, "column": 10, "direction": "callers"}
   Example: {"language": "Java", "symbol": "com.example.Service#processRequest(String)", "direction": "callers", "scope": "project_and_libraries"}
@@ -89,6 +90,11 @@ schema:
         "description": "1-based column number",
         "type": "integer"
       },
+      "cursor":
+      {
+        "description": "Opaque session/project-bound continuation from the previous hierarchy page. Other search parameters are ignored.",
+        "type": "string"
+      },
       "depth":
       {
         "description": "How many levels deep to traverse the call hierarchy (default: 3, max: 5)",
@@ -96,7 +102,7 @@ schema:
       },
       "direction":
       {
-        "description": "Direction: 'callers' (methods that call this method) or 'callees' (methods this method calls)",
+        "description": "Direction for a fresh query: 'callers' or 'callees'. Omit when cursor is provided.",
         "enum":
         [
           "callers",
@@ -131,6 +137,11 @@ schema:
         "description": "1-based line number",
         "type": "integer"
       },
+      "maxNodes":
+      {
+        "description": "Maximum hierarchy nodes returned and expanded in this page. Default: 20 on a fresh query and 100 with cursor; max: 500.",
+        "type": "integer"
+      },
       "project_path":
       {
         "description": "Absolute path to the project root. Required when multiple projects are open. For workspace projects, use the sub-project path.",
@@ -152,12 +163,64 @@ schema:
       {
         "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
         "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
-    "required":
-    [
-      "direction"
-    ],
     "type": "object"
   }
 
@@ -169,6 +232,7 @@ description:
   New parameters get a default value inserted at all call sites.
   
   Examples:
+  - By handle: {"symbolId": "<opaque-id>", "newName": "renamed"}
   - Add parameter: {"file": "src/Service.java", "line": 15, "column": 10, "newParameters": [{"oldIndex": 0, "name": "id", "type": "String"}, {"oldIndex": -1, "name": "validate", "type": "boolean", "defaultValue": "true"}]}
   - Change return type: {"file": "src/Service.java", "line": 15, "column": 10, "newReturnType": "Optional<User>"}
 schema:
@@ -180,15 +244,32 @@ schema:
         "description": "1-based column number",
         "type": "integer"
       },
+      "dryRun":
+      {
+        "description": "Resolve and validate the method, then discover usages/conflicts without modifying files. Default: false.",
+        "type": "boolean"
+      },
       "file":
       {
-        "description": "Path to file containing the method. REQUIRED.",
+        "description": "Path to file containing the method. Required with line+column; omit when symbolId is used.",
         "type": "string"
       },
       "generateDelegate":
       {
         "description": "Generate a delegation method with the old signature. Default: false.",
         "type": "boolean"
+      },
+      "language":
+      {
+        "description": "Language of the symbol. Required when using 'symbol' parameter. Currently supported languages: Java, Kotlin, JavaScript, TypeScript.",
+        "enum":
+        [
+          "Java",
+          "Kotlin",
+          "JavaScript",
+          "TypeScript"
+        ],
+        "type": "string"
       },
       "line":
       {
@@ -223,14 +304,69 @@ schema:
       {
         "description": "Absolute path to the project root. Required when multiple projects are open. For workspace projects, use the sub-project path.",
         "type": "string"
+      },
+      "symbol":
+      {
+        "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
+        "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
-    "required":
-    [
-      "file",
-      "line",
-      "column"
-    ],
     "type": "object"
   }
 
@@ -366,15 +502,15 @@ schema:
 description:
   Get code diagnostics from multiple sources: file analysis (errors, warnings, intentions), build output (compiler errors/warnings from last build), and test results (from open test run tabs).
   
-  Returns: problems with severity and location, available intentions/quick fixes, build errors, and test results with error messages and stack traces. The analysisMode field reports which provider produced the file problems: "open_daemon" (file open in an editor) or "closed_batch" (public batch analysis); null when no analysis ran.
+  Returns: problems with severity and location, available intentions/quick fixes, build errors, and test results with error messages and stack traces. Single-file calls report legacy top-level analysis metadata. Multi-file calls return one aggregate problems list plus fileAnalyses entries with mode, freshness, timeout, message, returned problemCount, and problemsTruncated metadata for each file. Code problems share a 100-item response cap; top-level problemsTruncated reports omitted problems. Fresh analysis does not imply complete output: re-query truncated files individually, narrowing startLine/endLine if needed.
   
-  At least one source must be active: provide 'file' for code analysis, 'includeBuildErrors' for build output, or 'includeTestResults' for test results. Can combine all three.
+  At least one source must be active: provide exactly one of 'file' or 'files' for code analysis, 'includeBuildErrors' for build output, or 'includeTestResults' for test results. Can combine file analysis with build and test results. A multi-file call accepts at most 100 supplied paths, all sharing one analysis timeout budget; lexical aliases are analyzed only once.
   
   File analysis uses fresh daemon highlights for files that are already open in an editor. Closed files use public batch analysis, so weak warnings and quick-fix intentions may be less complete unless the file is open. The analyzed file is re-read from disk first, so results reflect edits made outside the IDE without calling ide_sync_files. For diagnostics across many files or the whole project with per-file coverage metadata, use ide_project_diagnostics.
   
-  Parameters: file (optional, enables code analysis), line + column (optional, for intentions, requires file), startLine/endLine (optional, requires file), includeBuildErrors (optional), includeTestResults (optional), severity (optional, default 'all'), testResultFilter (optional, default 'failed'), maxBuildErrors (optional, default 100), maxTestResults (optional, default 100).
+  Parameters: file or files (mutually exclusive, enable code analysis), line + column (optional, for intentions, single file only), startLine/endLine (optional, single file only), includeBuildErrors (optional), includeTestResults (optional), severity (optional, default 'all'), testResultFilter (optional, default 'failed'), maxBuildErrors (optional, default 100), maxTestResults (optional, default 100).
   
-  Example: {"file": "src/MyClass.java"} or {"includeBuildErrors": true, "severity": "errors"} or {"file": "src/MyClass.java", "includeBuildErrors": true, "includeTestResults": true}
+  Example: {"file": "src/MyClass.java"} or {"files": ["src/A.java", "src/B.java"]} or {"includeBuildErrors": true, "severity": "errors"}
 schema:
   {
     "properties":
@@ -393,6 +529,18 @@ schema:
       {
         "description": "Path to file relative to project root (e.g., 'src/main/java/com/example/MyClass.java'). Optional — enables per-file code analysis.",
         "type": "string"
+      },
+      "files":
+      {
+        "description": "Project-relative file paths to analyze under one shared timeout budget (max 100). Mutually exclusive with 'file'.",
+        "items":
+        {
+          "type": "string"
+        },
+        "maxItems": 100,
+        "minItems": 1,
+        "type": "array",
+        "uniqueItems": true
       },
       "includeBuildErrors":
       {
@@ -466,9 +614,13 @@ description:
   {"file": "src/Worker.java", "class": "Worker", "member": "Worker", "content": "public interface Worker<T> extends Runnable { ... }"}
   
   The content should be the complete replacement including modifiers, type, name, and body.
+  It must contain exactly one syntactically valid declaration of the original category,
+  optionally surrounded by comments. Nested declarations are allowed. Invalid or ambiguous
+  content is rejected before editing; use ide_refactor_safe_delete for deletion.
   Auto-reformats the changed range by default.
   
   Examples:
+  - {"symbolId": "<opaque-id>", "content": "public void renamed() {}"}
   - {"file": "src/Main.java", "class": "Main", "member": "process", "content": "public void process(String input, boolean validate) {\n    if (validate) check(input);\n}"}
   - {"file": "src/Config.kt", "class": "Config", "member": "timeout", "content": "val timeout: Duration = Duration.ofSeconds(30)"}
   - {"file": "src/Service.java", "member": "Service", "content": "public class Service<T> implements Serializable { ... }"}
@@ -483,12 +635,24 @@ schema:
       },
       "content":
       {
-        "description": "The complete replacement member declaration including modifiers, type, name, and body.",
+        "description": "Exactly one complete, syntactically valid declaration of the original category, including modifiers, type, name, and body. Surrounding comments are allowed.",
         "type": "string"
       },
       "file":
       {
-        "description": "Path to file relative to project root. REQUIRED.",
+        "description": "Path to file relative to project root. Required with member selectors; omit when symbolId is used.",
+        "type": "string"
+      },
+      "language":
+      {
+        "description": "Language of the symbol. Required when using 'symbol' parameter. Currently supported languages: Java, Kotlin, JavaScript, TypeScript.",
+        "enum":
+        [
+          "Java",
+          "Kotlin",
+          "JavaScript",
+          "TypeScript"
+        ],
         "type": "string"
       },
       "line":
@@ -498,7 +662,7 @@ schema:
       },
       "member":
       {
-        "description": "Name of the method, function, field, or property to replace entirely.",
+        "description": "Name of the method, function, field, or property to replace entirely. Required unless symbolId is used.",
         "type": "string"
       },
       "parameterCount":
@@ -515,12 +679,71 @@ schema:
       {
         "description": "Auto-reformat the changed range and optimize imports. Default: true.",
         "type": "boolean"
+      },
+      "symbol":
+      {
+        "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
+        "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "required":
     [
-      "file",
-      "member",
       "content"
     ],
     "type": "object"
@@ -556,7 +779,10 @@ description:
   
   Supports: Java, Kotlin, Python, JavaScript, TypeScript, PHP, Markdown
   
-  Returns: Formatted tree string with element types, modifiers, signatures, and line numbers.
+  Returns: The legacy formatted tree string plus structured nodes with element types,
+  modifiers, signatures, source ranges, children, and optional symbolId handles. All nodes
+  are returned; at most 500 handles are allocated per response. symbolIdsTruncated and
+  symbolIdsOmitted report nodes whose optional handle was omitted by this budget.
   
   Parameters: file (required) - Path relative to project root
   
@@ -668,6 +894,7 @@ description:
   Returns: file path, line/column of definition, code preview, and symbol name.
   
   Target (mutually exclusive):
+  - symbolId: opaque handle returned by a previous semantic call
   - file + line + column: position-based lookup
   - language + symbol: fully qualified symbol reference (supported languages: Java, Kotlin, JavaScript, TypeScript)
   
@@ -725,6 +952,62 @@ schema:
       {
         "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
         "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "type": "object"
@@ -803,6 +1086,7 @@ description:
   Supports pagination: first call returns results + nextCursor. Pass cursor to get the next page.
   
   Target (mutually exclusive):
+  - symbolId: opaque handle returned by a previous semantic call (necessary for fresh search, ignored when cursor is provided)
   - file + line + column: position-based lookup (necessary for fresh search, ignored when cursor is provided)
   - language + symbol: fully qualified symbol reference (supported languages: Java, Kotlin, JavaScript, TypeScript; necessary for fresh search, ignored when cursor is provided)
   - cursor: pagination cursor from a previous response
@@ -880,6 +1164,62 @@ schema:
       {
         "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
         "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "type": "object"
@@ -894,6 +1234,7 @@ description:
   Supports pagination: first call returns results + nextCursor. Pass cursor to get the next page.
   
   Target (mutually exclusive):
+  - symbolId: opaque handle returned by a previous semantic call (necessary for fresh search, ignored when cursor is provided)
   - file + line + column: position-based lookup (necessary for fresh search, ignored when cursor is provided)
   - language + symbol: fully qualified symbol reference (supported languages: Java, Kotlin, JavaScript, TypeScript; necessary for fresh search, ignored when cursor is provided)
   - cursor: pagination cursor from a previous response
@@ -987,6 +1328,62 @@ schema:
       {
         "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
         "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "type": "object"
@@ -1003,6 +1400,7 @@ description:
   Returns: full hierarchy chain from immediate parent (depth=1) to root, with file locations (line/column) and containing class info.
   
   Target (mutually exclusive):
+  - symbolId: opaque handle returned by a previous semantic call
   - file + line + column: position-based lookup (position can be anywhere within the method body)
   - language + symbol: fully qualified symbol reference (supported languages: Java, Kotlin, JavaScript, TypeScript)
   
@@ -1050,6 +1448,62 @@ schema:
       {
         "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
         "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "type": "object"
@@ -1781,7 +2235,7 @@ description:
   Rename a symbol or file and update all references across the project. Use instead of find-and-replace for safe, semantic renaming that handles all usages correctly. Supports undo (Ctrl+Z).
   
   Two modes:
-  - **Symbol rename** (`targetType="symbol"`, file + line + column + newName): Rename a symbol at a specific position. `line` and `column` are 1-based and must be provided.
+  - **Symbol rename** (`targetType="symbol"`, symbolId + newName OR file + line + column + newName): Rename an exact saved symbol. `symbolId` is mutually exclusive with coordinates.
   - **File rename** (`targetType="file"`, file + newName): Rename the file itself. Any placeholder `line`/`column` values are ignored for mode selection. Works for all file types including binary files (images, etc.). Especially useful for Android resource files (.webp, .png, .xml in res/) where it updates all resource references across the project.
   
   Backward compatibility: if `targetType` is omitted, null/null line+column still means file rename; provided line+column still means symbol rename.
@@ -1801,7 +2255,7 @@ description:
   
   Returns: affected files list and change count. Modifies source files.
   
-  Parameters: file + newName (required). targetType is optional; line + column are only needed for symbol rename. overrideStrategy + relatedRenamingStrategy (optional).
+  Parameters: newName (required), plus symbolId or file target coordinates. targetType is optional; line + column are only needed for position-based symbol rename. overrideStrategy + relatedRenamingStrategy (optional).
   
   Examples:
   - Symbol rename: {"file": "src/UserService.java", "targetType": "symbol", "line": 15, "column": 18, "newName": "CustomerService"}
@@ -1815,9 +2269,26 @@ schema:
         "description": "1-based column number. Required for symbol rename; omit for file rename unless `targetType=file`.",
         "type": "integer"
       },
+      "dryRun":
+      {
+        "description": "Resolve and validate the target, then discover usages/conflicts without modifying files. Default: false.",
+        "type": "boolean"
+      },
       "file":
       {
-        "description": "Path to file relative to project root. REQUIRED.",
+        "description": "Path to file relative to project root. Required for file rename or position-based symbol rename; omit when symbolId is used.",
+        "type": "string"
+      },
+      "language":
+      {
+        "description": "Language of the symbol. Required when using 'symbol' parameter. Currently supported languages: Java, Kotlin, JavaScript, TypeScript.",
+        "enum":
+        [
+          "Java",
+          "Kotlin",
+          "JavaScript",
+          "TypeScript"
+        ],
         "type": "string"
       },
       "line":
@@ -1858,6 +2329,67 @@ schema:
         ],
         "type": "string"
       },
+      "symbol":
+      {
+        "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
+        "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "targetType":
       {
         "description": "What to rename: 'symbol' (requires 1-based line+column) or 'file' (renames the file itself and ignores placeholder line/column values). If omitted, legacy behavior applies.",
@@ -1871,7 +2403,6 @@ schema:
     },
     "required":
     [
-      "file",
       "newName"
     ],
     "type": "object"
@@ -1882,7 +2413,7 @@ description:
   Delete a symbol or file safely by first checking for usages. Use when removing code to avoid breaking references.
   
   Modes:
-  - target_type='symbol' (default): Delete the symbol at line/column (REQUIRED: file, line, column).
+  - target_type='symbol' (default): Delete the exact symbol selected by symbolId, or by file + line/column.
     If position is whitespace/comment, returns nearby symbol suggestions.
   - target_type='file': Delete the entire file (REQUIRED: file only).
     Only succeeds if no symbols have external usages. Internal call chains don't block deletion.
@@ -1893,6 +2424,7 @@ description:
   Returns: success status and affected files, OR blocking usages list, OR nearby symbol suggestions.
   
   Examples:
+  - Symbol ID: {"symbolId": "<opaque-id>"}
   - Symbol: {"file": "src/OldClass.java", "line": 10, "column": 14}
   - Symbol with force: {"file": "src/OldClass.java", "line": 10, "column": 14, "force": true}
   - File: {"file": "src/UnusedUtils.java", "target_type": "file"}
@@ -1905,9 +2437,14 @@ schema:
         "description": "1-based column number. REQUIRED when target_type='symbol' (default).",
         "type": "integer"
       },
+      "dryRun":
+      {
+        "description": "Resolve the target and check usages without deleting anything. Default: false.",
+        "type": "boolean"
+      },
       "file":
       {
-        "description": "Path to file relative to project root. REQUIRED.",
+        "description": "Path to file relative to project root. Required for file deletion or position-based symbol deletion; omit when symbolId is used.",
         "type": "string"
       },
       "force":
@@ -1915,6 +2452,18 @@ schema:
         "default": false,
         "description": "Force deletion even if usages exist. Default: false. Use with caution!",
         "type": "boolean"
+      },
+      "language":
+      {
+        "description": "Language of the symbol. Required when using 'symbol' parameter. Currently supported languages: Java, Kotlin, JavaScript, TypeScript.",
+        "enum":
+        [
+          "Java",
+          "Kotlin",
+          "JavaScript",
+          "TypeScript"
+        ],
+        "type": "string"
       },
       "line":
       {
@@ -1925,6 +2474,67 @@ schema:
       {
         "description": "Absolute path to the project root. Required when multiple projects are open. For workspace projects, use the sub-project path.",
         "type": "string"
+      },
+      "symbol":
+      {
+        "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
+        "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
       "target_type":
       {
@@ -1938,10 +2548,6 @@ schema:
         "type": "string"
       }
     },
-    "required":
-    [
-      "file"
-    ],
     "type": "object"
   }
 
@@ -2101,10 +2707,11 @@ description:
   For fields/properties: replaces the initializer expression (after =).
   Auto-reformats the changed range by default.
   
-  Requires: file (always), member (always). class is optional for top-level members (Kotlin).
+  Target with symbolId, or with file + member. class is optional for top-level members (Kotlin).
   For overloaded methods, use parameterCount or line to disambiguate.
   
   Examples:
+  - {"symbolId": "<opaque-id>", "content": "return 42;"}
   - {"file": "src/Main.java", "class": "Main", "member": "getName", "content": "return this.name;"}
   - {"file": "src/Config.kt", "member": "defaultPort", "content": "8080"}
 schema:
@@ -2123,7 +2730,19 @@ schema:
       },
       "file":
       {
-        "description": "Path to file relative to project root. REQUIRED.",
+        "description": "Path to file relative to project root. Required with member selectors; omit when symbolId is used.",
+        "type": "string"
+      },
+      "language":
+      {
+        "description": "Language of the symbol. Required when using 'symbol' parameter. Currently supported languages: Java, Kotlin, JavaScript, TypeScript.",
+        "enum":
+        [
+          "Java",
+          "Kotlin",
+          "JavaScript",
+          "TypeScript"
+        ],
         "type": "string"
       },
       "line":
@@ -2133,7 +2752,7 @@ schema:
       },
       "member":
       {
-        "description": "Name of the method, function, field, or property to replace the body/initializer of.",
+        "description": "Name of the method, function, field, or property to replace the body/initializer of. Required unless symbolId is used.",
         "type": "string"
       },
       "parameterCount":
@@ -2150,12 +2769,71 @@ schema:
       {
         "description": "Auto-reformat the changed range and optimize imports. Default: true.",
         "type": "boolean"
+      },
+      "symbol":
+      {
+        "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
+        "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "required":
     [
-      "file",
-      "member",
       "content"
     ],
     "type": "object"
@@ -2680,6 +3358,7 @@ description:
   Prefer this over ide_find_definition + reading the file when you only need the signature or the docs.
   
   Target (mutually exclusive):
+  - symbolId: opaque handle returned by a previous semantic call
   - file + line + column: position-based lookup, so overloads are addressable
   - language + symbol: fully qualified symbol reference (supported languages: Java, Kotlin, JavaScript, TypeScript)
   
@@ -2736,6 +3415,62 @@ schema:
       {
         "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
         "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "type": "object"
@@ -2753,7 +3488,7 @@ schema:
     {
       "paths":
       {
-        "description": "File or directory paths relative to project root to sync. If omitted, syncs the entire project.",
+        "description": "File or directory paths relative to the selected project/content root. Absolute paths, traversal, and symlink escapes are rejected. Deleted paths refresh their nearest existing parent. If omitted, syncs the entire selected root.",
         "items":
         {
           "type": "string"
@@ -2777,9 +3512,9 @@ description:
   
   Rust note: className parameter not supported for Rust; use file + line + column instead.
   
-  Returns: target class info, full supertype chain (recursive), and all subtypes in the project.
+  Returns deterministic breadth-first pages containing target class info, supertypes, subtypes, symbolId handles, and pagination metadata. Live progress is not available on stateless HTTP; continue with cursor.
   
-  Parameters: Either className (e.g., "com.example.MyClass" for Java/PHP-style FQNs or "MyComponent" for JavaScript/TypeScript symbols) OR file + line + column. scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files).
+  Parameters for a fresh query: either symbolId, className (e.g., "com.example.MyClass" for Java/PHP-style FQNs or "MyComponent" for JavaScript/TypeScript symbols), OR file + line + column. maxNodes (optional, default: 100, max: 500), scope (optional, default: "project_files"; supported: project_files, project_and_libraries, project_production_files, project_test_files). For the next page, pass cursor; other search parameters are ignored.
   
   Example: {"className": "com.example.UserService", "scope": "project_and_libraries"} or {"file": "src/MyClass.java", "line": 10, "column": 14}
 schema:
@@ -2796,6 +3531,11 @@ schema:
         "description": "1-based column number. Required if using file parameter.",
         "type": "integer"
       },
+      "cursor":
+      {
+        "description": "Opaque session/project-bound continuation from the previous hierarchy page. Other search parameters are ignored.",
+        "type": "string"
+      },
       "file":
       {
         "description": "Path to file relative to project root (e.g., 'src/main/java/com/example/MyClass.java'). Use with line and column.",
@@ -2806,9 +3546,26 @@ schema:
         "description": "Include supertypes/subtypes defined in generated sources (KSP/Dagger/annotation-processor output). Default: true — keep generated types in the hierarchy.",
         "type": "boolean"
       },
+      "language":
+      {
+        "description": "Language of the symbol. Required when using 'symbol' parameter. Currently supported languages: Java, Kotlin, JavaScript, TypeScript.",
+        "enum":
+        [
+          "Java",
+          "Kotlin",
+          "JavaScript",
+          "TypeScript"
+        ],
+        "type": "string"
+      },
       "line":
       {
         "description": "1-based line number where the class is defined. Required if using file parameter.",
+        "type": "integer"
+      },
+      "maxNodes":
+      {
+        "description": "Maximum hierarchy nodes returned and expanded in this page. Default: 100, max: 500.",
         "type": "integer"
       },
       "project_path":
@@ -2827,6 +3584,67 @@ schema:
           "project_test_files"
         ],
         "type": "string"
+      },
+      "symbol":
+      {
+        "description": "Fully qualified symbol reference. Format: 'com.example.ClassName' or 'com.example.ClassName#memberName'. Omit generics parameters.",
+        "type": "string"
+      },
+      "symbolId":
+      {
+        "description": "Opaque, non-canonical symbol handle returned by a semantic tool. Reuse this exact handle across line shifts and rename. It is bounded by the current MCP server session, exact project instance, inactivity TTL, and LRU eviction. The same PSI symbol may have multiple simultaneously valid handles, so never compare symbolId values for symbol equality.",
+        "type": "string"
+      },
+      "target":
+      {
+        "description": "Structured target selector. Choose exactly one variant: symbolId, position, or qualifiedName with language. Mutually exclusive with legacy top-level symbolId/file/line/column/language/symbol selectors and with className where that legacy selector is supported.",
+        "properties":
+        {
+          "language":
+          {
+            "description": "Language used to resolve qualifiedName.",
+            "type": "string"
+          },
+          "position":
+          {
+            "properties":
+            {
+              "column":
+              {
+                "description": "1-based column number",
+                "type": "integer"
+              },
+              "file":
+              {
+                "description": "Path to the file relative to project root",
+                "type": "string"
+              },
+              "line":
+              {
+                "description": "1-based line number",
+                "type": "integer"
+              }
+            },
+            "required":
+            [
+              "file",
+              "line",
+              "column"
+            ],
+            "type": "object"
+          },
+          "qualifiedName":
+          {
+            "description": "Language-qualified symbol reference, for example com.example.Foo#bar.",
+            "type": "string"
+          },
+          "symbolId":
+          {
+            "description": "Opaque, session/project/TTL/LRU-bound handle. Multiple unequal handles may identify the same PSI symbol; do not compare IDs for equality.",
+            "type": "string"
+          }
+        },
+        "type": "object"
       }
     },
     "type": "object"


### PR DESCRIPTION
  ## Summary

  Allow MCP clients to reuse semantic targets across navigation and refactoring calls, preview refactorings before applying them, and consume large results
  incrementally.

  - Add project- and session-scoped `symbolId` handles backed by smart PSI pointers, with bounded retention and explicit expiry.
  - Introduce unified `target` selectors: symbol handle, file position, or qualified name and language.
  - Add non-mutating `dryRun` previews for rename, safe delete, and change signature, including applicability, affected files, usage/conflict counts, and
  warnings.
  - Add bounded, deterministic hierarchy pagination with continuation cursors and preserved declaration identity.
  - Extend `ide_file_structure` with structured nodes, source ranges, and optional symbol handles.
  - Support multi-file diagnostics with a shared deadline, per-file freshness and timeout metadata, and explicit truncation reporting.

  Also validate exact symbol rebinding after member replacement, synchronize deleted paths within the selected project root, improve Kotlin declaration
  metadata, and fix the Ktor linkage error that prevented MCP server startup.

  Update documentation, smoke-test instructions, golden contracts, and behavior tests for the new functionality.

  ## Compatibility

  Existing selectors and legacy response fields remain supported. Symbol handles and pagination cursors belong to the active project/server session.

  Reconnect MCP clients after updating the plugin to refresh cached tool schemas.

  ## Checklist

  - [x] Changelog entries added under `[Unreleased]`
  - [x] `./scripts/check-pr.sh` passes on this branch
  - [x]  Full `./gradlew test` suite passes on this branch
  - [x] No new MCP tool names; existing schemas, documentation, and golden contracts updated
  - [x] No forbidden files included
